### PR TITLE
Fix cookies helper usage in debug session route

### DIFF
--- a/apps/web/src/app/api/debug/session/route.ts
+++ b/apps/web/src/app/api/debug/session/route.ts
@@ -9,7 +9,7 @@ export async function GET(req: Request) {
   const url = new URL(req.url);
   const verbose = url.searchParams.get("verbose") === "1";
 
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
   const supabase = createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,

--- a/apps/web/src/lib/supabaseServer.ts
+++ b/apps/web/src/lib/supabaseServer.ts
@@ -30,9 +30,9 @@ function getSupabaseEnv() {
  * Use:
  *   const supabase = await supabaseServer();
  */
-export function supabaseServer() {
+export async function supabaseServer() {
   const { url, anonKey } = getSupabaseEnv();
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   return createServerClient<Database>(url, anonKey, {
     cookies: {
@@ -53,9 +53,9 @@ export function supabaseServer() {
  * Example (como no /api/escolas/create):
  *   const supabase = await supabaseServerTyped<DBWithRPC>();
  */
-export function supabaseServerTyped<TDatabase = Database>() {
+export async function supabaseServerTyped<TDatabase = Database>() {
   const { url, anonKey } = getSupabaseEnv();
-  const cookieStore = cookies();
+  const cookieStore = await cookies();
 
   return createServerClient<TDatabase>(url, anonKey, {
     cookies: {


### PR DESCRIPTION
## Summary
- await the cookies helper in the debug session API route to match updated Next.js typings

## Testing
- pnpm -C apps/web build *(fails: missing required Supabase env vars locally)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692063185368832683f7f17ce1e1ab2a)