### PR TITLE
Revitalize secretaria portal dashboard and turmas workspace

### DIFF
--- a/apps/web/src/app/api/secretaria/dashboard/route.ts
+++ b/apps/web/src/app/api/secretaria/dashboard/route.ts
@@ -1,6 +1,17 @@
 import { NextResponse } from "next/server";
 import { supabaseServerTyped } from "@/lib/supabaseServer";
 
+type MatriculaResumo = {
+  status: string | null;
+  count: number;
+};
+
+type TurmaResumo = {
+  turma_id: string;
+  status: string | null;
+  count: number;
+};
+
 export async function GET() {
   try {
     const supabase = await supabaseServerTyped<any>();
@@ -15,29 +26,162 @@ export async function GET() {
       .order('created_at', { ascending: false })
       .limit(1);
     const escolaId = (prof?.[0] as any)?.escola_id as string | undefined;
-    if (!escolaId) return NextResponse.json({ ok: true, counts: { alunos: 0, matriculas: 0 }, avisos_recentes: [] });
+    if (!escolaId) {
+      return NextResponse.json({
+        ok: true,
+        counts: { alunos: 0, matriculas: 0, turmas: 0, pendencias: 0 },
+        resumo_status: [],
+        turmas_destaque: [],
+        novas_matriculas: [],
+        avisos_recentes: [],
+      });
+    }
 
-    const [alunosRes, matsRes, avisosRes] = await Promise.all([
+    const [alunosRes, turmasRes, matsRes, matsStatusRes, matsTurmaStatusRes, avisosRes, ultimasMatriculasRes] = await Promise.all([
       supabase.from('alunos').select('*', { count: 'exact', head: true }).eq('escola_id', escolaId),
+      supabase.from('turmas').select('id, nome, turno, ano_letivo, professor_id').eq('escola_id', escolaId).order('nome'),
       supabase.from('matriculas').select('*', { count: 'exact', head: true }).eq('escola_id', escolaId),
+      supabase
+        .from('matriculas')
+        .select('status, count:status', { group: 'status' })
+        .eq('escola_id', escolaId),
+      supabase
+        .from('matriculas')
+        .select('turma_id, status, count:turma_id', { group: 'turma_id,status' })
+        .eq('escola_id', escolaId),
       supabase
         .from('avisos')
         .select('id, titulo, resumo, origem, created_at')
         .eq('escola_id', escolaId)
         .order('created_at', { ascending: false })
         .limit(3),
+      supabase
+        .from('matriculas')
+        .select(`id, status, created_at, turma_id, turmas ( nome, turno ), alunos ( id, profiles!alunos_profile_id_fkey ( nome, email ) )`)
+        .eq('escola_id', escolaId)
+        .order('created_at', { ascending: false })
+        .limit(6),
     ]);
 
-    const counts = {
-      alunos: alunosRes.count ?? 0,
-      matriculas: matsRes.count ?? 0,
-    };
-    const avisos_recentes = (avisosRes.data || []).map((a: any) => ({ id: a.id, titulo: a.titulo, resumo: a.resumo, origem: a.origem, data: a.created_at }));
+    const resumoStatus = (matsStatusRes.data || []).map((row: MatriculaResumo) => ({
+      status: row.status ?? 'indefinido',
+      total: Number((row as any)?.count ?? row.count ?? 0),
+    }));
 
-    return NextResponse.json({ ok: true, counts, avisos_recentes });
+    const turmaStatus = new Map<string, Record<string, number>>();
+    for (const row of matsTurmaStatusRes.data || []) {
+      const turmaId = (row as TurmaResumo).turma_id;
+      if (!turmaId) continue;
+      const status = ((row as TurmaResumo).status ?? 'indefinido').toString();
+      const total = Number((row as any)?.count ?? (row as TurmaResumo).count ?? 0);
+      if (!turmaStatus.has(turmaId)) turmaStatus.set(turmaId, {});
+      turmaStatus.get(turmaId)![status] = (turmaStatus.get(turmaId)![status] ?? 0) + total;
+    }
+
+    const professorIds = Array.from(
+      new Set((turmasRes.data || []).map((t: any) => t.professor_id).filter((id: string | null | undefined): id is string => Boolean(id)))
+    );
+
+    let professoresMap = new Map<string, { nome: string | null; email: string | null }>();
+    if (professorIds.length) {
+      const { data: professores } = await supabase
+        .from('professores')
+        .select('id, profile_id')
+        .in('id', professorIds);
+      const profileIds = Array.from(
+        new Set((professores || []).map((p) => p.profile_id).filter((id: string | null | undefined): id is string => Boolean(id)))
+      );
+      let profilesMap = new Map<string, { nome: string | null; email: string | null }>();
+      if (profileIds.length) {
+        const { data: perfis } = await supabase
+          .from('profiles')
+          .select('user_id, nome, email')
+          .in('user_id', profileIds);
+        for (const perfil of perfis || []) {
+          profilesMap.set(perfil.user_id, { nome: perfil.nome ?? null, email: perfil.email ?? null });
+        }
+      }
+      for (const prof of professores || []) {
+        if (!prof?.id) continue;
+        const perfil = prof.profile_id ? profilesMap.get(prof.profile_id) : undefined;
+        professoresMap.set(prof.id, { nome: perfil?.nome ?? null, email: perfil?.email ?? null });
+      }
+    }
+
+    const turmasDestaque = (turmasRes.data || []).map((turma: any) => {
+      const counts = turmaStatus.get(turma.id) ?? {};
+      const total = Object.values(counts).reduce((acc, cur) => acc + Number(cur || 0), 0);
+      const professorInfo = turma.professor_id ? professoresMap.get(turma.professor_id) : undefined;
+      return {
+        id: turma.id,
+        nome: turma.nome,
+        turno: turma.turno,
+        ano_letivo: turma.ano_letivo,
+        total_alunos: total,
+        status_counts: counts,
+        professor: professorInfo ?? { nome: null, email: null },
+      };
+    });
+
+    turmasDestaque.sort((a, b) => (b.total_alunos ?? 0) - (a.total_alunos ?? 0));
+
+    const avisos_recentes = (avisosRes.data || []).map((a: any) => ({
+      id: a.id,
+      titulo: a.titulo,
+      resumo: a.resumo,
+      origem: a.origem,
+      data: a.created_at,
+    }));
+
+    const novasMatriculas = (ultimasMatriculasRes.data || []).map((row: any) => {
+      const alunoProfile = row.alunos?.profiles?.[0] ?? row.alunos?.profiles;
+      return {
+        id: row.id,
+        status: row.status,
+        created_at: row.created_at,
+        turma: {
+          id: row.turma_id,
+          nome: row.turmas?.nome ?? 'Sem turma',
+          turno: row.turmas?.turno ?? null,
+        },
+        aluno: {
+          id: row.alunos?.id ?? null,
+          nome: alunoProfile?.nome ?? 'Aluno sem nome',
+          email: alunoProfile?.email ?? null,
+        },
+      };
+    });
+
+    const pendencias = resumoStatus
+      .filter((item) => normalizeStatus(item.status).context === 'alert')
+      .reduce((acc, item) => acc + item.total, 0);
+
+    return NextResponse.json({
+      ok: true,
+      counts: {
+        alunos: alunosRes.count ?? 0,
+        matriculas: matsRes.count ?? 0,
+        turmas: turmasRes.data?.length ?? 0,
+        pendencias,
+      },
+      resumo_status: resumoStatus,
+      turmas_destaque: turmasDestaque.slice(0, 4),
+      novas_matriculas: novasMatriculas,
+      avisos_recentes,
+    });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }
+}
+
+function normalizeStatus(status: string) {
+  const value = (status || '').toLowerCase();
+  if (["ativa", "ativo", "active"].includes(value)) return { label: "Ativo", context: "success" as const };
+  if (["concluida", "concluido", "graduado"].includes(value)) return { label: "Concluído", context: "muted" as const };
+  if (["transferido", "transferida"].includes(value)) return { label: "Transferido", context: "alert" as const };
+  if (["pendente", "aguardando"].includes(value)) return { label: "Pendente", context: "alert" as const };
+  if (["trancado", "suspenso", "desistente", "inativo"].includes(value)) return { label: "Irregular", context: "alert" as const };
+  return { label: status || 'Indefinido', context: "neutral" as const };
 }
 

--- a/apps/web/src/app/api/secretaria/turmas/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/route.ts
@@ -1,0 +1,141 @@
+import { NextResponse } from "next/server";
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+
+export async function GET(req: Request) {
+  try {
+    const supabase = await supabaseServerTyped<any>();
+    const { data: userRes } = await supabase.auth.getUser();
+    const user = userRes?.user;
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 });
+
+    const { data: prof } = await supabase
+      .from('profiles')
+      .select('escola_id')
+      .order('created_at', { ascending: false })
+      .limit(1);
+    const escolaId = (prof?.[0] as any)?.escola_id as string | undefined;
+    if (!escolaId) {
+      return NextResponse.json({
+        ok: true,
+        items: [],
+        total: 0,
+        stats: { totalTurmas: 0, totalAlunos: 0, porTurno: [] },
+      });
+    }
+
+    const url = new URL(req.url);
+    const turnoFilter = url.searchParams.get('turno') || undefined;
+
+    const { data: turmas, error: turmasError } = await supabase
+      .from('turmas')
+      .select('id, nome, turno, ano_letivo, professor_id, created_at')
+      .eq('escola_id', escolaId)
+      .order('nome');
+    if (turmasError) return NextResponse.json({ ok: false, error: turmasError.message }, { status: 400 });
+
+    const turmaIds = (turmas || []).map((t) => t.id);
+    let professoresMap = new Map<string, { nome: string | null; email: string | null }>();
+    const professorIds = Array.from(new Set((turmas || []).map((t) => t.professor_id).filter((id): id is string => Boolean(id))));
+    if (professorIds.length) {
+      const { data: professores } = await supabase
+        .from('professores')
+        .select('id, profile_id')
+        .in('id', professorIds);
+      const profileIds = Array.from(new Set((professores || []).map((p) => p.profile_id).filter((id): id is string => Boolean(id))));
+      if (profileIds.length) {
+        const { data: perfis } = await supabase
+          .from('profiles')
+          .select('user_id, nome, email')
+          .in('user_id', profileIds);
+        const profilesMap = new Map<string, { nome: string | null; email: string | null }>();
+        for (const perfil of perfis || []) {
+          profilesMap.set(perfil.user_id, { nome: perfil.nome ?? null, email: perfil.email ?? null });
+        }
+        for (const profItem of professores || []) {
+          if (!profItem?.id) continue;
+          const perfil = profItem.profile_id ? profilesMap.get(profItem.profile_id) : undefined;
+          professoresMap.set(profItem.id, { nome: perfil?.nome ?? null, email: perfil?.email ?? null });
+        }
+      }
+    }
+
+    let matriculasResumo: any[] | null = [];
+    if (turmaIds.length) {
+      const { data } = await supabase
+        .from('matriculas')
+        .select('turma_id, status, count:turma_id', { group: 'turma_id,status' })
+        .eq('escola_id', escolaId)
+        .in('turma_id', turmaIds);
+      matriculasResumo = data || [];
+    }
+
+    const { data: matriculasRecency } = await supabase
+      .from('matriculas')
+      .select('turma_id, created_at')
+      .eq('escola_id', escolaId)
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    const lastByTurma = new Map<string, string>();
+    for (const row of matriculasRecency || []) {
+      if (row.turma_id && !lastByTurma.has(row.turma_id)) {
+        lastByTurma.set(row.turma_id, row.created_at ?? '');
+      }
+    }
+
+    const countsByTurma = new Map<string, Record<string, number>>();
+    let totalAlunos = 0;
+    for (const row of matriculasResumo || []) {
+      const turmaId = (row as any)?.turma_id;
+      if (!turmaId) continue;
+      const status = ((row as any)?.status ?? 'indefinido').toString();
+      const count = Number((row as any)?.count ?? 0);
+      if (!countsByTurma.has(turmaId)) countsByTurma.set(turmaId, {});
+      const current = countsByTurma.get(turmaId)!;
+      current[status] = (current[status] ?? 0) + count;
+      totalAlunos += count;
+    }
+
+    const items = (turmas || [])
+      .filter((turma) => {
+        if (!turnoFilter) return true;
+        return (turma.turno ?? 'sem_turno') === turnoFilter;
+      })
+      .map((turma) => {
+        const statusCounts = countsByTurma.get(turma.id) ?? {};
+        const total = Object.values(statusCounts).reduce((acc, cur) => acc + Number(cur || 0), 0);
+        return {
+          id: turma.id,
+          nome: turma.nome,
+          turno: turma.turno ?? 'Sem turno',
+          ano_letivo: turma.ano_letivo,
+          professor: turma.professor_id ? professoresMap.get(turma.professor_id) ?? { nome: null, email: null } : { nome: null, email: null },
+          status_counts: statusCounts,
+          total_alunos: total,
+          ultima_matricula: lastByTurma.get(turma.id) ?? turma.created_at ?? null,
+        };
+      });
+
+    const porTurnoMap = new Map<string, number>();
+    for (const turma of turmas || []) {
+      const key = turma.turno ?? 'Sem turno';
+      porTurnoMap.set(key, (porTurnoMap.get(key) ?? 0) + 1);
+    }
+
+    const porTurno = Array.from(porTurnoMap.entries()).map(([turno, total]) => ({ turno, total }));
+
+    return NextResponse.json({
+      ok: true,
+      items,
+      total: items.length,
+      stats: {
+        totalTurmas: turmas?.length ?? 0,
+        totalAlunos,
+        porTurno,
+      },
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/turmas/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/turmas/page.tsx
@@ -1,0 +1,13 @@
+import AuditPageView from "@/components/audit/AuditPageView";
+import TurmasListClient from "@/components/secretaria/TurmasListClient";
+
+export const dynamic = 'force-dynamic';
+
+export default function Page() {
+  return (
+    <>
+      <AuditPageView portal="secretaria" acao="PAGE_VIEW" entity="turmas_list" />
+      <TurmasListClient />
+    </>
+  );
+}

--- a/apps/web/src/components/secretaria/DashboardLoader.tsx
+++ b/apps/web/src/components/secretaria/DashboardLoader.tsx
@@ -1,11 +1,35 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type DashboardData = {
   ok: boolean;
-  counts: { alunos: number; matriculas: number };
+  counts: { alunos: number; matriculas: number; turmas: number; pendencias: number };
+  resumo_status: Array<{ status: string; total: number }>;
+  turmas_destaque: Array<{
+    id: string;
+    nome: string;
+    turno: string | null;
+    ano_letivo: string | null;
+    total_alunos: number;
+    status_counts: Record<string, number>;
+    professor?: { nome: string | null; email: string | null };
+  }>;
+  novas_matriculas: Array<{
+    id: string;
+    status: string;
+    created_at: string;
+    turma: { id: string; nome: string; turno: string | null };
+    aluno: { id: string | null; nome: string; email: string | null };
+  }>;
   avisos_recentes: Array<{ id: string; titulo: string; resumo: string; origem: string; data: string }>;
+};
+
+type StatusChip = {
+  label: string;
+  status: string;
+  total: number;
+  variant: "success" | "alert" | "muted" | "neutral";
 };
 
 export default function SecretariaDashboardLoader() {
@@ -32,39 +56,223 @@ export default function SecretariaDashboardLoader() {
     return () => { mounted = false };
   }, []);
 
+  const statusChips: StatusChip[] = useMemo(() => {
+    if (!data?.resumo_status) return [];
+    return data.resumo_status.map((item) => {
+      const norm = normalizeStatus(item.status);
+      return { label: norm.label, status: item.status, total: item.total, variant: norm.context };
+    });
+  }, [data?.resumo_status]);
+
   if (loading) return <div>Carregando painel…</div>;
   if (error) return <div className="text-red-600">Erro: {error}</div>;
 
   return (
-    <div className="space-y-6">
-      <div className="grid md:grid-cols-3 gap-6">
-        <div className="bg-white p-6 rounded-xl shadow border">
-          <h2 className="text-gray-600 text-sm font-medium">Alunos</h2>
-          <p className="text-3xl font-bold text-indigo-600 mt-2">{data?.counts.alunos ?? 0}</p>
-          <p className="text-gray-400 text-sm">Total cadastrados</p>
+    <div className="space-y-8">
+      <section>
+        <h2 className="text-sm font-semibold text-moxinexa-gray uppercase tracking-wide mb-3">Visão geral</h2>
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          <SummaryCard title="Alunos ativos" value={data?.counts.alunos ?? 0} hint="Perfis cadastrados" accent="from-sky-500/10 to-sky-200/40" icon="👩‍🎓" />
+          <SummaryCard title="Matrículas" value={data?.counts.matriculas ?? 0} hint="Histórico e vigentes" accent="from-indigo-500/10 to-indigo-200/40" icon="📚" />
+          <SummaryCard title="Turmas" value={data?.counts.turmas ?? 0} hint="Turmas disponíveis" accent="from-emerald-500/10 to-emerald-200/40" icon="🏫" />
+          <SummaryCard title="Pendências" value={data?.counts.pendencias ?? 0} hint="Status a acompanhar" accent="from-amber-500/10 to-amber-200/40" icon="⚠️" emphasize />
         </div>
-        <div className="bg-white p-6 rounded-xl shadow border">
-          <h2 className="text-gray-600 text-sm font-medium">Matrículas</h2>
-          <p className="text-3xl font-bold text-indigo-600 mt-2">{data?.counts.matriculas ?? 0}</p>
-          <p className="text-gray-400 text-sm">Ativas e históricas</p>
+      </section>
+
+      {statusChips.length > 0 && (
+        <section className="bg-gradient-to-br from-white to-slate-50 border border-slate-200 rounded-2xl p-6 shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+            <div>
+              <h3 className="text-lg font-semibold text-moxinexa-dark">Situação das matrículas</h3>
+              <p className="text-sm text-moxinexa-gray">Acompanhe o estado académico dos estudantes.</p>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {statusChips.map((chip) => (
+                <StatusBadge key={chip.status} label={chip.label} value={chip.total} variant={chip.variant} />
+              ))}
+            </div>
+          </div>
+
+          <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+            {statusChips.map((chip) => (
+              <div key={chip.status} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+                <p className="text-xs uppercase font-semibold text-slate-500">{chip.label}</p>
+                <p className="text-2xl font-bold text-slate-900 mt-1">{chip.total}</p>
+                <ProgressBar progress={calcPercentage(chip.total, data?.counts.matriculas ?? 0)} variant={chip.variant} />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      <section className="grid gap-6 xl:grid-cols-5">
+        <div className="xl:col-span-3 space-y-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-moxinexa-dark">Turmas em destaque</h3>
+            <a href="/secretaria/turmas" className="text-sm text-emerald-600 hover:text-emerald-700">Ver todas as turmas</a>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            {(data?.turmas_destaque ?? []).map((turma) => (
+              <TurmaCard key={turma.id} turma={turma} />
+            ))}
+            {data?.turmas_destaque?.length === 0 && (
+              <div className="col-span-full text-sm text-moxinexa-gray border border-dashed border-slate-300 rounded-xl p-6 bg-white">
+                Nenhuma turma encontrada para esta escola.
+              </div>
+            )}
+          </div>
         </div>
-        <div className="bg-white p-6 rounded-xl shadow border">
-          <h2 className="text-gray-600 text-sm font-medium">Avisos recentes</h2>
-          {data?.avisos_recentes?.length ? (
-            <ul className="mt-2 space-y-1 text-sm">
-              {data!.avisos_recentes.map((a) => (
-                <li key={a.id} className="text-gray-700">
-                  <span className="text-gray-500 mr-2">{new Date(a.data).toLocaleDateString()}:</span>
-                  <span className="font-medium">{a.titulo}</span>
+
+        <div className="xl:col-span-2 space-y-4">
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-moxinexa-dark">Últimas matrículas</h3>
+              <a href="/secretaria/matriculas" className="text-xs text-emerald-600 hover:text-emerald-700">Ver lista completa</a>
+            </div>
+            <ul className="space-y-3">
+              {(data?.novas_matriculas ?? []).map((item) => (
+                <li key={item.id} className="rounded-lg border border-slate-200 p-3 bg-slate-50">
+                  <div className="flex justify-between text-sm">
+                    <div>
+                      <p className="font-semibold text-slate-800">{item.aluno.nome}</p>
+                      <p className="text-xs text-slate-500">{item.turma.nome}</p>
+                    </div>
+                    <span className="text-xs text-slate-500">{new Date(item.created_at).toLocaleDateString()}</span>
+                  </div>
+                  <div className="mt-2 flex items-center justify-between text-xs text-slate-600">
+                    <span>{formatStatus(item.status)}</span>
+                    {item.aluno.email && <span className="truncate max-w-[150px]">{item.aluno.email}</span>}
+                  </div>
                 </li>
               ))}
+              {data?.novas_matriculas?.length === 0 && (
+                <li className="text-sm text-slate-500">Nenhuma movimentação recente.</li>
+              )}
             </ul>
-          ) : (
-            <div className="text-sm text-gray-600 mt-2">Nenhum aviso.</div>
-          )}
+          </section>
+
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h3 className="text-sm font-semibold text-moxinexa-dark mb-3">Avisos recentes</h3>
+            {data?.avisos_recentes?.length ? (
+              <ul className="space-y-3">
+                {data!.avisos_recentes.map((a) => (
+                  <li key={a.id} className="border-l-4 border-emerald-500/70 bg-emerald-50/50 p-3 rounded">
+                    <p className="text-xs text-emerald-700">{new Date(a.data).toLocaleDateString()}</p>
+                    <p className="text-sm font-semibold text-emerald-900">{a.titulo}</p>
+                    {a.resumo && <p className="text-xs text-emerald-800/70 mt-1">{a.resumo}</p>}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-sm text-slate-500">Nenhum aviso.</div>
+            )}
+          </section>
         </div>
+      </section>
+    </div>
+  );
+}
+
+function SummaryCard({ title, value, hint, accent, icon, emphasize }: { title: string; value: number; hint: string; accent: string; icon: string; emphasize?: boolean }) {
+  return (
+    <div className={`relative overflow-hidden rounded-2xl border border-slate-200 bg-white p-5 shadow-sm ${emphasize ? 'ring-1 ring-amber-100' : ''}`}>
+      <div className={`absolute inset-0 bg-gradient-to-br ${accent}`} aria-hidden />
+      <div className="relative flex flex-col gap-2">
+        <span className="text-2xl" aria-hidden>{icon}</span>
+        <span className="text-sm font-semibold text-slate-600 uppercase tracking-wide">{title}</span>
+        <span className="text-3xl font-bold text-slate-900">{value}</span>
+        <span className="text-xs text-slate-500">{hint}</span>
       </div>
     </div>
   );
+}
+
+function StatusBadge({ label, value, variant }: { label: string; value: number; variant: StatusChip["variant"] }) {
+  const palette: Record<StatusChip["variant"], string> = {
+    success: 'bg-emerald-100 text-emerald-700 border border-emerald-200',
+    alert: 'bg-amber-100 text-amber-700 border border-amber-200',
+    muted: 'bg-slate-100 text-slate-600 border border-slate-200',
+    neutral: 'bg-slate-50 text-slate-600 border border-slate-200',
+  };
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${palette[variant]}`}>
+      {label}
+      <span className="font-semibold">{value}</span>
+    </span>
+  );
+}
+
+function ProgressBar({ progress, variant }: { progress: number; variant: StatusChip["variant"] }) {
+  const color: Record<StatusChip["variant"], string> = {
+    success: 'bg-emerald-500',
+    alert: 'bg-amber-500',
+    muted: 'bg-slate-400',
+    neutral: 'bg-slate-300',
+  };
+  return (
+    <div className="mt-3 h-2 rounded-full bg-slate-100">
+      <div className={`h-2 rounded-full transition-all ${color[variant]}`} style={{ width: `${Math.min(100, Math.max(0, progress))}%` }} />
+    </div>
+  );
+}
+
+function TurmaCard({ turma }: { turma: NonNullable<DashboardData["turmas_destaque"]>[number] }) {
+  const professorNome = turma.professor?.nome || 'Sem diretor atribuído';
+  const statusEntries = Object.entries(turma.status_counts || {});
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm flex flex-col gap-3">
+      <div>
+        <h4 className="text-lg font-semibold text-slate-800">{turma.nome}</h4>
+        <p className="text-xs text-slate-500">{turma.turno ? `${turma.turno} • ` : ''}{turma.ano_letivo ?? 'Ano letivo não definido'}</p>
+      </div>
+      <div className="flex items-center gap-2 text-xs text-slate-500">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-100 text-emerald-700">👩‍🏫</span>
+        <div>
+          <p className="font-medium text-slate-700">{professorNome}</p>
+          {turma.professor?.email && <p className="text-[11px] text-slate-500">{turma.professor.email}</p>}
+        </div>
+      </div>
+      <div className="text-sm text-slate-600">Total de alunos: <span className="font-semibold">{turma.total_alunos}</span></div>
+      {statusEntries.length > 0 ? (
+        <div className="grid grid-cols-2 gap-2 text-xs text-slate-600">
+          {statusEntries.map(([status, total]) => {
+            const norm = normalizeStatus(status);
+            return (
+              <div key={status} className="flex items-center justify-between rounded border border-slate-200 bg-slate-50 px-2 py-1">
+                <span>{norm.label}</span>
+                <span className="font-semibold">{total}</span>
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <p className="text-xs text-slate-500">Sem matrículas associadas.</p>
+      )}
+      <div className="flex items-center justify-between pt-2 text-xs text-emerald-600">
+        <a href="/secretaria/turmas" className="hover:underline">Gerir turma</a>
+        <span className="text-slate-400">Atualizado em tempo real</span>
+      </div>
+    </div>
+  );
+}
+
+function normalizeStatus(status: string) {
+  const value = (status || '').toLowerCase();
+  if (["ativa", "ativo", "active"].includes(value)) return { label: "Ativo", context: "success" as const };
+  if (["concluida", "concluido", "graduado"].includes(value)) return { label: "Concluído", context: "muted" as const };
+  if (["transferido", "transferida"].includes(value)) return { label: "Transferido", context: "alert" as const };
+  if (["pendente", "aguardando"].includes(value)) return { label: "Pendente", context: "alert" as const };
+  if (["trancado", "suspenso", "desistente", "inativo"].includes(value)) return { label: "Irregular", context: "alert" as const };
+  return { label: status || 'Indefinido', context: "neutral" as const };
+}
+
+function calcPercentage(value: number, total: number) {
+  if (!total) return 0;
+  return Math.round((value / total) * 100);
+}
+
+function formatStatus(status: string) {
+  return normalizeStatus(status).label;
 }
 

--- a/apps/web/src/components/secretaria/SecretariaSidebar.tsx
+++ b/apps/web/src/components/secretaria/SecretariaSidebar.tsx
@@ -8,6 +8,7 @@ export default function SecretariaSidebar() {
   const items: NavItem[] = [
     { href: "/secretaria", label: "Dashboard", icon: "HomeIcon" },
     { href: "/secretaria/alunos", label: "Alunos", icon: "UsersIcon" },
+    { href: "/secretaria/turmas", label: "Turmas", icon: "RectangleStackIcon" },
     { href: "/secretaria/matriculas", label: "Matrículas", icon: "AcademicCapIcon" },
     { href: "/secretaria/relatorios", label: "Relatórios", icon: "ChartBarIcon" },
     { href: "/secretaria/alertas", label: "Alertas", icon: "BellAlertIcon" },

--- a/apps/web/src/components/secretaria/TurmasListClient.tsx
+++ b/apps/web/src/components/secretaria/TurmasListClient.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+interface TurmaItem {
+  id: string;
+  nome: string;
+  turno: string;
+  ano_letivo: string | null;
+  professor: { nome: string | null; email: string | null };
+  status_counts: Record<string, number>;
+  total_alunos: number;
+  ultima_matricula: string | null;
+}
+
+interface TurmasResponse {
+  ok: boolean;
+  items: TurmaItem[];
+  total: number;
+  stats: {
+    totalTurmas: number;
+    totalAlunos: number;
+    porTurno: Array<{ turno: string; total: number }>;
+  };
+  error?: string;
+}
+
+const TURNO_LABELS: Record<string, string> = {
+  Manhã: "Manhã",
+  Tarde: "Tarde",
+  Noite: "Noite",
+  Integral: "Integral",
+  "Sem turno": "Sem turno",
+  sem_turno: "Sem turno",
+};
+
+export default function TurmasListClient() {
+  const [turno, setTurno] = useState<string>("todos");
+  const [busca, setBusca] = useState("");
+  const [data, setData] = useState<TurmasResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const params = new URLSearchParams();
+        if (turno !== "todos") params.set("turno", turno);
+        const res = await fetch(`/api/secretaria/turmas?${params.toString()}`, { cache: 'no-store' });
+        const json = (await res.json()) as TurmasResponse;
+        if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao carregar turmas');
+        if (mounted) setData(json);
+      } catch (e) {
+        if (mounted) setError(e instanceof Error ? e.message : String(e));
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => { mounted = false };
+  }, [turno]);
+
+  const filtrosTurno = useMemo(() => {
+    const porTurno = data?.stats?.porTurno ?? [];
+    const base = porTurno.map((item) => ({
+      id: item.turno,
+      label: TURNO_LABELS[item.turno] || item.turno,
+      total: item.total,
+    }));
+    return [{ id: "todos", label: "Todos", total: data?.stats?.totalTurmas ?? 0 }, ...base];
+  }, [data?.stats?.porTurno, data?.stats?.totalTurmas]);
+
+  const itensFiltrados = useMemo(() => {
+    const itens = data?.items ?? [];
+    const lowerBusca = busca.trim().toLowerCase();
+    return itens.filter((item) => {
+      if (turno !== "todos" && (item.turno ?? 'sem_turno') !== turno) return false;
+      if (!lowerBusca) return true;
+      return (
+        item.nome.toLowerCase().includes(lowerBusca) ||
+        (item.professor?.nome || '').toLowerCase().includes(lowerBusca) ||
+        (item.professor?.email || '').toLowerCase().includes(lowerBusca)
+      );
+    });
+  }, [data?.items, turno, busca]);
+
+  if (loading) {
+    return <div className="p-6">Carregando turmas…</div>;
+  }
+
+  if (error) {
+    return <div className="p-6 text-red-600">Erro ao carregar turmas: {error}</div>;
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-moxinexa-dark">Gestão de turmas</h1>
+          <p className="text-sm text-moxinexa-gray">Acompanhe distribuição, diretoria de turma e progresso acadêmico.</p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button className="rounded-full border border-emerald-500/60 px-4 py-2 text-sm text-emerald-600 hover:bg-emerald-50 transition">+ Nova turma</button>
+          <button className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-600 hover:bg-slate-50 transition">Importar lista</button>
+        </div>
+      </header>
+
+      <section className="grid gap-4 md:grid-cols-3">
+        <HighlightCard title="Turmas ativas" value={data?.stats?.totalTurmas ?? 0} description="Estruturas prontas para alocação de estudantes." icon="🏫" />
+        <HighlightCard title="Alunos vinculados" value={data?.stats?.totalAlunos ?? 0} description="Total de matrículas distribuídas nas turmas." icon="👩‍🎓" />
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <p className="text-xs font-semibold uppercase text-slate-500">Distribuição por turno</p>
+          <ul className="mt-3 space-y-2 text-sm text-slate-600">
+            {filtrosTurno.slice(1).map((item) => (
+              <li key={item.id} className="flex items-center justify-between">
+                <span>{item.label}</span>
+                <span className="font-semibold">{item.total}</span>
+              </li>
+            ))}
+            {filtrosTurno.length <= 1 && <li>Sem turnos cadastrados.</li>}
+          </ul>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-wrap gap-2">
+            {filtrosTurno.map((item) => {
+              const isActive = turno === item.id;
+              return (
+                <button
+                  key={item.id}
+                  onClick={() => setTurno(item.id)}
+                  className={`rounded-full px-4 py-1.5 text-sm transition flex items-center gap-2 ${
+                    isActive
+                      ? 'bg-emerald-600 text-white shadow'
+                      : 'border border-slate-200 text-slate-600 hover:bg-slate-50'
+                  }`}
+                >
+                  <span>{item.label}</span>
+                  <span
+                    className={`rounded-full px-2 py-[2px] text-xs font-semibold ${
+                      isActive ? 'bg-white/30 text-white/90' : 'bg-slate-100 text-slate-600'
+                    }`}
+                  >
+                    {item.total}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="search"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              placeholder="Pesquisar turma, diretor ou e-mail"
+              className="w-full rounded-full border border-slate-200 px-4 py-2 text-sm focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200 lg:w-72"
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 overflow-x-auto">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="text-left text-slate-500">
+              <tr>
+                <th className="py-3 pr-4">Turma</th>
+                <th className="py-3 pr-4">Diretor</th>
+                <th className="py-3 pr-4">Turno</th>
+                <th className="py-3 pr-4">Alunos</th>
+                <th className="py-3 pr-4">Última movimentação</th>
+                <th className="py-3 pr-4">Ações</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {itensFiltrados.map((item) => (
+                <tr key={item.id} className="align-top">
+                  <td className="py-3 pr-4">
+                    <p className="font-semibold text-slate-800">{item.nome}</p>
+                    <p className="text-xs text-slate-500">{item.ano_letivo ?? 'Ano letivo não informado'}</p>
+                  </td>
+                  <td className="py-3 pr-4 text-sm text-slate-700">
+                    {item.professor?.nome ? (
+                      <div>
+                        <p className="font-medium">{item.professor.nome}</p>
+                        {item.professor.email && <p className="text-xs text-slate-500">{item.professor.email}</p>}
+                      </div>
+                    ) : (
+                      <span className="text-xs text-amber-600">Sem diretor associado</span>
+                    )}
+                  </td>
+                  <td className="py-3 pr-4 text-xs text-slate-600">{TURNO_LABELS[item.turno] || item.turno}</td>
+                  <td className="py-3 pr-4">
+                    <div className="flex flex-wrap gap-2">
+                      {Object.entries(item.status_counts || {}).map(([status, total]) => {
+                        const norm = normalizeStatus(status);
+                        return (
+                          <span key={status} className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs ${norm.className}`}>
+                            {norm.label}
+                            <strong>{total}</strong>
+                          </span>
+                        );
+                      })}
+                      {Object.keys(item.status_counts || {}).length === 0 && (
+                        <span className="text-xs text-slate-400">Sem matrículas</span>
+                      )}
+                    </div>
+                  </td>
+                  <td className="py-3 pr-4 text-xs text-slate-500">
+                    {item.ultima_matricula ? new Date(item.ultima_matricula).toLocaleString() : 'Sem registos'}
+                  </td>
+                  <td className="py-3 pr-4">
+                    <div className="flex flex-col gap-2 text-xs">
+                      <button className="rounded-full border border-slate-200 px-3 py-1 text-slate-600 hover:border-emerald-500 hover:text-emerald-600 transition">Gerir alunos</button>
+                      <button className="rounded-full border border-slate-200 px-3 py-1 text-slate-600 hover:border-emerald-500 hover:text-emerald-600 transition">Definir diretor</button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+              {itensFiltrados.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-sm text-slate-500">Nenhuma turma corresponde aos filtros atuais.</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function HighlightCard({ title, value, description, icon }: { title: string; value: number; description: string; icon: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="text-3xl" aria-hidden>{icon}</div>
+      <p className="mt-2 text-sm font-semibold uppercase tracking-wide text-slate-500">{title}</p>
+      <p className="text-3xl font-bold text-slate-900">{value}</p>
+      <p className="mt-2 text-sm text-slate-500">{description}</p>
+    </div>
+  );
+}
+
+function normalizeStatus(status: string) {
+  const value = (status || '').toLowerCase();
+  if (["ativa", "ativo", "active"].includes(value)) return { label: "Ativos", className: 'bg-emerald-100 text-emerald-700 border border-emerald-200' };
+  if (["concluida", "concluido", "graduado"].includes(value)) return { label: "Concluídos", className: 'bg-slate-100 text-slate-600 border border-slate-200' };
+  if (["transferido", "transferida"].includes(value)) return { label: "Transferidos", className: 'bg-blue-100 text-blue-700 border border-blue-200' };
+  if (["pendente", "aguardando"].includes(value)) return { label: "Pendentes", className: 'bg-amber-100 text-amber-700 border border-amber-200' };
+  if (["trancado", "suspenso", "desistente", "inativo"].includes(value)) return { label: "Irregulares", className: 'bg-rose-100 text-rose-700 border border-rose-200' };
+  return { label: status || 'Outros', className: 'bg-slate-50 text-slate-600 border border-slate-200' };
+}


### PR DESCRIPTION
## Summary
- expand the secretaria dashboard API to surface matriculation statuses, featured turmas, and recent activity
- redesign the secretaria dashboard UI with richer cards, progress visuals, and quick enrollment insights
- add a turmas management route with filtered listings, stats, and navigation entry in the portal sidebar

## Testing
- pnpm --filter web lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916ec05abac83268689d64c26bdaede)