### PR TITLE
Connect migration wizard to real import context

### DIFF
--- a/apps/web/src/app/api/migracao/[importId]/erros/route.ts
+++ b/apps/web/src/app/api/migracao/[importId]/erros/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+import { createRouteClient } from "@/lib/supabase/route-client";
+
+export async function GET(_req: Request, { params }: { params: { importId: string } }) {
+  const supabase = await createRouteClient();
+
+  const { data, error } = await supabase
+    .from("import_errors")
+    .select("row_number, column_name, message, raw_value")
+    .eq("import_id", params.importId)
+    .order("row_number", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ errors: data ?? [] });
+}

--- a/apps/web/src/app/api/migracao/alunos/validar/route.ts
+++ b/apps/web/src/app/api/migracao/alunos/validar/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: Request) {
 
   await supabase
     .from("import_migrations")
-    .update({ status: "validado", total_rows: staged.length })
+    .update({ status: "validado", total_rows: staged.length, column_map: columnMap })
     .eq("id", importId);
 
   return NextResponse.json({ preview: summarizePreview(staged), total: staged.length });

--- a/apps/web/src/app/api/migracao/historico/route.ts
+++ b/apps/web/src/app/api/migracao/historico/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+import { createRouteClient } from "@/lib/supabase/route-client";
+
+export async function GET() {
+  const supabase = await createRouteClient();
+
+  const { data, error } = await supabase
+    .from("import_migrations")
+    .select(
+      `
+        id,
+        escola_id,
+        file_name,
+        status,
+        total_rows,
+        imported_rows,
+        error_rows,
+        processed_at,
+        created_at
+      `,
+    )
+    .order("created_at", { ascending: false })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ items: data ?? [] });
+}

--- a/apps/web/src/app/migracao/historico/page.tsx
+++ b/apps/web/src/app/migracao/historico/page.tsx
@@ -1,10 +1,38 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/Card";
 
