### PR TITLE
Create tenant SDK package and harden multi-tenant guardrails

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@supabase:registry=https://registry.npmjs.org/

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,15 +1,32 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const path = require("path");
 
+const REQUIRED_PUBLIC_ENV = ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"];
+const REQUIRED_SERVER_ENV = ["SUPABASE_SERVICE_ROLE_KEY"];
+
+function ensureSupabaseEnv() {
+  const missingPublic = REQUIRED_PUBLIC_ENV.filter((name) => !process.env[name]);
+  const missingServer = REQUIRED_SERVER_ENV.filter((name) => !process.env[name]);
+  const missing = [...missingPublic, ...missingServer];
+
+  const isStrict = process.env.CI === "true" || process.env.NODE_ENV === "production";
+
+  if (missing.length > 0) {
+    const message = `Missing Supabase environment variables: ${missing.join(", ")}`;
+    if (isStrict) {
+      throw new Error(`[next.config] ${message}`);
+    }
+    // eslint-disable-next-line no-console
+    console.warn(`[next.config] ${message}`);
+  }
+}
+
+ensureSupabaseEnv();
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   // Suas configurações existentes aqui...
-  
-  // ⚠️ ADICIONE ESTAS LINHAS:
-  env: {
-    NEXT_PUBLIC_SUPABASE_URL: process.env.NEXT_PUBLIC_SUPABASE_URL,
-    NEXT_PUBLIC_SUPABASE_ANON_KEY: process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-  },
+
   // Silence multi-lockfile root inference by pointing to monorepo root
   outputFileTracingRoot: path.join(__dirname, "../.."),
   eslint: {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "typecheck": "tsc --noEmit",
     "dev": "next dev",
     "build": "next build",
     "start": "next start"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@moxi/tenant-sdk": "workspace:*",
     "@supabase/ssr": "^0.7.0",
     "@supabase/supabase-js": "^2.81.0",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/api/escolas/[id]/settings/use-mv/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/settings/use-mv/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseServer } from '@/lib/supabaseServer'
-import { createClient as createAdminClient } from '@supabase/supabase-js'
 import { hasPermission } from '@/lib/permissions'
+import { createServiceRoleClient, invalidateTenantConfig } from '@moxi/tenant-sdk'
 
 export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id: escolaId } = await context.params
@@ -19,11 +19,13 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
     if (!hasPermission(papel as any, 'configurar_escola')) return NextResponse.json({ ok: false, error: 'Sem permissão' }, { status: 403 })
 
     const { enabled } = await req.json()
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL!
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY!
-    const admin = createAdminClient(url, key)
+    const admin = createServiceRoleClient()
     const { error } = await admin.from('escolas').update({ use_mv_dashboards: !!enabled }).eq('id', escolaId)
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 })
+
+    // Keep cached tenant configuration aligned with updates from this route
+    invalidateTenantConfig(escolaId)
+
     return NextResponse.json({ ok: true })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)

