### PR TITLE
Align plan naming across super-admin routes

### DIFF
--- a/apps/web/src/app/super-admin/escolas/page.tsx
+++ b/apps/web/src/app/super-admin/escolas/page.tsx
@@ -35,10 +35,14 @@ async function fetchInitial() {
   type RawSchool = { id: string; nome: string | null; status: string | null; plano: string | null; last_access: string | null; total_alunos: number; total_professores: number; cidade: string | null; estado: string | null }
   const prettyPlan = (p?: string | null): string => {
     switch ((p || '').toLowerCase()) {
-      case 'basico': return 'Básico'
-      case 'standard': return 'Premium'
-      case 'premium': return 'Enterprise'
-      default: return (p as any) || 'Básico'
+      case 'basico':
+        return 'Básico'
+      case 'standard':
+        return 'Standard'
+      case 'premium':
+        return 'Premium'
+      default:
+        return (p as any) || 'Básico'
     }
   }
   const normalized = (initialSchools as RawSchool[]).map(d => ({

--- a/apps/web/src/components/super-admin/escolas/SchoolRow.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolRow.tsx
@@ -136,8 +136,8 @@ export function SchoolRow({
       <td className="py-3 px-4">
         <select className="border rounded-md px-2 py-1 text-sm" value={String(valueOrForm('plan', school.plan || 'Básico'))} onChange={(e) => onInputChange('plan', e.target.value)}>
           <option value="Básico">Básico</option>
+          <option value="Standard">Standard</option>
           <option value="Premium">Premium</option>
-          <option value="Enterprise">Enterprise</option>
         </select>
       </td>
       <td className="py-3 px-4 text-gray-700">{school.lastAccess || '—'}</td>

--- a/apps/web/src/components/super-admin/escolas/SchoolsFilters.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolsFilters.tsx
@@ -56,8 +56,8 @@ export function SchoolsFilters({
           >
             <option value="all">Todos planos</option>
             <option value="Básico">Básico</option>
+            <option value="Standard">Standard</option>
             <option value="Premium">Premium</option>
-            <option value="Enterprise">Enterprise</option>
           </select>
         </div>
         <div className="text-sm text-gray-600 flex gap-4">

--- a/apps/web/src/components/super-admin/escolas/SchoolsTableClient.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolsTableClient.tsx
@@ -65,10 +65,14 @@ export default function SchoolsTableClient({
       // Normalize like server page.tsx does
       const prettyPlan = (p?: string | null): string => {
         switch ((p || '').toLowerCase()) {
-          case 'basico': return 'Básico';
-          case 'standard': return 'Premium';
-          case 'premium': return 'Enterprise';
-          default: return (p as any) || 'Básico';
+          case 'basico':
+            return 'Básico';
+          case 'standard':
+            return 'Standard';
+          case 'premium':
+            return 'Premium';
+          default:
+            return (p as any) || 'Básico';
         }
       }
 
@@ -214,10 +218,15 @@ export default function SchoolsTableClient({
 
       const unPrettyPlan = (p?: string | null): string => {
         switch ((p || '').toLowerCase()) {
-          case 'básico': return 'basico';
-          case 'premium': return 'standard';
-          case 'enterprise': return 'premium';
-          default: return (p as any) || 'basico';
+          case 'básico':
+          case 'basico':
+            return 'basico';
+          case 'standard':
+            return 'standard';
+          case 'premium':
+            return 'premium';
+          default:
+            return (p as any) || 'basico';
         }
       }
 

--- a/apps/web/src/components/super-admin/escolas/types.ts
+++ b/apps/web/src/components/super-admin/escolas/types.ts
@@ -2,7 +2,7 @@ export type School = {
   id: string | number;
   name: string;
   status: "ativa" | "suspensa" | "pendente" | string;
-  plan: "Enterprise" | "Premium" | "Básico" | string;
+  plan: "Básico" | "Standard" | "Premium" | string;
   lastAccess: string | null;
   students: number;
   teachers: number;


### PR DESCRIPTION
## Summary
- align the prettyPlan helper on the server-rendered super-admin schools page with the canonical Básico/Standard/Premium names
- propagate the same plan naming to the client table helpers, editing workflow, and filtering controls
- tighten the shared School types to reflect the updated display names

## Testing
- pnpm lint *(fails: workspace web@0.1.0 is missing a lint script)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69175fc03afc832685b37015e910cae6)