+interface HistoricoItem {
+  id: string;
+  file_name: string | null;
+  status: string | null;
+  total_rows: number | null;
+  imported_rows: number | null;
+  error_rows: number | null;
+  created_at: string;
+  processed_at: string | null;
+}
+
 export default function HistoricoImportacao() {
-  const placeholders = [
-    { importId: "demo-1", status: "uploaded", total: 120 },
-    { importId: "demo-2", status: "imported", total: 87 },
-  ];
+  const [items, setItems] = useState<HistoricoItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function carregar() {
+      setLoading(true);
+      const res = await fetch("/api/migracao/historico");
+      const payload = await res.json();
+      if (res.ok) setItems(payload.items || []);
+      setLoading(false);
+    }
+    carregar();
+  }, []);
+
+  if (loading) {
+    return <main className="p-6">Carregando histórico…</main>;
+  }
 
   return (
     <main className="p-6 space-y-4">
@@ -14,14 +42,18 @@ export default function HistoricoImportacao() {
       </div>
 
       <div className="grid gap-3 md:grid-cols-2">
-        {placeholders.map((item) => (
-          <Card key={item.importId}>
+        {items.map((item) => (
+          <Card key={item.id}>
             <CardHeader>
-              <CardTitle>Importação {item.importId}</CardTitle>
+              <CardTitle>{item.file_name || "Importação"}</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-2">
-              <p className="text-sm">Status: {item.status}</p>
-              <p className="text-sm">Registros: {item.total}</p>
+            <CardContent className="space-y-2 text-sm">
+              <p>Status: {item.status}</p>
+              <p>Registros: {item.total_rows}</p>
+              <p>Importados: {item.imported_rows ?? "-"}</p>
+              <p>Com erro: {item.error_rows ?? "-"}</p>
+              <p>Criado: {new Date(item.created_at).toLocaleString()}</p>
+              {item.processed_at && <p>Processado: {new Date(item.processed_at).toLocaleString()}</p>}
             </CardContent>
           </Card>
         ))}

--- a/docs/importacao-matriculas.md
+++ b/docs/importacao-matriculas.md
@@ -1,0 +1,51 @@
+# Fluxo de importação de alunos e matrícula em massa
+
+Este guia descreve o fluxo ponta a ponta de importação de alunos via wizard, validação em staging, disparo da função de importação e acompanhamento de histórico/erros. Também resume como matricular os alunos importados (ou existentes) pela API/UX atual.
+
+## Visão geral
+1. **Upload autenticado**: o wizard obtém `escolaId` e `userId` da sessão Supabase e envia o CSV para `/api/migracao/upload`, que salva no bucket `migracoes` e cria um registro em `import_migrations` com `importId` real.
+2. **Mapeamento + validação**: o usuário mapeia colunas no passo 2; `/api/migracao/alunos/validar` lê o arquivo, converte linhas para `staging_alunos`, limpa erros anteriores e salva `column_map`/`total_rows` na mesma `import_migrations`.
+3. **Importação**: `/api/migracao/alunos/importar` chama a RPC `importar_alunos` usando `importId/escolaId`, marca a importação como `imported` e retorna um resumo (`imported`, `skipped`, `errors`).
+4. **Acompanhamento**: a tela de finalização busca `/api/migracao/[importId]/erros` para listar erros linha a linha e a página de histórico consome `/api/migracao/historico` para exibir as últimas 50 importações.
+
+## Wizard de migração (frontend)
+- **Contexto autenticado**: o wizard carrega `userId` e `escolaId` da sessão Supabase no `useEffect` e impede upload sem escola válida.【F:apps/web/src/app/migracao/alunos/page.tsx†L22-L147】
+- **Upload (passo 1)**: envia `file`, `escolaId` e opcionalmente `userId` para `/api/migracao/upload`; guarda `importId` retornado, limpa erros anteriores e extrai cabeçalhos do CSV para mapeamento.【F:apps/web/src/app/migracao/alunos/page.tsx†L89-L118】
+- **Mapeamento + validação (passo 2)**: envia `importId`, `escolaId` e `columnMap` para `/api/migracao/alunos/validar`; na resposta, popula a pré-visualização das primeiras linhas e avança ao passo 3.【F:apps/web/src/app/migracao/alunos/page.tsx†L62-L87】
+- **Importação (passo 3)**: dispara `/api/migracao/alunos/importar` com os IDs reais; após sucesso, carrega erros detalhados via `/api/migracao/[importId]/erros` e mostra o resumo retornado pela API.【F:apps/web/src/app/migracao/alunos/page.tsx†L120-L215】
+
+## APIs do fluxo de importação
+- **Upload** (`POST /api/migracao/upload`)
+  - Campos obrigatórios: `file` (CSV), `escolaId`; opcional `userId` para `created_by`.
+  - Valida tamanho máximo, calcula hash, garante bucket `migracoes`, salva o arquivo e insere em `import_migrations` com status `uploaded`; devolve `importId` para o frontend.【F:apps/web/src/app/api/migracao/upload/route.ts†L11-L79】
+
+- **Validação** (`POST /api/migracao/alunos/validar`)
+  - Corpo: `{ importId, escolaId, columnMap }`.
+  - Baixa o CSV salvo, converte para staging com `mapAlunoFromCsv`, limpa `staging_alunos` e `import_errors` do `importId`, faz `upsert` do staging, atualiza `import_migrations` com `status: "validado"`, `total_rows` e `column_map`, e retorna `preview` + total de linhas.【F:apps/web/src/app/api/migracao/alunos/validar/route.ts†L10-L74】
+
+- **Importação** (`POST /api/migracao/alunos/importar`)
+  - Corpo: `{ importId, escolaId }`.
+  - Executa a função `importar_alunos` passando o `importId` validado e atualiza `import_migrations` para `imported` com `processed_at`; responde com o resumo de importação para o wizard.【F:apps/web/src/app/api/migracao/alunos/importar/route.ts†L9-L52】
+
+- **Erros de importação** (`GET /api/migracao/[importId]/erros`)
+  - Retorna `row_number`, `column_name`, `message` e `raw_value` de `import_errors` ordenados por linha, usados no passo 4 para exibição detalhada.【F:apps/web/src/app/api/migracao/[importId]/erros/route.ts†L5-L19】
+
+- **Histórico** (`GET /api/migracao/historico`)
+  - Lista até 50 registros de `import_migrations` (arquivo, status, contagens, timestamps) para a página de histórico da UI.【F:apps/web/src/app/api/migracao/historico/route.ts†L5-L30】
+
+## Persistência do mapeamento de colunas
+Há uma migração que adiciona o campo `column_map` em `import_migrations`, permitindo auditar ou reutilizar o mapeamento usado em cada importação.【F:supabase/migrations/20251125120000_import_migrations_add_column_map.sql†L1-L2】
+
+## Histórico e erros na UI
+A página `/migracao/historico` consome a rota de histórico e renderiza cards com status, contagens e timestamps das importações recentes, substituindo os placeholders anteriores.【F:apps/web/src/app/migracao/historico/page.tsx†L1-L49】 Use essa tela para acompanhar progresso e verificar rapidamente quantos registros foram importados ou falharam.
+
+## Matrícula de alunos (criação e atualização)
+- **Listagem e filtros**: `GET /api/secretaria/matriculas` aplica escopo da escola do usuário (profiles/escola_usuarios), suporta filtros por texto, turma, status ou múltiplos status e paginação; retorna `items` e `total` para a página `/secretaria/matriculas`.【F:apps/web/src/app/api/secretaria/matriculas/route.ts†L8-L150】
+- **Criação de matrícula**: `POST /api/secretaria/matriculas` resolve a escola via aluno ou perfil, valida campos obrigatórios, garante/gera `numero_login` do aluno quando necessário, cria a matrícula com status `ativo` e, se parâmetros de preço/dia não forem fornecidos, resolve mensalidade via `resolveMensalidade` antes de gerar os lançamentos financeiros.【F:apps/web/src/app/api/secretaria/matriculas/route.ts†L152-L400】
+- **Atualização de status**: use `PUT /api/secretaria/matriculas/[id]/status` (não mostrado aqui) para alterar status com escopo de escola; combine com confirmações na UI para operações sensíveis.
+
+## Boas práticas ao operar o fluxo
+- Sempre iniciar o wizard autenticado para garantir `escolaId` válido.
+- Não pular a etapa de validação: ela popula `staging_alunos`, limpa tentativas anteriores e salva o mapeamento.
+- Após importar, consulte erros detalhados para corrigir linhas com problemas e reprocessar se necessário (o fluxo é idempotente por `importId`).
+- Ao matricular, reusar `numero_matricula` sugerido ou já presente do aluno evita duplicidade e mantém o login alinhado ao cadastro.

--- a/supabase/migrations/20251125120000_import_migrations_add_column_map.sql
+++ b/supabase/migrations/20251125120000_import_migrations_add_column_map.sql
@@ -1,0 +1,2 @@
+alter table public.import_migrations
+  add column if not exists column_map jsonb;


### PR DESCRIPTION
## Summary
- retrieve logged-in session to access real user and school identifiers
- capture the backend importId on upload and reuse it across validation and import steps
- validate/import using real identifiers with clearer error handling for missing context

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692489348728832683f1de2ccdd83593)