### PR TITLE
Add pending course pricing alert and API support

### DIFF
--- a/apps/web/src/app/api/financeiro/dashboard/route.ts
+++ b/apps/web/src/app/api/financeiro/dashboard/route.ts
@@ -1,8 +1,11 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { supabaseServer } from "@/lib/supabaseServer";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   const s = await supabaseServer();
+  const { searchParams } = new URL(req.url);
+  const escolaId = searchParams.get("escolaId");
+  const anoLetivoParam = searchParams.get("anoLetivo");
 
   // 1) Total de matriculados (ativos)
   const { count: totalMatriculados, error: totalMatriculadosError } = await s
@@ -64,11 +67,88 @@ export async function GET() {
       ? (totalInadimplentes / totalMatriculados) * 100
       : 0;
 
+  // 4) Cursos sem tabela de preços por escola/ano
+  const ofertaQuery = s
+    .from("cursos_oferta")
+    .select("escola_id, curso_id, turmas:turma_id(ano_letivo)");
+
+  if (escolaId) ofertaQuery.eq("escola_id", escolaId);
+  if (anoLetivoParam) ofertaQuery.eq("turmas.ano_letivo", anoLetivoParam);
+
+  const { data: ofertas, error: ofertasError } = await ofertaQuery;
+
+  if (ofertasError) {
+    console.error("❌ Erro ao buscar cursos ofertados:", ofertasError.message);
+    return NextResponse.json(
+      { error: `Erro DB (Cursos ofertados): ${ofertasError.message}` },
+      { status: 500 }
+    );
+  }
+
+  const tabelasQuery = s
+    .from("financeiro_tabelas")
+    .select("escola_id, ano_letivo, curso_id");
+
+  if (escolaId) tabelasQuery.eq("escola_id", escolaId);
+  if (anoLetivoParam) tabelasQuery.eq("ano_letivo", Number(anoLetivoParam));
+
+  const { data: tabelas, error: tabelasError } = await tabelasQuery;
+
+  if (tabelasError) {
+    console.error("❌ Erro ao buscar tabelas de preço:", tabelasError.message);
+    return NextResponse.json(
+      { error: `Erro DB (Tabelas): ${tabelasError.message}` },
+      { status: 500 }
+    );
+  }
+
+  const tabelasSet = new Set(
+    (tabelas || [])
+      .filter((t: any) => t.curso_id)
+      .map(
+        (t: any) => `${t.escola_id}::${t.ano_letivo ?? ""}::${t.curso_id}`
+      )
+  );
+
+  const pendentesPorEscolaAno: Record<string, Record<string, number>> = {};
+
+  (ofertas || []).forEach((o: any) => {
+    const turma = Array.isArray(o.turmas) ? o.turmas[0] : o.turmas;
+    const anoLetivo = turma?.ano_letivo;
+    if (!o?.curso_id || !o?.escola_id || !anoLetivo) return;
+
+    const tabelaKey = `${o.escola_id}::${anoLetivo}::${o.curso_id}`;
+    if (tabelasSet.has(tabelaKey)) return;
+
+    const escolaKey = String(o.escola_id);
+    const anoKey = String(anoLetivo);
+    pendentesPorEscolaAno[escolaKey] ??= {};
+    pendentesPorEscolaAno[escolaKey][anoKey] =
+      (pendentesPorEscolaAno[escolaKey][anoKey] ?? 0) + 1;
+  });
+
+  const totalPorEscola: Record<string, number> = Object.fromEntries(
+    Object.entries(pendentesPorEscolaAno).map(([escola, anos]) => [
+      escola,
+      Object.values(anos).reduce((acc, v) => acc + v, 0),
+    ])
+  );
+
+  const cursosPendentesTotal = Object.values(totalPorEscola).reduce(
+    (acc, v) => acc + v,
+    0
+  );
+
   return NextResponse.json({
     matriculados: { total: totalMatriculados ?? 0 },
     inadimplencia: { total: totalInadimplentes, percentual: percentualInadimplencia },
     risco: { total: totalEmRisco },
     confirmados: { total: pagos.length, valor: valorConfirmado },
     pendentes: { total: naoPagos.length, valor: valorPendente },
+    cursosPendentes: {
+      total: cursosPendentesTotal,
+      totalPorEscola,
+      porEscolaAno: pendentesPorEscolaAno,
+    },
   });
 }


### PR DESCRIPTION
## Summary
- count offered courses without pricing tables per escola/ano in the financeiro dashboard API, with optional filtering by query params
- expose pending course counts in API responses for reuse across dashboards
- surface an alert on the school finance page linking to the pricing setup when pending courses exist

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692de471fea083268e01c6a250a457a9)