### PR TITLE
Relax Supabase service role key requirement during build

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,22 +2,27 @@
 const path = require("path");
 
 const REQUIRED_PUBLIC_ENV = ["NEXT_PUBLIC_SUPABASE_URL", "NEXT_PUBLIC_SUPABASE_ANON_KEY"];
-const REQUIRED_SERVER_ENV = ["SUPABASE_SERVICE_ROLE_KEY"];
+const OPTIONAL_SERVER_ENV = ["SUPABASE_SERVICE_ROLE_KEY"];
 
 function ensureSupabaseEnv() {
   const missingPublic = REQUIRED_PUBLIC_ENV.filter((name) => !process.env[name]);
-  const missingServer = REQUIRED_SERVER_ENV.filter((name) => !process.env[name]);
-  const missing = [...missingPublic, ...missingServer];
+  const missingServer = OPTIONAL_SERVER_ENV.filter((name) => !process.env[name]);
 
   const isStrict = process.env.CI === "true" || process.env.NODE_ENV === "production";
 
-  if (missing.length > 0) {
-    const message = `Missing Supabase environment variables: ${missing.join(", ")}`;
+  if (missingPublic.length > 0) {
+    const message = `Missing required Supabase environment variables: ${missingPublic.join(", ")}`;
     if (isStrict) {
       throw new Error(`[next.config] ${message}`);
     }
     // eslint-disable-next-line no-console
     console.warn(`[next.config] ${message}`);
+  }
+
+  if (missingServer.length > 0) {
+    const message = `Missing optional Supabase server environment variables: ${missingServer.join(", ")}`;
+    // eslint-disable-next-line no-console
+    console.warn(`[next.config] ${message}. Server-side features that rely on these values may not function until they are configured.`);
   }
 }
 


### PR DESCRIPTION
## Summary
- treat the Supabase service role key as optional during build-time configuration
- continue enforcing required public Supabase environment variables while warning about missing server values

## Testing
- CI=1 NEXT_PUBLIC_SUPABASE_URL=http://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy pnpm --filter web build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917523dbe288326842bab1126d10fbc)