### PR TITLE
feat: scaffold aluno migration wizard

### DIFF
--- a/apps/web/src/app/api/migracao/alunos/importar/route.ts
+++ b/apps/web/src/app/api/migracao/alunos/importar/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+
+import type { Database } from "~types/supabase";
+import type { ImportResult } from "~types/migracao";
+
+export const dynamic = "force-dynamic";
+
+interface ImportBody {
+  importId: string;
+  escolaId: string;
+}
+
+export async function POST(request: Request) {
+  const adminUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!adminUrl || !serviceKey) {
+    return NextResponse.json({ error: "SUPABASE configuration missing" }, { status: 500 });
+  }
+
+  let body: ImportBody;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+  }
+
+  const { importId, escolaId } = body;
+  if (!importId || !escolaId) {
+    return NextResponse.json({ error: "importId e escolaId são obrigatórios" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient<Database>(adminUrl, serviceKey);
+
+  const { data, error } = await supabase.rpc("importar_alunos", {
+    p_import_id: importId,
+    p_escola_id: escolaId,
+  });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const result = (Array.isArray(data) && data.length ? data[0] : data) as ImportResult;
+
+  await supabase
+    .from("import_migrations")
+    .update({ status: "imported", processed_at: new Date().toISOString() })
+    .eq("id", importId);
+
+  return NextResponse.json({ result });
+}

--- a/apps/web/src/app/api/migracao/alunos/validar/route.ts
+++ b/apps/web/src/app/api/migracao/alunos/validar/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+
+import type { Database } from "~types/supabase";
+import type { AlunoStagingRecord, MappedColumns } from "~types/migracao";
+import { csvToJsonLines, mapAlunoFromCsv, summarizePreview } from "../../utils";
+
+export const dynamic = "force-dynamic";
+
+interface ValidateBody {
+  importId: string;
+  escolaId: string;
+  columnMap: MappedColumns;
+}
+
+export async function POST(request: Request) {
+  const adminUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!adminUrl || !serviceKey) {
+    return NextResponse.json({ error: "SUPABASE configuration missing" }, { status: 500 });
+  }
+
+  let body: ValidateBody;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "JSON inválido" }, { status: 400 });
+  }
+
+  const { importId, escolaId, columnMap } = body;
+  if (!importId || !escolaId) {
+    return NextResponse.json({ error: "importId e escolaId são obrigatórios" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient<Database>(adminUrl, serviceKey);
+
+  const { data: migration, error: migrationError } = await supabase
+    .from("import_migrations")
+    .select("storage_path")
+    .eq("id", importId)
+    .single();
+
+  if (migrationError || !migration) {
+    return NextResponse.json({ error: migrationError?.message || "Importação não encontrada" }, { status: 404 });
+  }
+
+  const { data: fileData, error: downloadError } = await supabase.storage
+    .from("migracoes")
+    .download(migration.storage_path!);
+
+  if (downloadError || !fileData) {
+    return NextResponse.json({ error: downloadError?.message || "Arquivo não encontrado" }, { status: 404 });
+  }
+
+  const text = await fileData.text();
+  const entries = csvToJsonLines(text);
+  const staged: AlunoStagingRecord[] = entries.map((entry) => mapAlunoFromCsv(entry, columnMap, importId, escolaId));
+
+  // Clear previous staging/errors for idempotency
+  await supabase.from("import_errors").delete().eq("import_id", importId);
+  await supabase.from("staging_alunos").delete().eq("import_id", importId);
+
+  const { error: stageError } = await supabase.from("staging_alunos").upsert(staged);
+  if (stageError) {
+    return NextResponse.json({ error: stageError.message }, { status: 500 });
+  }
+
+  await supabase
+    .from("import_migrations")
+    .update({ status: "validado", total_rows: staged.length })
+    .eq("id", importId);
+
+  return NextResponse.json({ preview: summarizePreview(staged), total: staged.length });
+}

--- a/apps/web/src/app/api/migracao/upload/route.ts
+++ b/apps/web/src/app/api/migracao/upload/route.ts
@@ -1,0 +1,79 @@
+import { NextResponse } from "next/server";
+import { createClient as createAdminClient } from "@supabase/supabase-js";
+import { randomUUID } from "node:crypto";
+
+import type { Database } from "~types/supabase";
+import type { ImportStatus } from "~types/migracao";
+import { hashBuffer, MAX_UPLOAD_SIZE } from "../utils";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const adminUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!adminUrl || !serviceKey) {
+    return NextResponse.json({ error: "SUPABASE configuration missing" }, { status: 500 });
+  }
+
+  const formData = await request.formData();
+  const file = formData.get("file");
+  const escolaId = formData.get("escolaId")?.toString();
+  const createdBy = formData.get("userId")?.toString();
+
+  if (!file || !(file instanceof File)) {
+    return NextResponse.json({ error: "Arquivo obrigatório" }, { status: 400 });
+  }
+
+  if (!escolaId) {
+    return NextResponse.json({ error: "escolaId obrigatório" }, { status: 400 });
+  }
+
+  const buffer = Buffer.from(await file.arrayBuffer());
+  if (buffer.byteLength > MAX_UPLOAD_SIZE) {
+    return NextResponse.json({ error: "Arquivo maior que o limite permitido" }, { status: 400 });
+  }
+
+  const hash = hashBuffer(buffer);
+  const importId = randomUUID();
+  const objectPath = `migracoes/${importId}/${file.name}`;
+
+  const supabase = createAdminClient<Database>(adminUrl, serviceKey);
+
+  // Ensure bucket exists
+  try {
+    const { data: bucketInfo, error: bucketError } = await supabase.storage.getBucket("migracoes");
+    if (bucketError || !bucketInfo) {
+      await supabase.storage.createBucket("migracoes", { public: false });
+    }
+  } catch (err) {
+    console.warn("[upload] bucket check failed", err);
+  }
+
+  const { error: uploadError } = await supabase.storage.from("migracoes").upload(objectPath, buffer, {
+    cacheControl: "3600",
+    upsert: false,
+    contentType: file.type || "text/csv",
+  });
+
+  if (uploadError) {
+    return NextResponse.json({ error: uploadError.message }, { status: 500 });
+  }
+
+  const status: ImportStatus = "uploaded";
+  const { error: dbError } = await supabase.from("import_migrations").insert({
+    id: importId,
+    escola_id: escolaId,
+    created_by: createdBy,
+    file_name: file.name,
+    file_hash: hash,
+    storage_path: objectPath,
+    status,
+  });
+
+  if (dbError) {
+    return NextResponse.json({ error: dbError.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ importId, status, objectPath, hash });
+}

--- a/apps/web/src/app/api/migracao/utils.ts
+++ b/apps/web/src/app/api/migracao/utils.ts
@@ -1,0 +1,90 @@
+import crypto from "node:crypto";
+
+import type { AlunoCSV, AlunoStagingRecord, MappedColumns } from "~types/migracao";
+
+export const MAX_UPLOAD_SIZE = 12 * 1024 * 1024; // 12 MB
+
+export function hashBuffer(buffer: Buffer): string {
+  const hash = crypto.createHash("sha256");
+  hash.update(buffer);
+  return hash.digest("hex");
+}
+
+export function normalizeText(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const cleaned = value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .trim()
+    .replace(/\s+/g, " ");
+  return cleaned.toLowerCase();
+}
+
+export function normalizeDateString(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  const formats = [
+    { regex: /^(\d{4})-(\d{2})-(\d{2})$/, map: (y: string, m: string, d: string) => `${y}-${m}-${d}` },
+    { regex: /^(\d{2})\/(\d{2})\/(\d{4})$/, map: (d: string, m: string, y: string) => `${y}-${m}-${d}` },
+    { regex: /^(\d{2})-(\d{2})-(\d{4})$/, map: (d: string, m: string, y: string) => `${y}-${m}-${d}` },
+    { regex: /^(\d{2})\/(\d{2})\/(\d{2})$/, map: (d: string, m: string, y: string) => `20${y}-${m}-${d}` },
+  ];
+
+  for (const { regex, map } of formats) {
+    const match = normalized.match(regex);
+    if (match) {
+      return map(match[1], match[2], match[3]);
+    }
+  }
+
+  return undefined;
+}
+
+export function csvToJsonLines(csv: string): AlunoCSV[] {
+  const lines = csv.split(/\r?\n/).filter(Boolean);
+  if (lines.length === 0) return [];
+
+  const delimiter = lines[0].includes(";") && !lines[0].includes(",") ? ";" : ",";
+  const headers = lines[0].split(delimiter).map((h) => h.trim());
+
+  return lines.slice(1).map((line) => {
+    const values = line.split(delimiter);
+    const entry: AlunoCSV = {};
+    headers.forEach((header, idx) => {
+      entry[header] = values[idx]?.trim();
+    });
+    return entry;
+  });
+}
+
+export function mapAlunoFromCsv(entry: AlunoCSV, columnMap: MappedColumns, importId: string, escolaId: string): AlunoStagingRecord {
+  const mapped: AlunoStagingRecord = {
+    import_id: importId,
+    escola_id: escolaId,
+    raw_data: entry,
+  };
+
+  const nomeKey = columnMap.nome;
+  if (nomeKey) mapped.nome = normalizeText(entry[nomeKey]);
+
+  const dataKey = columnMap.data_nascimento;
+  if (dataKey) mapped.data_nascimento = normalizeDateString(entry[dataKey]);
+
+  const telKey = columnMap.telefone;
+  if (telKey) mapped.telefone = entry[telKey]?.replace(/[^\d+]/g, "");
+
+  const biKey = columnMap.bi;
+  if (biKey) mapped.bi = entry[biKey]?.trim();
+
+  const emailKey = columnMap.email;
+  if (emailKey) mapped.email = entry[emailKey]?.trim().toLowerCase();
+
+  const profileKey = columnMap.profile_id;
+  if (profileKey) mapped.profile_id = entry[profileKey]?.trim();
+
+  return mapped;
+}
+
+export function summarizePreview(rows: AlunoStagingRecord[], limit = 20): AlunoStagingRecord[] {
+  return rows.slice(0, limit);
+}

--- a/apps/web/src/app/migracao/alunos/page.tsx
+++ b/apps/web/src/app/migracao/alunos/page.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState } from "react";
+
+import Button from "~/components/ui/Button";
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
+import { ColumnMapper } from "~/components/migracao/ColumnMapper";
+import { ErrorList } from "~/components/migracao/ErrorList";
+import { PreviewTable } from "~/components/migracao/PreviewTable";
+import { ProgressInfo } from "~/components/migracao/ProgressInfo";
+import { UploadField } from "~/components/migracao/UploadField";
+import type { AlunoStagingRecord, MappedColumns } from "~types/migracao";
+
+export default function AlunoMigrationWizard() {
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState<File | null>(null);
+  const [headers, setHeaders] = useState<string[]>([]);
+  const [mapping, setMapping] = useState<MappedColumns>({});
+  const [preview, setPreview] = useState<AlunoStagingRecord[]>([]);
+  const [errors, setErrors] = useState<string[]>([]);
+  const [apiErrors, setApiErrors] = useState<string[]>([]);
+
+  const totalSteps = 4;
+
+  const extractHeaders = async () => {
+    if (!file) return;
+    const text = await file.text();
+    const [firstLine] = text.split(/\r?\n/);
+    const delimiter = firstLine.includes(";") && !firstLine.includes(",") ? ";" : ",";
+    setHeaders(firstLine.split(delimiter).map((h) => h.trim()));
+  };
+
+  const handleValidateLocal = async () => {
+    setErrors([]);
+    if (!file) {
+      setErrors(["Selecione um arquivo para continuar"]);
+      return;
+    }
+    await extractHeaders();
+    const text = await file.text();
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    if (lines.length <= 1) {
+      setErrors(["Arquivo sem registros"]);
+      return;
+    }
+    const delimiter = headers.length && headers[0].includes(";") && !headers[0].includes(",") ? ";" : ",";
+    const rows = lines.slice(1).map((line) => line.split(delimiter));
+    const mapped: AlunoStagingRecord[] = rows.slice(0, 20).map((cols, idx) => ({
+      import_id: "preview",
+      escola_id: "preview",
+      nome: mapping.nome ? cols[headers.indexOf(mapping.nome)] : undefined,
+      data_nascimento: mapping.data_nascimento ? cols[headers.indexOf(mapping.data_nascimento)] : undefined,
+      telefone: mapping.telefone ? cols[headers.indexOf(mapping.telefone)] : undefined,
+      bi: mapping.bi ? cols[headers.indexOf(mapping.bi)] : undefined,
+      email: mapping.email ? cols[headers.indexOf(mapping.email)] : undefined,
+      profile_id: mapping.profile_id ? cols[headers.indexOf(mapping.profile_id)] : undefined,
+      raw_data: { row: idx },
+    }));
+    setPreview(mapped);
+    setStep(3);
+  };
+
+  const handleUpload = async () => {
+    setApiErrors([]);
+    if (!file) {
+      setApiErrors(["Selecione um arquivo para subir"]);
+      return;
+    }
+    const formData = new FormData();
+    formData.append("file", file);
+    formData.append("escolaId", "pending-escola");
+
+    const response = await fetch("/api/migracao/upload", { method: "POST", body: formData });
+    if (!response.ok) {
+      const payload = await response.json();
+      setApiErrors([payload.error || "Erro ao enviar arquivo"]);
+      return;
+    }
+    setStep(2);
+    await extractHeaders();
+  };
+
+  const handleImport = async () => {
+    setApiErrors([]);
+    const response = await fetch("/api/migracao/alunos/importar", {
+      method: "POST",
+      body: JSON.stringify({ importId: "preview", escolaId: "pending-escola" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!response.ok) {
+      const payload = await response.json();
+      setApiErrors([payload.error || "Falha ao importar"]);
+      return;
+    }
+    setStep(4);
+  };
+
+  return (
+    <main className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Migração de Alunos</h1>
+          <p className="text-sm text-muted-foreground">Wizard passo a passo para upload, validação e importação.</p>
+        </div>
+        <ProgressInfo step={step} total={totalSteps} />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>1) Upload</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <UploadField onFileSelected={setFile} />
+            <Button onClick={handleUpload} disabled={!file}>
+              Enviar arquivo
+            </Button>
+            {errors.map((err) => (
+              <p key={err} className="text-sm text-destructive">{err}</p>
+            ))}
+            {apiErrors.map((err) => (
+              <p key={err} className="text-sm text-destructive">{err}</p>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>2) Mapeamento</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ColumnMapper headers={headers} mapping={mapping} onChange={setMapping} />
+            <Button variant="secondary" onClick={handleValidateLocal} disabled={!file}>
+              Pré-visualizar
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>3) Pré-visualização</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <PreviewTable records={preview} />
+          <Button variant="secondary" onClick={handleImport} disabled={!preview.length}>
+            Importar
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>4) Finalização</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Acompanhe o status da importação. Erros aparecerão abaixo e podem ser baixados pelo time técnico.
+          </p>
+          <ErrorList
+            errors={apiErrors.map((message, idx) => ({ message, row_number: idx + 1, column_name: "api" }))}
+          />
+        </CardContent>
+      </Card>
+    </main>
+  );
+}

--- a/apps/web/src/app/migracao/historico/page.tsx
+++ b/apps/web/src/app/migracao/historico/page.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
+
+export default function HistoricoImportacao() {
+  const placeholders = [
+    { importId: "demo-1", status: "uploaded", total: 120 },
+    { importId: "demo-2", status: "imported", total: 87 },
+  ];
+
+  return (
+    <main className="p-6 space-y-4">
+      <div>
+        <h1 className="text-2xl font-semibold">Histórico de Importações</h1>
+        <p className="text-sm text-muted-foreground">Acompanhe importações recentes e resultados.</p>
+      </div>
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {placeholders.map((item) => (
+          <Card key={item.importId}>
+            <CardHeader>
+              <CardTitle>Importação {item.importId}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2">
+              <p className="text-sm">Status: {item.status}</p>
+              <p className="text-sm">Registros: {item.total}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/migracao/ColumnMapper.tsx
+++ b/apps/web/src/components/migracao/ColumnMapper.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { Input } from "~/components/ui/Input";
+import { Label } from "~/components/ui/Label";
+import { Select } from "~/components/ui/Select";
+
+import type { MappedColumns } from "~types/migracao";
+
+interface ColumnMapperProps {
+  headers: string[];
+  mapping: MappedColumns;
+  onChange: (next: MappedColumns) => void;
+}
+
+const FIELD_OPTIONS: { key: keyof MappedColumns; label: string }[] = [
+  { key: "nome", label: "Nome" },
+  { key: "data_nascimento", label: "Data de nascimento" },
+  { key: "telefone", label: "Telefone" },
+  { key: "bi", label: "BI" },
+  { key: "email", label: "Email" },
+  { key: "profile_id", label: "Profile ID" },
+];
+
+export function ColumnMapper({ headers, mapping, onChange }: ColumnMapperProps) {
+  const options = useMemo(() => headers.filter(Boolean), [headers]);
+
+  const update = (field: keyof MappedColumns, value: string) => {
+    onChange({ ...mapping, [field]: value });
+  };
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {FIELD_OPTIONS.map((field) => (
+        <div key={field.key} className="space-y-2">
+          <Label>{field.label}</Label>
+          <Select value={mapping[field.key] || ""} onChange={(event) => update(field.key, event.target.value)}>
+            <option value="">-- Selecione --</option>
+            {options.map((header) => (
+              <option key={header} value={header}>
+                {header}
+              </option>
+            ))}
+          </Select>
+        </div>
+      ))}
+      <div className="space-y-2 md:col-span-2">
+        <Label>Colunas no arquivo</Label>
+        <Input readOnly value={options.join(", ")} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/migracao/ErrorList.tsx
+++ b/apps/web/src/components/migracao/ErrorList.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ErroImportacao } from "~types/migracao";
+
+interface ErrorListProps {
+  errors: ErroImportacao[];
+}
+
+export function ErrorList({ errors }: ErrorListProps) {
+  if (!errors.length) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-semibold">Erros encontrados ({errors.length})</p>
+      <div className="border rounded-md overflow-hidden">
+        <table className="min-w-full text-sm">
+          <thead className="bg-muted">
+            <tr>
+              <th className="px-3 py-2 text-left">Linha</th>
+              <th className="px-3 py-2 text-left">Coluna</th>
+              <th className="px-3 py-2 text-left">Mensagem</th>
+            </tr>
+          </thead>
+          <tbody>
+            {errors.map((error, idx) => (
+              <tr key={idx} className="border-t">
+                <td className="px-3 py-2">{error.row_number ?? "-"}</td>
+                <td className="px-3 py-2">{error.column_name || "-"}</td>
+                <td className="px-3 py-2">{error.message}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/migracao/PreviewTable.tsx
+++ b/apps/web/src/components/migracao/PreviewTable.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import type { AlunoStagingRecord } from "~types/migracao";
+
+interface PreviewTableProps {
+  records: AlunoStagingRecord[];
+}
+
+export function PreviewTable({ records }: PreviewTableProps) {
+  if (!records.length) {
+    return <p className="text-sm text-muted-foreground">Nenhum registro para pré-visualizar.</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto border rounded-md">
+      <table className="min-w-full text-sm">
+        <thead className="bg-muted">
+          <tr>
+            <th className="px-3 py-2 text-left">Nome</th>
+            <th className="px-3 py-2 text-left">Data</th>
+            <th className="px-3 py-2 text-left">Telefone</th>
+            <th className="px-3 py-2 text-left">BI</th>
+            <th className="px-3 py-2 text-left">Email</th>
+          </tr>
+        </thead>
+        <tbody>
+          {records.map((record, idx) => (
+            <tr key={idx} className="border-t">
+              <td className="px-3 py-2">{record.nome || "-"}</td>
+              <td className="px-3 py-2">{record.data_nascimento || "-"}</td>
+              <td className="px-3 py-2">{record.telefone || "-"}</td>
+              <td className="px-3 py-2">{record.bi || "-"}</td>
+              <td className="px-3 py-2">{record.email || "-"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/components/migracao/ProgressInfo.tsx
+++ b/apps/web/src/components/migracao/ProgressInfo.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Progress } from "~/components/ui/Progress";
+
+interface ProgressInfoProps {
+  step: number;
+  total: number;
+}
+
+export function ProgressInfo({ step, total }: ProgressInfoProps) {
+  const percentage = Math.round((step / total) * 100);
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between text-sm">
+        <span>Etapa {step} de {total}</span>
+        <span>{percentage}%</span>
+      </div>
+      <Progress value={percentage} />
+    </div>
+  );
+}

--- a/apps/web/src/components/migracao/UploadField.tsx
+++ b/apps/web/src/components/migracao/UploadField.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useRef, useState } from "react";
+
+import Button from "~/components/ui/Button";
+import { Input } from "~/components/ui/Input";
+
+interface UploadFieldProps {
+  onFileSelected: (file: File) => void;
+  maxSizeMb?: number;
+}
+
+export function UploadField({ onFileSelected, maxSizeMb = 12 }: UploadFieldProps) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [fileName, setFileName] = useState<string>("");
+
+  const handleFile = (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const file = files[0];
+    const limit = maxSizeMb * 1024 * 1024;
+    if (file.size > limit) {
+      setError(`Arquivo maior que ${maxSizeMb}MB`);
+      return;
+    }
+    setError(null);
+    setFileName(file.name);
+    onFileSelected(file);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Input
+          ref={inputRef}
+          type="file"
+          accept=".csv, application/vnd.ms-excel, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+          onChange={(event) => handleFile(event.target.files)}
+          className="max-w-xs"
+        />
+        <Button type="button" variant="secondary" onClick={() => inputRef.current?.click()}>
+          Selecionar arquivo
+        </Button>
+      </div>
+      {fileName && <p className="text-sm text-muted-foreground">Selecionado: {fileName}</p>}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+      <p className="text-xs text-muted-foreground">Limite: até {maxSizeMb}MB</p>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/Label.tsx
+++ b/apps/web/src/components/ui/Label.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+import { cn } from "~/components/ui/utils";
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label ref={ref} className={cn("text-sm font-medium", className)} {...props} />
+  ),
+);
+Label.displayName = "Label";

--- a/apps/web/src/components/ui/Progress.tsx
+++ b/apps/web/src/components/ui/Progress.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "~/components/ui/utils";
+
+interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
+  value?: number;
+}
+
+export const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(({ className, value = 0, ...props }, ref) => {
+  const clamped = Math.min(100, Math.max(0, value));
+  return (
+    <div ref={ref} className={cn("h-3 w-full overflow-hidden rounded-full bg-muted", className)} {...props}>
+      <div
+        className="h-full bg-primary transition-all"
+        style={{ width: `${clamped}%` }}
+        aria-valuenow={clamped}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        role="progressbar"
+      />
+    </div>
+  );
+});
+Progress.displayName = "Progress";

--- a/apps/web/src/components/ui/utils.ts
+++ b/apps/web/src/components/ui/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(" ");
+}

--- a/supabase/migrations/20251125090000_student_import_wizard.sql
+++ b/supabase/migrations/20251125090000_student_import_wizard.sql
@@ -1,0 +1,255 @@
+-- Student import wizard support
+
+-- Ensure required extension for text normalization
+CREATE EXTENSION IF NOT EXISTS unaccent;
+
+-- Support tables for imports
+CREATE TABLE IF NOT EXISTS public.import_migrations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL,
+  created_by uuid,
+  file_name text,
+  file_hash text,
+  storage_path text,
+  status text NOT NULL DEFAULT 'uploaded',
+  total_rows integer DEFAULT 0,
+  imported_rows integer DEFAULT 0,
+  error_rows integer DEFAULT 0,
+  processed_at timestamptz,
+  created_at timestamptz DEFAULT now(),
+  CONSTRAINT import_migrations_escola_fk FOREIGN KEY (escola_id) REFERENCES public.escolas(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS public.import_errors (
+  id bigserial PRIMARY KEY,
+  import_id uuid NOT NULL REFERENCES public.import_migrations(id) ON DELETE CASCADE,
+  row_number integer,
+  column_name text,
+  message text NOT NULL,
+  raw_value text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.staging_alunos (
+  id bigserial PRIMARY KEY,
+  import_id uuid NOT NULL REFERENCES public.import_migrations(id) ON DELETE CASCADE,
+  escola_id uuid NOT NULL,
+  profile_id uuid,
+  nome text,
+  data_nascimento date,
+  telefone text,
+  bi text,
+  email text,
+  raw_data jsonb,
+  created_at timestamptz DEFAULT now()
+);
+
+-- Column tracking on alunos
+ALTER TABLE public.alunos
+  ADD COLUMN IF NOT EXISTS import_id uuid;
+
+ALTER TABLE public.alunos
+  ADD COLUMN IF NOT EXISTS telefone text;
+
+-- Required indexes
+CREATE UNIQUE INDEX IF NOT EXISTS alunos_bi_key ON public.alunos(bi_numero);
+CREATE INDEX IF NOT EXISTS alunos_tel_idx ON public.alunos(telefone);
+CREATE INDEX IF NOT EXISTS alunos_nome_data_idx ON public.alunos(nome, data_nascimento);
+
+CREATE INDEX IF NOT EXISTS staging_alunos_import_id_idx ON public.staging_alunos(import_id);
+CREATE INDEX IF NOT EXISTS import_errors_import_id_idx ON public.import_errors(import_id);
+
+-- Normalization helpers
+CREATE OR REPLACE FUNCTION public.normalize_text(input_text text)
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  cleaned text;
+BEGIN
+  IF input_text IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  cleaned := lower(unaccent(input_text));
+  cleaned := regexp_replace(cleaned, '\\s+', ' ', 'g');
+  cleaned := trim(cleaned);
+  IF cleaned = '' THEN
+    RETURN NULL;
+  END IF;
+  RETURN cleaned;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.normalize_date(input_text text)
+RETURNS date
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  candidate date;
+  formats text[] := ARRAY['YYYY-MM-DD', 'DD/MM/YYYY', 'DD-MM-YYYY', 'MM/DD/YYYY', 'YYYY/MM/DD'];
+  fmt text;
+BEGIN
+  IF input_text IS NULL OR trim(input_text) = '' THEN
+    RETURN NULL;
+  END IF;
+
+  FOR fmt IN SELECT unnest(formats) LOOP
+    BEGIN
+      candidate := to_date(input_text, fmt);
+      EXIT WHEN candidate IS NOT NULL;
+    EXCEPTION
+      WHEN others THEN
+        candidate := NULL;
+    END;
+  END LOOP;
+
+  RETURN candidate;
+END;
+$$;
+
+-- RPC to import alunos from staging
+CREATE OR REPLACE FUNCTION public.importar_alunos(p_import_id uuid, p_escola_id uuid)
+RETURNS TABLE(imported integer, skipped integer, errors integer)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_imported integer := 0;
+  v_skipped integer := 0;
+  v_errors integer := 0;
+BEGIN
+  -- Basic guard: ensure migration exists
+  PERFORM 1 FROM public.import_migrations m WHERE m.id = p_import_id AND m.escola_id = p_escola_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Import % for escola % not found', p_import_id, p_escola_id;
+  END IF;
+
+  -- Clean previous errors for re-runs
+  DELETE FROM public.import_errors e WHERE e.import_id = p_import_id;
+
+  -- Iterate through staging rows
+  FOR v_record IN SELECT * FROM public.staging_alunos WHERE import_id = p_import_id LOOP
+    IF v_record.profile_id IS NULL THEN
+      v_errors := v_errors + 1;
+      INSERT INTO public.import_errors(import_id, row_number, column_name, message, raw_value)
+      VALUES (p_import_id, v_record.id::integer, 'profile_id', 'Profile obrigatório para importar aluno', NULL);
+      CONTINUE;
+    END IF;
+
+    BEGIN
+      INSERT INTO public.alunos (
+        id,
+        escola_id,
+        profile_id,
+        data_nascimento,
+        nome,
+        bi_numero,
+        email,
+        telefone,
+        import_id
+      )
+      VALUES (
+        gen_random_uuid(),
+        p_escola_id,
+        v_record.profile_id,
+        v_record.data_nascimento,
+        v_record.nome,
+        v_record.bi,
+        v_record.email,
+        v_record.telefone,
+        p_import_id
+      )
+      ON CONFLICT (profile_id, escola_id) DO UPDATE SET
+        nome = EXCLUDED.nome,
+        data_nascimento = EXCLUDED.data_nascimento,
+        bi_numero = COALESCE(EXCLUDED.bi_numero, public.alunos.bi_numero),
+        email = COALESCE(EXCLUDED.email, public.alunos.email),
+        telefone = COALESCE(EXCLUDED.telefone, public.alunos.telefone),
+        import_id = EXCLUDED.import_id;
+      v_imported := v_imported + 1;
+    EXCEPTION
+      WHEN others THEN
+        v_errors := v_errors + 1;
+        INSERT INTO public.import_errors(import_id, row_number, column_name, message, raw_value)
+        VALUES (p_import_id, v_record.id::integer, 'alunos', SQLERRM, row_to_json(v_record)::text);
+    END;
+  END LOOP;
+
+  v_skipped := (SELECT COUNT(*) FROM public.staging_alunos WHERE import_id = p_import_id) - v_imported - v_errors;
+
+  UPDATE public.import_migrations
+  SET status = 'imported',
+      processed_at = now(),
+      imported_rows = v_imported,
+      error_rows = v_errors
+  WHERE id = p_import_id;
+
+  RETURN QUERY SELECT v_imported, v_skipped, v_errors;
+END;
+$$;
+
+-- RLS policies
+ALTER TABLE public.import_migrations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.import_errors ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.staging_alunos ENABLE ROW LEVEL SECURITY;
+
+-- Service role full access
+DROP POLICY IF EXISTS import_migrations_service_full ON public.import_migrations;
+CREATE POLICY import_migrations_service_full ON public.import_migrations
+FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS import_errors_service_full ON public.import_errors;
+CREATE POLICY import_errors_service_full ON public.import_errors
+FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS staging_alunos_service_full ON public.staging_alunos;
+CREATE POLICY staging_alunos_service_full ON public.staging_alunos
+FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Tenant-aware read for staff/admin
+DROP POLICY IF EXISTS import_migrations_staff_read ON public.import_migrations;
+CREATE POLICY import_migrations_staff_read ON public.import_migrations
+FOR SELECT TO authenticated USING (public.is_staff_escola(escola_id));
+
+DROP POLICY IF EXISTS import_errors_staff_read ON public.import_errors;
+CREATE POLICY import_errors_staff_read ON public.import_errors
+FOR SELECT TO authenticated USING (
+  EXISTS (
+    SELECT 1 FROM public.import_migrations m
+    WHERE m.id = import_errors.import_id
+      AND public.is_staff_escola(m.escola_id)
+  )
+);
+
+DROP POLICY IF EXISTS staging_alunos_staff_read ON public.staging_alunos;
+CREATE POLICY staging_alunos_staff_read ON public.staging_alunos
+FOR SELECT TO authenticated USING (public.is_staff_escola(escola_id));
+
+-- Staff/admin write for their tenant
+DROP POLICY IF EXISTS import_migrations_staff_write ON public.import_migrations;
+CREATE POLICY import_migrations_staff_write ON public.import_migrations
+FOR INSERT TO authenticated WITH CHECK (public.is_staff_escola(escola_id));
+
+DROP POLICY IF EXISTS import_errors_staff_write ON public.import_errors;
+CREATE POLICY import_errors_staff_write ON public.import_errors
+FOR INSERT TO authenticated WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.import_migrations m
+    WHERE m.id = import_errors.import_id
+      AND public.is_staff_escola(m.escola_id)
+  )
+);
+
+DROP POLICY IF EXISTS staging_alunos_staff_write ON public.staging_alunos;
+CREATE POLICY staging_alunos_staff_write ON public.staging_alunos
+FOR INSERT TO authenticated WITH CHECK (public.is_staff_escola(escola_id));
+
+-- Allow updates of status by staff/admin
+DROP POLICY IF EXISTS import_migrations_staff_update ON public.import_migrations;
+CREATE POLICY import_migrations_staff_update ON public.import_migrations
+FOR UPDATE TO authenticated USING (public.is_staff_escola(escola_id)) WITH CHECK (public.is_staff_escola(escola_id));
+
+-- Service role passthrough on alunos for imports
+DROP POLICY IF EXISTS alunos_service_import ON public.alunos;
+CREATE POLICY alunos_service_import ON public.alunos
+FOR ALL TO service_role USING (true) WITH CHECK (true);

--- a/types/migracao.ts
+++ b/types/migracao.ts
@@ -1,0 +1,38 @@
+export type ImportStatus = "uploaded" | "validando" | "validado" | "imported" | "failed";
+
+export interface AlunoCSV {
+  nome?: string;
+  data_nascimento?: string;
+  telefone?: string;
+  bi?: string;
+  email?: string;
+  profile_id?: string;
+  [key: string]: string | undefined;
+}
+
+export interface AlunoStagingRecord {
+  import_id: string;
+  escola_id: string;
+  profile_id?: string;
+  nome?: string;
+  data_nascimento?: string;
+  telefone?: string;
+  bi?: string;
+  email?: string;
+  raw_data?: Record<string, unknown>;
+}
+
+export interface ErroImportacao {
+  row_number?: number;
+  column_name?: string;
+  message: string;
+  raw_value?: string;
+}
+
+export interface ImportResult {
+  imported: number;
+  skipped: number;
+  errors: number;
+}
+
+export type MappedColumns = Record<string, string>;


### PR DESCRIPTION
## Summary
- add Supabase migration to support aluno import staging, errors, RPC, and RLS for service role
- create API endpoints and helpers for upload, validation, and import flows
- scaffold migration wizard pages, UI components, and shared types for aluno imports

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243846f8d88326a0d9c0369bd13ea4)