--- a/apps/web/src/app/api/escolas/[id]/usuarios/list/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/usuarios/list/route.ts
@@ -24,6 +24,7 @@ export async function GET(req: NextRequest, context: { params: Promise<{ id: str
 
     const { data: links, error } = await scopeToTenant(admin, 'escola_usuarios', escolaId)
       .select('user_id, papel')
+      .returns<{ user_id: string; papel: string | null }[]>()
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
 
     const ids = (links || []).map(l => l.user_id)

--- a/apps/web/src/app/api/secretaria/dashboard/route.ts
+++ b/apps/web/src/app/api/secretaria/dashboard/route.ts
@@ -12,6 +12,9 @@ type TurmaResumo = {
   count: number;
 };
 
+const withGroup = (group: string) =>
+  ({ group } as unknown as { head?: boolean; count?: 'exact' | 'planned' | 'estimated' });
+
 export async function GET() {
   try {
     const supabase = await supabaseServerTyped<any>();
@@ -43,11 +46,11 @@ export async function GET() {
       supabase.from('matriculas').select('*', { count: 'exact', head: true }).eq('escola_id', escolaId),
       supabase
         .from('matriculas')
-        .select('status, count:status', { group: 'status' })
+        .select('status, count:status', withGroup('status'))
         .eq('escola_id', escolaId),
       supabase
         .from('matriculas')
-        .select('turma_id, status, count:turma_id', { group: 'turma_id,status' })
+        .select('turma_id, status, count:turma_id', withGroup('turma_id,status'))
         .eq('escola_id', escolaId),
       supabase
         .from('avisos')

--- a/apps/web/src/app/api/secretaria/turmas/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { supabaseServerTyped } from "@/lib/supabaseServer";
 
+const withGroup = (group: string) =>
+  ({ group } as unknown as { head?: boolean; count?: 'exact' | 'planned' | 'estimated' });
+
 export async function GET(req: Request) {
   try {
     const supabase = await supabaseServerTyped<any>();
@@ -63,7 +66,7 @@ export async function GET(req: Request) {
     if (turmaIds.length) {
       const { data } = await supabase
         .from('matriculas')
-        .select('turma_id, status, count:turma_id', { group: 'turma_id,status' })
+        .select('turma_id, status, count:turma_id', withGroup('turma_id,status'))
         .eq('escola_id', escolaId)
         .in('turma_id', turmaIds);
       matriculasResumo = data || [];

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -8,6 +8,7 @@
       }
     ],
     "baseUrl": ".",
+    "moduleResolution": "Bundler",
     "paths": {
       "~/*": [
         "src/*"
@@ -18,6 +19,12 @@
       "~types/*": [
         "../../types/*"
       ], // ajuste se suas types estiverem em outro lugar
+      "@supabase/supabase-js": [
+        "./node_modules/@supabase/supabase-js"
+      ],
+      "@supabase/supabase-js/*": [
+        "./node_modules/@supabase/supabase-js/*"
+      ],
       "@moxi/tenant-sdk": [
         "../../packages/tenant-sdk/src/index.ts"
       ],

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -17,7 +17,13 @@
       ],
       "~types/*": [
         "../../types/*"
-      ] // ajuste se suas types estiverem em outro lugar
+      ], // ajuste se suas types estiverem em outro lugar
+      "@moxi/tenant-sdk": [
+        "../../packages/tenant-sdk/src/index.ts"
+      ],
+      "@moxi/tenant-sdk/*": [
+        "../../packages/tenant-sdk/src/*"
+      ]
     },
     "allowJs": true,
     "noEmit": true,

--- a/infra/db-scripts/ensure_next_month_partitions.sql
+++ b/infra/db-scripts/ensure_next_month_partitions.sql
@@ -1,0 +1,13 @@
+-- Runs the partition helpers to eagerly create the current and next month
+-- partitions for frequencias/lancamentos. Safe to execute multiple times.
+DO $$
+BEGIN
+  PERFORM public.create_month_partition('frequencias', date_trunc('month', current_date)::date);
+  PERFORM public.create_month_partition('frequencias', date_trunc('month', current_date + interval '1 month')::date);
+  PERFORM public.create_month_partition_ts('lancamentos', date_trunc('month', current_date)::date);
+  PERFORM public.create_month_partition_ts('lancamentos', date_trunc('month', current_date + interval '1 month')::date);
+EXCEPTION
+  WHEN others THEN
+    RAISE NOTICE '[partitions] erro ao criar partições: %', SQLERRM;
+END;
+$$;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "description": "Monorepo for Moxi EdTech projects",
   "workspaces": [
-    "apps/*"
+    "apps/*",
+    "packages/*"
   ],
   "scripts": {
     "dev": "npm run dev --workspace=web",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
     "build": "npm run build --workspace=web",
     "start": "npm run start --workspace=web",
     "lint": "npm run lint --workspace=web",
-    "typecheck": "npm run typecheck --workspace=web",
+    "typecheck": "pnpm -r typecheck",
     "clean": "rm -rf .next node_modules/.cache",
     "gen:types": "mkdir -p types && supabase gen types typescript --project-id wjtifcpxxxotsbmvbgoq > types/supabase.ts",
     "db:push": "supabase db push --project-ref wjtifcpxxxotsbmvbgoq",
     "db:reset": "supabase db reset",
-    "db:seed:remote": "sh -c 'cat supabase/seeds/*.sql > supabase/.tmp_seed.sql && supabase db execute --project-ref wjtifcpxxxotsbmvbgoq --file supabase/.tmp_seed.sql && rm -f supabase/.tmp_seed.sql'"
+    "db:seed:remote": "sh -c 'cat supabase/seeds/*.sql > supabase/.tmp_seed.sql && supabase db execute --project-ref wjtifcpxxxotsbmvbgoq --file supabase/.tmp_seed.sql && rm -f supabase/.tmp_seed.sql'",
+    "test:rls": "psql -f supabase/tests/assert_tenant_rls.sql"
   },
   "devDependencies": {
     "@types/node": "^24.10.0",

--- a/packages/tenant-sdk/package.json
+++ b/packages/tenant-sdk/package.json
@@ -10,6 +10,9 @@
     }
   },
   "peerDependencies": {
-    "@supabase/supabase-js": "^2.48.0"
+    "@supabase/supabase-js": "^2.81.0"
+  },
+  "devDependencies": {
+    "@supabase/supabase-js": "^2.81.0"
   }
 }

--- a/packages/tenant-sdk/package.json
+++ b/packages/tenant-sdk/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@moxi/tenant-sdk",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "peerDependencies": {
+    "@supabase/supabase-js": "^2.48.0"
+  }
+}

--- a/packages/tenant-sdk/src/index.ts
+++ b/packages/tenant-sdk/src/index.ts
@@ -1,0 +1,91 @@
+import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "../../types/supabase";
+
+type TenantTables = {
+  [TableName in keyof Database["public"]["Tables"]]: "escola_id" extends keyof Database["public"]["Tables"][TableName]["Row"]
+    ? TableName
+    : never;
+}[keyof Database["public"]["Tables"]];
+
+type TenantConfigRow = Database["public"]["Tables"]["escola_configuracoes"]["Row"];
+
+const tenantConfigCache = new Map<string, TenantConfigRow | null>();
+
+function resolveServiceRoleEnv() {
+  const url = process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  const missing: string[] = [];
+  if (!url) missing.push("SUPABASE_URL/NEXT_PUBLIC_SUPABASE_URL");
+  if (!serviceRoleKey) missing.push("SUPABASE_SERVICE_ROLE_KEY");
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[tenant-sdk] Missing environment variables: ${missing.join(", ")}. ` +
+        "Configure them before using the tenant SDK."
+    );
+  }
+
+  return { url, serviceRoleKey } as { url: string; serviceRoleKey: string };
+}
+
+export function createServiceRoleClient(): SupabaseClient<Database> {
+  const { url, serviceRoleKey } = resolveServiceRoleEnv();
+
+  return createSupabaseClient<Database>(url, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+    },
+  });
+}
+
+export function scopeToTenant<TableName extends TenantTables>(
+  client: SupabaseClient<Database>,
+  table: TableName,
+  escolaId: string
+) {
+  if (!escolaId) {
+    throw new Error("[tenant-sdk] Missing escolaId when scoping query to tenant");
+  }
+  return client.from(table).eq("escola_id", escolaId);
+}
+
+type TenantConfigOptions = {
+  client?: SupabaseClient<Database>;
+  refresh?: boolean;
+};
+
+export async function getTenantConfig(
+  escolaId: string,
+  options: TenantConfigOptions = {}
+): Promise<TenantConfigRow | null> {
+  if (!escolaId) {
+    throw new Error("[tenant-sdk] escolaId is required to load tenant configuration");
+  }
+
+  if (!options.refresh && tenantConfigCache.has(escolaId)) {
+    return tenantConfigCache.get(escolaId) ?? null;
+  }
+
+  const client = options.client ?? createServiceRoleClient();
+  const { data, error } = await scopeToTenant(client, "escola_configuracoes", escolaId)
+    .select("*")
+    .maybeSingle();
+
+  if (error && error.code !== "PGRST116") {
+    throw new Error(`[tenant-sdk] Failed to load tenant config for ${escolaId}: ${error.message}`);
+  }
+
+  tenantConfigCache.set(escolaId, data ?? null);
+  return data ?? null;
+}
+
+export function invalidateTenantConfig(escolaId: string) {
+  if (escolaId) {
+    tenantConfigCache.delete(escolaId);
+  }
+}
+
+export function clearTenantConfigCache() {
+  tenantConfigCache.clear();
+}

--- a/packages/tenant-sdk/tsconfig.json
+++ b/packages/tenant-sdk/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "baseUrl": "../..",
+    "paths": {
+      "~types/*": [
+        "types/*"
+      ]
+    }
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - 'apps/*'
+  - 'packages/*'

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -15,11 +15,11 @@ schemas = ["public", "graphql_public"]
 extra_search_path = ["public", "extensions"]
 # The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
 # for accidental or malicious requests.
-max_rows = 1000
+max_rows = 500
 
 [api.tls]
 # Enable HTTPS endpoints locally using a self-signed certificate.
-enabled = false
+enabled = true
 
 [db]
 # Port to use for the local database URL.
@@ -61,13 +61,13 @@ sql_paths = ["./seed.sql"]
 
 [db.network_restrictions]
 # Enable management of network restrictions.
-enabled = false
+enabled = true
 # List of IPv4 CIDR blocks allowed to connect to the database.
 # Defaults to allow all IPv4 connections. Set empty array to block all IPs.
-allowed_cidrs = ["0.0.0.0/0"]
+allowed_cidrs = ["127.0.0.1/32"]
 # List of IPv6 CIDR blocks allowed to connect to the database.
 # Defaults to allow all IPv6 connections. Set empty array to block all IPs.
-allowed_cidrs_v6 = ["::/0"]
+allowed_cidrs_v6 = ["::1/128"]
 
 [realtime]
 enabled = true

--- a/supabase/tests/assert_tenant_rls.sql
+++ b/supabase/tests/assert_tenant_rls.sql
@@ -1,0 +1,45 @@
+-- Ensures that every table with an escola_id column has RLS + FORCE RLS enabled
+-- and at least one policy defined. Intended to run via `supabase test db`.
+DO $$
+DECLARE
+  rec record;
+  missing_policy text;
+  missing_force text;
+BEGIN
+  FOR rec IN
+    SELECT c.oid, c.relname AS table_name
+    FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      JOIN pg_attribute a ON a.attrelid = c.oid
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND a.attname = 'escola_id'
+  LOOP
+    -- Ensure at least one policy exists
+    SELECT p.policyname
+      INTO missing_policy
+      FROM pg_policies p
+      WHERE p.schemaname = 'public'
+        AND p.tablename = rec.table_name
+      LIMIT 1;
+
+    IF missing_policy IS NULL THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = format('Tabela %s não possui políticas de RLS definidas.', rec.table_name);
+    END IF;
+
+    -- Ensure FORCE ROW LEVEL SECURITY is active
+    SELECT CASE WHEN c.relforcerowsecurity THEN NULL ELSE c.relname END
+      INTO missing_force
+      FROM pg_class c
+      WHERE c.oid = rec.oid;
+
+    IF missing_force IS NOT NULL THEN
+      RAISE EXCEPTION USING
+        ERRCODE = 'P0001',
+        MESSAGE = format('Tabela %s precisa de FORCE ROW LEVEL SECURITY.', rec.table_name);
+    END IF;
+  END LOOP;
+END;
+$$;


### PR DESCRIPTION
## Summary
- add a shared `@moxi/tenant-sdk` workspace package with helpers for service-role clients, tenant scoping, and cached configuration lookups
- refactor selected API routes to consume the SDK and gate build-time environment validation in Next.js
- tighten Supabase local defaults plus add SQL checks/cron-friendly scripts for RLS and partition maintenance

## Testing
- pnpm --filter web typecheck *(fails: script not defined)*
- pnpm install *(fails: registry returns 403 for @supabase/supabase-js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69173ea1c4f083268388d00e42f4da61)