### PR TITLE
Add finance item catalog and sale workflow

### DIFF
--- a/apps/web/src/app/api/financeiro/itens/route.ts
+++ b/apps/web/src/app/api/financeiro/itens/route.ts
@@ -1,0 +1,167 @@
+import { NextResponse } from 'next/server'
+import { supabaseServer } from '@/lib/supabaseServer'
+
+async function resolveEscolaId(
+  s: Awaited<ReturnType<typeof supabaseServer>>,
+  userId: string
+) {
+  const { data: prof } = await s
+    .from('profiles' as any)
+    .select('current_escola_id, escola_id')
+    .eq('user_id', userId)
+    .limit(1)
+  let escolaId = ((prof?.[0] as any)?.current_escola_id || (prof?.[0] as any)?.escola_id) as
+    | string
+    | undefined
+  if (!escolaId) {
+    const { data: vinc } = await s.from('escola_usuarios').select('escola_id').eq('user_id', userId).limit(1)
+    escolaId = (vinc?.[0] as any)?.escola_id as string | undefined
+  }
+  return escolaId
+}
+
+export async function GET(req: Request) {
+  try {
+    const s = await supabaseServer()
+    const { data: userRes } = await s.auth.getUser()
+    const user = userRes?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+    const escolaId = await resolveEscolaId(s, user.id)
+    if (!escolaId) return NextResponse.json({ ok: true, items: [] })
+
+    const url = new URL(req.url)
+    const onlyActive = url.searchParams.get('ativos') === 'true'
+
+    let query = s
+      .from('financeiro_itens')
+      .select('id, nome, categoria, preco, controla_estoque, estoque_atual, ativo, created_at, updated_at')
+      .eq('escola_id', escolaId)
+      .order('created_at', { ascending: false })
+
+    if (onlyActive) query = query.eq('ativo', true)
+
+    const { data, error } = await query
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    return NextResponse.json({ ok: true, items: data || [] })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const s = await supabaseServer()
+    const { data: userRes } = await s.auth.getUser()
+    const user = userRes?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+    const escolaId = await resolveEscolaId(s, user.id)
+    if (!escolaId) return NextResponse.json({ ok: false, error: 'Escola não encontrada' }, { status: 400 })
+
+    const body = await req.json().catch(() => ({}))
+    const { nome, categoria = 'outros', preco, controla_estoque = false, estoque_atual = 0, ativo = true } = body || {}
+
+    if (!nome || !preco) return NextResponse.json({ ok: false, error: 'Nome e preço são obrigatórios' }, { status: 400 })
+
+    const payload = {
+      escola_id: escolaId,
+      nome: String(nome).trim(),
+      categoria,
+      preco: Number(Number(preco).toFixed(2)),
+      controla_estoque: Boolean(controla_estoque),
+      estoque_atual: Math.max(0, Number(estoque_atual) || 0),
+      ativo: Boolean(ativo),
+    }
+
+    const { data, error } = await s.from('financeiro_itens').insert(payload as any).select().single()
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    return NextResponse.json({ ok: true, item: data })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export async function PUT(req: Request) {
+  try {
+    const s = await supabaseServer()
+    const { data: userRes } = await s.auth.getUser()
+    const user = userRes?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+    const escolaId = await resolveEscolaId(s, user.id)
+    if (!escolaId) return NextResponse.json({ ok: false, error: 'Escola não encontrada' }, { status: 400 })
+
+    const body = await req.json().catch(() => ({}))
+    const { id, nome, categoria, preco, controla_estoque, estoque_atual, ativo } = body || {}
+    if (!id) return NextResponse.json({ ok: false, error: 'ID é obrigatório' }, { status: 400 })
+
+    const { data: registro } = await s
+      .from('financeiro_itens')
+      .select('id, escola_id')
+      .eq('id', id)
+      .maybeSingle()
+    if (!registro || (registro as any).escola_id !== escolaId)
+      return NextResponse.json({ ok: false, error: 'Registro não encontrado' }, { status: 404 })
+
+    const updatePayload: Record<string, any> = { updated_at: new Date().toISOString() }
+    if (nome !== undefined) updatePayload.nome = String(nome).trim()
+    if (categoria !== undefined) updatePayload.categoria = categoria
+    if (preco !== undefined) updatePayload.preco = Number(Number(preco).toFixed(2))
+    if (controla_estoque !== undefined) updatePayload.controla_estoque = Boolean(controla_estoque)
+    if (estoque_atual !== undefined) updatePayload.estoque_atual = Math.max(0, Number(estoque_atual) || 0)
+    if (ativo !== undefined) updatePayload.ativo = Boolean(ativo)
+
+    const { data, error } = await s
+      .from('financeiro_itens')
+      .update(updatePayload)
+      .eq('id', id)
+      .select()
+      .single()
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    return NextResponse.json({ ok: true, item: data })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}
+
+export async function DELETE(req: Request) {
+  try {
+    const s = await supabaseServer()
+    const { data: userRes } = await s.auth.getUser()
+    const user = userRes?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+    const escolaId = await resolveEscolaId(s, user.id)
+    if (!escolaId) return NextResponse.json({ ok: false, error: 'Escola não encontrada' }, { status: 400 })
+
+    const url = new URL(req.url)
+    const id = url.searchParams.get('id')
+    if (!id) return NextResponse.json({ ok: false, error: 'ID é obrigatório' }, { status: 400 })
+
+    const { data: registro } = await s
+      .from('financeiro_itens')
+      .select('id, escola_id')
+      .eq('id', id)
+      .maybeSingle()
+    if (!registro || (registro as any).escola_id !== escolaId)
+      return NextResponse.json({ ok: false, error: 'Registro não encontrado' }, { status: 404 })
+
+    const { error } = await s
+      .from('financeiro_itens')
+      .update({ ativo: false, updated_at: new Date().toISOString() })
+      .eq('id', id)
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    return NextResponse.json({ ok: true })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/api/financeiro/itens/venda/route.ts
+++ b/apps/web/src/app/api/financeiro/itens/venda/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from 'next/server'
+import { supabaseServer } from '@/lib/supabaseServer'
+
+async function resolveEscolaId(
+  s: Awaited<ReturnType<typeof supabaseServer>>,
+  userId: string
+) {
+  const { data: prof } = await s
+    .from('profiles' as any)
+    .select('current_escola_id, escola_id')
+    .eq('user_id', userId)
+    .limit(1)
+  let escolaId = ((prof?.[0] as any)?.current_escola_id || (prof?.[0] as any)?.escola_id) as
+    | string
+    | undefined
+  if (!escolaId) {
+    const { data: vinc } = await s.from('escola_usuarios').select('escola_id').eq('user_id', userId).limit(1)
+    escolaId = (vinc?.[0] as any)?.escola_id as string | undefined
+  }
+  return escolaId
+}
+
+export async function POST(req: Request) {
+  try {
+    const s = await supabaseServer()
+    const { data: userRes } = await s.auth.getUser()
+    const user = userRes?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+    const escolaId = await resolveEscolaId(s, user.id)
+    if (!escolaId) return NextResponse.json({ ok: false, error: 'Escola não encontrada' }, { status: 400 })
+
+    const body = await req.json().catch(() => ({}))
+    const {
+      aluno_id,
+      item_id,
+      quantidade,
+      valor_unitario,
+      desconto = 0,
+      metodo_pagamento = 'numerario',
+      descricao,
+      status = 'pago',
+    } = body || {}
+
+    if (!aluno_id || !item_id) return NextResponse.json({ ok: false, error: 'Aluno e item são obrigatórios' }, { status: 400 })
+    const qty = Number(quantidade)
+    if (!qty || qty <= 0) return NextResponse.json({ ok: false, error: 'Quantidade inválida' }, { status: 400 })
+
+    const { data, error } = await s.rpc('registrar_venda_avulsa', {
+      p_escola_id: escolaId,
+      p_aluno_id: aluno_id,
+      p_item_id: item_id,
+      p_quantidade: qty,
+      p_valor_unit: valor_unitario !== undefined ? Number(Number(valor_unitario).toFixed(2)) : null,
+      p_desconto: Number(Number(desconto || 0).toFixed(2)),
+      p_metodo_pagamento: metodo_pagamento,
+      p_status: status,
+      p_descricao: descricao,
+      p_created_by: user.id,
+    })
+
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    return NextResponse.json({ ok: true, result: data?.[0] })
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/apps/web/src/app/escola/[id]/financeiro/vendas/VendaCaixaClient.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/vendas/VendaCaixaClient.tsx
@@ -1,0 +1,412 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import type React from "react"
+
+type VendaProps = { escolaId: string }
+
+type Item = {
+  id: string
+  nome: string
+  categoria: string
+  preco: number
+  controla_estoque: boolean
+  estoque_atual: number
+  ativo: boolean
+}
+
+export default function VendaCaixaClient({ escolaId }: VendaProps) {
+  const [items, setItems] = useState<Item[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState({
+    nome: "",
+    categoria: "outros",
+    preco: "0",
+    controla_estoque: false,
+    estoque_atual: "0",
+    ativo: true,
+  })
+
+  const [sale, setSale] = useState({
+    aluno_id: "",
+    item_id: "",
+    quantidade: "1",
+    valor_unitario: "",
+    desconto: "0",
+    metodo_pagamento: "numerario",
+    descricao: "",
+    status: "pago",
+  })
+
+  useEffect(() => {
+    fetchItems()
+  }, [])
+
+  useEffect(() => {
+    const selected = items.find((i) => i.id === sale.item_id)
+    if (selected && !sale.valor_unitario) {
+      setSale((prev) => ({ ...prev, valor_unitario: String(selected.preco) }))
+    }
+  }, [sale.item_id, sale.valor_unitario, items])
+
+  async function fetchItems() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch("/api/financeiro/itens?ativos=false", { cache: "no-store" })
+      const json = await res.json()
+      if (!json.ok) throw new Error(json.error || "Erro ao carregar itens")
+      setItems(json.items || [])
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  function resetForm() {
+    setEditingId(null)
+    setForm({ nome: "", categoria: "outros", preco: "0", controla_estoque: false, estoque_atual: "0", ativo: true })
+  }
+
+  async function handleItemSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+
+    const payload = {
+      ...form,
+      preco: Number(form.preco),
+      estoque_atual: Number(form.estoque_atual),
+      controla_estoque: Boolean(form.controla_estoque),
+    }
+
+    const method = editingId ? "PUT" : "POST"
+    const res = await fetch("/api/financeiro/itens", {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(editingId ? { ...payload, id: editingId } : payload),
+    })
+    const json = await res.json()
+    if (!json.ok) {
+      setError(json.error || "Erro ao salvar item")
+    } else {
+      setMessage(editingId ? "Item atualizado" : "Item criado")
+      resetForm()
+      fetchItems()
+    }
+  }
+
+  async function handleDelete(id: string) {
+    if (!window.confirm("Desativar este item?")) return
+    const res = await fetch(`/api/financeiro/itens?id=${encodeURIComponent(id)}`, { method: "DELETE" })
+    const json = await res.json()
+    if (!json.ok) setError(json.error || "Erro ao desativar")
+    else {
+      setMessage("Item desativado")
+      fetchItems()
+    }
+  }
+
+  async function handleVenda(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setMessage(null)
+
+    const res = await fetch("/api/financeiro/itens/venda", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ...sale,
+        quantidade: Number(sale.quantidade),
+        valor_unitario: sale.valor_unitario ? Number(sale.valor_unitario) : undefined,
+        desconto: Number(sale.desconto || 0),
+      }),
+    })
+    const json = await res.json()
+    if (!json.ok) {
+      setError(json.error || "Erro ao registrar venda")
+    } else {
+      const novoEstoque = json?.result?.estoque_atual
+      setMessage(
+        `Venda registada. Lançamento ${json?.result?.lancamento_id || ""}${
+          novoEstoque !== undefined ? ` | Estoque atual: ${novoEstoque}` : ""
+        }`
+      )
+      setSale({
+        aluno_id: "",
+        item_id: "",
+        quantidade: "1",
+        valor_unitario: "",
+        desconto: "0",
+        metodo_pagamento: "numerario",
+        descricao: "",
+        status: "pago",
+      })
+      fetchItems()
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold">Vendas e Caixa</h1>
+          <p className="text-sm text-gray-500">Registre itens avulsos, controle estoque e lançamentos.</p>
+        </div>
+        <div className="text-xs text-gray-500">Escola: {escolaId}</div>
+      </div>
+
+      {(error || message) && (
+        <div
+          className={`p-3 rounded border text-sm ${
+            error ? "bg-red-50 border-red-200 text-red-700" : "bg-green-50 border-green-200 text-green-700"
+          }`}
+        >
+          {error || message}
+        </div>
+      )}
+
+      <div className="grid lg:grid-cols-2 gap-6">
+        <div className="bg-white border rounded-xl shadow-sm p-4">
+          <h2 className="font-semibold mb-2">Itens do catálogo</h2>
+          <p className="text-xs text-gray-500 mb-4">Gerencie preços e estoque dos produtos vendidos avulsamente.</p>
+
+          <form onSubmit={handleItemSubmit} className="space-y-3">
+            <div className="grid grid-cols-2 gap-3">
+              <label className="text-sm">
+                Nome
+                <input
+                  required
+                  value={form.nome}
+                  onChange={(e) => setForm({ ...form, nome: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                />
+              </label>
+              <label className="text-sm">
+                Categoria
+                <select
+                  value={form.categoria}
+                  onChange={(e) => setForm({ ...form, categoria: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                >
+                  <option value="uniforme">Uniforme</option>
+                  <option value="documento">Documento</option>
+                  <option value="material">Material</option>
+                  <option value="transporte">Transporte</option>
+                  <option value="servico">Serviço</option>
+                  <option value="outros">Outros</option>
+                </select>
+              </label>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="text-sm">
+                Preço (AOA)
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  required
+                  value={form.preco}
+                  onChange={(e) => setForm({ ...form, preco: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                />
+              </label>
+              <label className="text-sm flex items-center gap-2 mt-6">
+                <input
+                  type="checkbox"
+                  checked={form.controla_estoque}
+                  onChange={(e) => setForm({ ...form, controla_estoque: e.target.checked })}
+                />
+                Controla estoque
+              </label>
+            </div>
+            {form.controla_estoque && (
+              <label className="text-sm block">
+                Estoque atual
+                <input
+                  type="number"
+                  min="0"
+                  value={form.estoque_atual}
+                  onChange={(e) => setForm({ ...form, estoque_atual: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                />
+              </label>
+            )}
+            <div className="flex items-center gap-3">
+              <button type="submit" className="bg-moxinexa-teal text-white px-4 py-2 rounded">
+                {editingId ? "Atualizar" : "Adicionar"}
+              </button>
+              {editingId && (
+                <button type="button" onClick={resetForm} className="text-sm text-gray-600">
+                  Cancelar edição
+                </button>
+              )}
+            </div>
+          </form>
+
+          <div className="mt-6">
+            <h3 className="font-medium text-sm mb-2">Itens cadastrados</h3>
+            {loading ? (
+              <div className="text-sm text-gray-500">Carregando itens...</div>
+            ) : items.length === 0 ? (
+              <div className="text-sm text-gray-500">Nenhum item cadastrado ainda.</div>
+            ) : (
+              <div className="space-y-2 max-h-80 overflow-auto pr-1">
+                {items.map((item) => (
+                  <div key={item.id} className="border rounded-lg px-3 py-2 flex justify-between items-center">
+                    <div>
+                      <div className="font-medium">{item.nome}</div>
+                      <div className="text-xs text-gray-500">
+                        {item.categoria} · Preço: AOA {Number(item.preco).toFixed(2)} · Estoque:{" "}
+                        {item.controla_estoque ? item.estoque_atual : "N/A"}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-3 text-sm">
+                      <button
+                        onClick={() => {
+                          setEditingId(item.id)
+                          setForm({
+                            nome: item.nome,
+                            categoria: item.categoria,
+                            preco: String(item.preco),
+                            controla_estoque: item.controla_estoque,
+                            estoque_atual: String(item.estoque_atual ?? 0),
+                            ativo: item.ativo,
+                          })
+                        }}
+                        className="text-blue-600"
+                      >
+                        Editar
+                      </button>
+                      <button onClick={() => handleDelete(item.id)} className="text-red-600">
+                        Desativar
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="bg-white border rounded-xl shadow-sm p-4">
+          <h2 className="font-semibold mb-2">Registrar venda avulsa</h2>
+          <p className="text-xs text-gray-500 mb-4">
+            A venda gera um lançamento financeiro e baixa de estoque em um único passo.
+          </p>
+
+          <form onSubmit={handleVenda} className="space-y-3">
+            <label className="text-sm block">
+              Aluno (ID)
+              <input
+                required
+                value={sale.aluno_id}
+                onChange={(e) => setSale({ ...sale, aluno_id: e.target.value })}
+                className="mt-1 w-full border rounded px-2 py-1"
+                placeholder="UUID do aluno"
+              />
+            </label>
+            <label className="text-sm block">
+              Item
+              <select
+                required
+                value={sale.item_id}
+                onChange={(e) => setSale({ ...sale, item_id: e.target.value, valor_unitario: "" })}
+                className="mt-1 w-full border rounded px-2 py-1"
+              >
+                <option value="">Selecione</option>
+                {items
+                  .filter((i) => i.ativo)
+                  .map((i) => (
+                    <option key={i.id} value={i.id}>
+                      {i.nome} — AOA {Number(i.preco).toFixed(2)}
+                    </option>
+                  ))}
+              </select>
+            </label>
+            <div className="grid grid-cols-3 gap-3">
+              <label className="text-sm">
+                Quantidade
+                <input
+                  type="number"
+                  min="1"
+                  required
+                  value={sale.quantidade}
+                  onChange={(e) => setSale({ ...sale, quantidade: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                />
+              </label>
+              <label className="text-sm">
+                Valor unitário (AOA)
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={sale.valor_unitario}
+                  onChange={(e) => setSale({ ...sale, valor_unitario: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                  placeholder="Usar preço do item"
+                />
+              </label>
+              <label className="text-sm">
+                Desconto
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={sale.desconto}
+                  onChange={(e) => setSale({ ...sale, desconto: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                />
+              </label>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <label className="text-sm">
+                Método de pagamento
+                <select
+                  value={sale.metodo_pagamento}
+                  onChange={(e) => setSale({ ...sale, metodo_pagamento: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                >
+                  <option value="numerario">Numerário</option>
+                  <option value="multicaixa">Multicaixa</option>
+                  <option value="transferencia">Transferência</option>
+                  <option value="deposito">Depósito</option>
+                </select>
+              </label>
+              <label className="text-sm">
+                Status
+                <select
+                  value={sale.status}
+                  onChange={(e) => setSale({ ...sale, status: e.target.value })}
+                  className="mt-1 w-full border rounded px-2 py-1"
+                >
+                  <option value="pago">Pago</option>
+                  <option value="pendente">Pendente</option>
+                </select>
+              </label>
+            </div>
+            <label className="text-sm block">
+              Descrição (opcional)
+              <textarea
+                value={sale.descricao}
+                onChange={(e) => setSale({ ...sale, descricao: e.target.value })}
+                className="mt-1 w-full border rounded px-2 py-1"
+                rows={3}
+                placeholder="Ex.: Venda de uniforme tamanho M"
+              />
+            </label>
+            <button type="submit" className="bg-moxinexa-teal text-white px-4 py-2 rounded">
+              Registrar venda
+            </button>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/escola/[id]/financeiro/vendas/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/vendas/page.tsx
@@ -1,0 +1,15 @@
+import PortalLayout from "@/components/layout/PortalLayout"
+import AuditPageView from "@/components/audit/AuditPageView"
+import VendaCaixaClient from "./VendaCaixaClient"
+
+type PageParams = { params: Promise<{ id: string }> }
+
+export default async function Page({ params }: PageParams) {
+  const awaitedParams = await params
+  return (
+    <PortalLayout>
+      <AuditPageView portal="financeiro" acao="PAGE_VIEW" entity="vendas_avulsas" />
+      <VendaCaixaClient escolaId={awaitedParams.id} />
+    </PortalLayout>
+  )
+}

--- a/supabase/migrations/20251203123500_financeiro_venda_avulsa.sql
+++ b/supabase/migrations/20251203123500_financeiro_venda_avulsa.sql
@@ -1,0 +1,81 @@
+-- Função para registrar venda avulsa com controle de estoque
+-- Atualiza estoque e cria lançamento financeiro de forma atômica
+create or replace function public.registrar_venda_avulsa(
+  p_escola_id uuid,
+  p_aluno_id uuid,
+  p_item_id uuid,
+  p_quantidade int,
+  p_valor_unit numeric,
+  p_desconto numeric default 0,
+  p_metodo_pagamento metodo_pagamento_enum default 'numerario',
+  p_status financeiro_status default 'pago',
+  p_descricao text default null,
+  p_created_by uuid default null
+)
+returns table(lancamento_id uuid, estoque_atual int) as $$
+declare
+  v_item financeiro_itens%rowtype;
+  v_total numeric(12,2);
+  v_desc text;
+begin
+  if p_quantidade is null or p_quantidade <= 0 then
+    raise exception 'Quantidade inválida';
+  end if;
+
+  select *
+    into v_item
+    from financeiro_itens
+   where id = p_item_id
+     and escola_id = p_escola_id
+   for update;
+
+  if not found then
+    raise exception 'Item não encontrado para a escola';
+  end if;
+
+  if v_item.controla_estoque and v_item.estoque_atual < p_quantidade then
+    raise exception 'Estoque insuficiente';
+  end if;
+
+  v_total := coalesce(p_valor_unit, v_item.preco) * p_quantidade;
+  v_desc := coalesce(p_descricao, 'Venda de ' || v_item.nome);
+
+  update financeiro_itens
+     set estoque_atual = estoque_atual - case when v_item.controla_estoque then p_quantidade else 0 end,
+         updated_at = now()
+   where id = v_item.id
+   returning estoque_atual into estoque_atual;
+
+  insert into financeiro_lancamentos(
+    escola_id,
+    aluno_id,
+    matricula_id,
+    tipo,
+    origem,
+    descricao,
+    valor_original,
+    valor_multa,
+    valor_desconto,
+    status,
+    data_pagamento,
+    metodo_pagamento,
+    created_by
+  ) values (
+    p_escola_id,
+    p_aluno_id,
+    null,
+    'debito',
+    'venda_avulsa',
+    v_desc,
+    v_total,
+    0,
+    coalesce(p_desconto, 0),
+    coalesce(p_status, 'pago'),
+    case when coalesce(p_status, 'pago') = 'pago' then now() else null end,
+    p_metodo_pagamento,
+    p_created_by
+  ) returning id into lancamento_id;
+
+  return next;
+end;
+$$ language plpgsql security definer set search_path = public;


### PR DESCRIPTION
## Summary
- add CRUD API for catálogo de itens financeiros e gestão de estoque
- criar função e endpoint de venda avulsa com baixa de estoque atômica via RPC
- adicionar página de vendas/caixa para gerenciar itens e registrar vendas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de4a3f8848326bb9bffee5e9fa506)