### PR TITLE
Add plan tier enum migration and feature gating utilities

### DIFF
--- a/apps/web/src/app/(portal-aluno)/aluno/layout.tsx
+++ b/apps/web/src/app/(portal-aluno)/aluno/layout.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
 import AlunoShell from "@/components/aluno/AlunoShell";
+import { parsePlanTier, type PlanTier } from "@/config/plans";
 
 type Vínculo = { papel: string | null; escola_id: string } | null;
 type Perfil = { id: string; nome: string | null } | null;
@@ -50,10 +51,11 @@ export default function AlunoLayout({ children }: { children: React.ReactNode })
       // Gate por plano/feature
       let ok = true;
       if (escolaId) {
-        const { data: esc } = await s.from('escolas').select('plano, aluno_portal_enabled').eq('id', escolaId).maybeSingle();
-        const plano = (esc as any)?.plano as string | undefined;
+        const { data: esc } = await (s as any).from('escolas').select('plano_atual, plano, aluno_portal_enabled').eq('id', escolaId).maybeSingle();
+        const planoRaw = (esc as any)?.plano_atual ?? (esc as any)?.plano as string | undefined;
+        const plano: PlanTier = parsePlanTier(planoRaw);
         const enabled = Boolean((esc as any)?.aluno_portal_enabled);
-        ok = Boolean(plano && (plano === 'standard' || plano === 'premium') && enabled);
+        ok = Boolean(plano && (plano === 'profissional' || plano === 'premium') && enabled);
       }
 
       if (!active) return;

--- a/apps/web/src/app/api/escolas/[id]/nome/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/nome/route.ts
@@ -3,6 +3,7 @@ import { supabaseServer } from "@/lib/supabaseServer";
 import { hasPermission } from "@/lib/permissions";
 import { createClient as createAdminClient } from "@supabase/supabase-js";
 import type { Database } from "~types/supabase";
+import { parsePlanTier } from "@/config/plans";
 
 // GET /api/escolas/[id]/nome
 // Returns the escola display name using service role after authorization.
@@ -76,7 +77,7 @@ export async function GET(_req: NextRequest, context: { params: Promise<{ id: st
 
     const { data, error } = await (admin as any)
       .from("escolas")
-      .select("nome, plano, status")
+      .select("nome, plano_atual, plano, status")
       .eq("id", escolaId)
       .maybeSingle();
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
@@ -85,7 +86,7 @@ export async function GET(_req: NextRequest, context: { params: Promise<{ id: st
     return NextResponse.json({
       ok: true,
       nome: row?.nome ?? null,
-      plano: row?.plano ?? null,
+      plano: row?.plano_atual ? parsePlanTier(row.plano_atual) : row?.plano ? parsePlanTier(row.plano) : null,
       status: row?.status ?? null,
     });
   } catch (e) {

--- a/apps/web/src/app/api/escolas/[id]/plano/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/plano/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
 import { supabaseServerTyped } from "@/lib/supabaseServer";
+import { parsePlanTier } from "@/config/plans";
 
 export async function GET(_req: Request, context: { params: Promise<{ id: string }> }) {
   try {
     const { id } = await context.params;
     const supabase = await supabaseServerTyped<any>();
-    const { data } = await supabase.from('escolas').select('plano').eq('id', id).maybeSingle();
-    return NextResponse.json({ plano: (data as any)?.plano ?? null });
+    const { data } = await supabase.from('escolas').select('plano_atual, plano').eq('id', id).maybeSingle();
+    const planoRaw = (data as any)?.plano_atual ?? (data as any)?.plano ?? null;
+    return NextResponse.json({ plano: planoRaw ? parsePlanTier(planoRaw) : null });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ plano: null, error: message }, { status: 200 });
   }
 }
-

--- a/apps/web/src/app/api/super-admin/escolas/[id]/update/route.ts
+++ b/apps/web/src/app/api/super-admin/escolas/[id]/update/route.ts
@@ -5,7 +5,7 @@ import { recordAuditServer } from '@/lib/audit'
 
 const BodySchema = z.object({
   aluno_portal_enabled: z.boolean().optional(),
-  plano: z.enum(['basico','standard','premium']).optional(),
+  plano: z.enum(['essencial','profissional','premium']).optional(),
 })
 
 export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
@@ -28,7 +28,11 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
 
     const patch: Record<string, any> = {}
     if (typeof updates.aluno_portal_enabled === 'boolean') patch.aluno_portal_enabled = updates.aluno_portal_enabled
-    if (updates.plano) patch.plano = updates.plano
+    if (updates.plano) {
+      patch.plano_atual = updates.plano
+      // compat: manter campo legacy se existir
+      patch.plano = updates.plano
+    }
     if (Object.keys(patch).length === 0) return NextResponse.json({ ok: true })
 
     const sAny = s as any

--- a/apps/web/src/app/api/test/seed/route.ts
+++ b/apps/web/src/app/api/test/seed/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: NextRequest) {
     // Create school (minimal fields)
     const { data: escolaIns, error: escolaErr } = await (admin as any)
       .from('escolas')
-      .insert({ nome: escolaNome, plano: 'basico', aluno_portal_enabled: true })
+      .insert({ nome: escolaNome, plano: 'essencial', plano_atual: 'essencial', aluno_portal_enabled: true })
       .select('id, nome')
       .single()
     if (escolaErr || !escolaIns) return NextResponse.json({ ok: false, error: escolaErr?.message || 'Falha ao criar escola' }, { status: 400 })
@@ -66,4 +66,3 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: message }, { status: 500 })
   }
 }
-

--- a/apps/web/src/app/escola/[id]/financeiro/alertas/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/alertas/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,14 +18,13 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <PortalLayout>
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Alertas Automáticos</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/escola/[id]/financeiro/boletos/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/boletos/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,14 +18,13 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <PortalLayout>
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Gerar Boleto/Link de Pagamento</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <>
                 {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a>

--- a/apps/web/src/app/escola/[id]/financeiro/contabilidade/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/contabilidade/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,12 +18,11 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
   const allowed = plan === 'premium'
 
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Integração Contábil</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/escola/[id]/financeiro/dashboards/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/dashboards/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,12 +18,11 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
   const allowed = plan === 'premium'
 
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Dashboards Avançados</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/escola/[id]/financeiro/exportacoes/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/exportacoes/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,14 +18,13 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <PortalLayout>
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Exportações (Excel/PDF)</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/escola/[id]/financeiro/fiscal/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/fiscal/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -17,12 +18,11 @@ export default async function Page() {
       </PortalLayout>
     )
   }
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
   const allowed = plan === 'premium'
 
@@ -33,7 +33,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Módulo Fiscal (NF-e, AGT)</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/escola/[id]/financeiro/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/page.tsx
@@ -2,6 +2,7 @@ import PortalLayout from "@/components/layout/PortalLayout";
 import AuditPageView from "@/components/audit/AuditPageView";
 import { supabaseServer } from "@/lib/supabaseServer";
 import Link from "next/link";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 export default async function Page({ params }: { params: Promise<{ id: string }> }) {
   const awaitedParams = await params;
@@ -26,15 +27,15 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
   const cursosPendentesPorEscola = (dashboardResumo as any)?.cursosPendentes?.totalPorEscola || {}
   const cursosPendentes = Number(cursosPendentesPorEscola[escolaId] || 0)
 
-  const plan = ((detalhes as any)?.plano || 'basico') as 'basico'|'standard'|'premium'
+  const plan: PlanTier = parsePlanTier((detalhes as any)?.plano);
 
-  const isStandard = plan === 'standard' || plan === 'premium'
-  const isPremium = plan === 'premium'
+  const isStandard = plan === 'profissional' || plan === 'premium';
+  const isPremium = plan === 'premium';
 
   return (
     <PortalLayout>
       <AuditPageView portal="financeiro" acao="PAGE_VIEW" entity="home" />
-      <div className="mb-4 text-sm text-moxinexa-gray">Plano atual: <b className="uppercase">{plan}</b></div>
+      <div className="mb-4 text-sm text-moxinexa-gray">Plano atual: <b className="uppercase">{PLAN_NAMES[plan]}</b></div>
       {cursosPendentes > 0 && (
         <div className="mb-4 rounded-xl border-2 border-amber-500 bg-amber-50 p-4 text-amber-900 shadow-sm">
           <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
@@ -112,11 +113,11 @@ export default async function Page({ params }: { params: Promise<{ id: string }>
       </div>
       
       {/* Banner de upgrade */}
-      {(plan === 'basico' || plan === 'standard') && (
+      {(plan === 'essencial' || plan === 'profissional') && (
         <div className="mt-6 p-4 bg-amber-50 border border-amber-300 rounded text-amber-800 text-sm font-sans">
-          {plan === 'basico' ? (
+          {plan === 'essencial' ? (
             <>
-              <div className="font-medium">Desbloqueie recursos do plano Standard:</div>
+              <div className="font-medium">Desbloqueie recursos do plano Profissional:</div>
               <ul className="list-disc ml-5 mt-1">
                 <li>Geração de boletos/links de pagamento</li>
                 <li>Relatórios financeiros detalhados</li>

--- a/apps/web/src/app/escola/[id]/financeiro/relatorios/detalhados/page.tsx
+++ b/apps/web/src/app/escola/[id]/financeiro/relatorios/detalhados/page.tsx
@@ -1,6 +1,7 @@
 import PortalLayout from "@/components/layout/PortalLayout"
 import AuditPageView from "@/components/audit/AuditPageView"
 import { supabaseServer } from "@/lib/supabaseServer"
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -18,14 +19,13 @@ export default async function Page() {
     )
   }
   const eid: string = escolaId
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${eid}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <PortalLayout>
@@ -34,7 +34,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Relatórios Detalhados</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar seu plano.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar seu plano.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/alertas/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/alertas/page.tsx
@@ -1,5 +1,6 @@
 import AuditPageView from "@/components/audit/AuditPageView";
 import { supabaseServer } from "@/lib/supabaseServer";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -27,14 +28,13 @@ export default async function Page() {
     )
   }
   const eid: string = escolaId
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${eid}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <>
@@ -43,7 +43,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Alertas (Secretaria)</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar o plano da escola.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar o plano da escola.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/exportacoes/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/exportacoes/page.tsx
@@ -1,5 +1,6 @@
 import AuditPageView from "@/components/audit/AuditPageView";
 import { supabaseServer } from "@/lib/supabaseServer";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 export default async function Page() {
   const s = await supabaseServer()
@@ -27,14 +28,13 @@ export default async function Page() {
     )
   }
   const eid: string = escolaId
-  let plan: 'basico'|'standard'|'premium' = 'basico'
+  let plan: PlanTier = 'essencial'
   try {
     const res = await fetch(`/api/escolas/${eid}/nome`, { cache: 'no-store' })
     const json = await res.json().catch(() => null)
-    const p = (json?.plano || 'basico') as any
-    if (['basico','standard','premium'].includes(p)) plan = p
+    plan = parsePlanTier(json?.plano)
   } catch {}
-  const allowed = plan === 'standard' || plan === 'premium'
+  const allowed = plan === 'profissional' || plan === 'premium'
 
   return (
     <>
@@ -43,7 +43,7 @@ export default async function Page() {
         <h1 className="text-lg font-semibold mb-2">Exportações (Secretaria)</h1>
         {!allowed ? (
           <div className="p-4 bg-amber-50 border border-amber-200 rounded text-amber-800 text-sm">
-            Disponível no plano Standard ou Premium. Fale com o Super Admin para atualizar o plano da escola.
+            Disponível no plano {PLAN_NAMES.profissional} ou {PLAN_NAMES.premium}. Fale com o Super Admin para atualizar o plano da escola.
             {isSuperAdmin && escolaId && (
               <> {' '}<a href={`/super-admin/escolas/${escolaId}/edit`} className="underline text-amber-900">Abrir edição da escola</a></>
             )}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/page.tsx
@@ -11,6 +11,8 @@ import {
 } from "lucide-react";
 import { useEscolaId } from "@/hooks/useEscolaId";
 import { GlobalSearch } from "@/components/GlobalSearch";
+import type { PlanTier } from "@/config/plans";
+import type { PlanTier } from "@/config/plans";
 
 // --- TIPOS ---
 type DashboardData = {
@@ -28,7 +30,7 @@ type DashboardData = {
   avisos_recentes: Array<{ id: string; titulo: string; resumo: string; data: string }>;
 };
 
-type Plano = "standard" | "premium" | "enterprise" | "basic" | "basico";
+type Plano = PlanTier | "enterprise";
 
 export default function SecretariaDashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null);
@@ -37,7 +39,7 @@ export default function SecretariaDashboardPage() {
   const { escolaId, isLoading: escolaLoading } = useEscolaId();
   
   // Mock de permissões e plano (em prod viriam do contexto)
-  const [plan] = useState<Plano>('standard');
+  const [plan] = useState<Plano>('profissional');
   const canCriarMatricula = true;
 
   useEffect(() => {
@@ -249,13 +251,13 @@ export default function SecretariaDashboardPage() {
                             </div>
                         </div>
 
-                        {/* Upgrade (Se Básico) */}
-                        {plan === 'basico' && (
+                        {/* Upgrade (Se Essencial) */}
+                        {plan === 'essencial' && (
                             <div className="border border-dashed border-slate-300 rounded-2xl p-4 text-center hover:bg-slate-50 transition cursor-pointer group">
                                 <div className="w-10 h-10 bg-purple-100 text-purple-600 rounded-full flex items-center justify-center mx-auto mb-2 group-hover:scale-110 transition">
                                     <Crown className="w-5 h-5" />
                                 </div>
-                                <p className="text-xs font-bold text-slate-700">Plano Standard</p>
+                                <p className="text-xs font-bold text-slate-700">Plano Profissional</p>
                                 <p className="text-[10px] text-slate-500 mt-1">Ative para ter relatórios financeiros avançados.</p>
                             </div>
                         )}

--- a/apps/web/src/app/super-admin/escolas/page.tsx
+++ b/apps/web/src/app/super-admin/escolas/page.tsx
@@ -1,4 +1,5 @@
 import SchoolsTableClient from "@/components/super-admin/escolas/SchoolsTableClient";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 export const dynamic = 'force-dynamic'
 
@@ -34,16 +35,8 @@ async function fetchInitial() {
   // Normalize on the server to keep client payload small and stable
   type RawSchool = { id: string; nome: string | null; status: string | null; plano: string | null; last_access: string | null; total_alunos: number; total_professores: number; cidade: string | null; estado: string | null }
   const prettyPlan = (p?: string | null): string => {
-    switch ((p || '').toLowerCase()) {
-      case 'basico':
-        return 'Básico'
-      case 'standard':
-        return 'Standard'
-      case 'premium':
-        return 'Premium'
-      default:
-        return (p as any) || 'Básico'
-    }
+    const tier: PlanTier = parsePlanTier(p);
+    return PLAN_NAMES[tier];
   }
   const normalized = (initialSchools as RawSchool[]).map(d => ({
     id: String(d.id),

--- a/apps/web/src/components/layout/PortalLayout.tsx
+++ b/apps/web/src/components/layout/PortalLayout.tsx
@@ -18,6 +18,7 @@ import {
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline";
 import clsx from "clsx";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 // Definir tipos específicos
 type MenuItemName = 
@@ -80,7 +81,7 @@ export default function PortalLayout({
 }) {
   const [active, setActive] = useState<MenuItemName>("Dashboard");
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
-  const [plan, setPlan] = useState<"basico"|"standard"|"premium"|null>(null)
+  const [plan, setPlan] = useState<PlanTier | null>(null)
   const [userName, setUserName] = useState<string | null>(null)
   const [escolaNome, setEscolaNome] = useState<string | null>(null)
 
@@ -123,8 +124,8 @@ export default function PortalLayout({
             setEscolaNome(String(json.nome))
           }
           if (mounted) {
-            const p = (json?.plano || null) as any
-            if (p && ['basico','standard','premium'].includes(p)) setPlan(p)
+            const p = json?.plano ?? null
+            if (p) setPlan(parsePlanTier(p))
           }
         } catch {}
         
@@ -264,7 +265,7 @@ export default function PortalLayout({
                     {active}
                   </h1>
                   {plan && (
-                    <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-gray-100 border text-gray-600">Plano: {plan}</span>
+                    <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-gray-100 border text-gray-600">Plano: {PLAN_NAMES[plan]}</span>
                   )}
                   {escolaNome && (
                     <span className="text-[10px] px-2 py-1 rounded-full bg-blue-50 border border-blue-200 text-blue-700" title={escolaNome}>

--- a/apps/web/src/components/layout/StudentPortalLayout.tsx
+++ b/apps/web/src/components/layout/StudentPortalLayout.tsx
@@ -14,6 +14,7 @@ import {
 } from '@heroicons/react/24/outline'
 import SignOutButton from '@/components/auth/SignOutButton'
 import BackButton from '@/components/navigation/BackButton'
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 type Item = { name: string, icon: React.ComponentType<React.SVGProps<SVGSVGElement>> }
 
@@ -28,7 +29,7 @@ const items: Item[] = [
 export default function StudentPortalLayout({ children }: { children: React.ReactNode }) {
   const [active, setActive] = useState('Dashboard')
   const [open, setOpen] = useState(false)
-  const [plan, setPlan] = useState<'basico'|'standard'|'premium'|null>(null)
+  const [plan, setPlan] = useState<PlanTier | null>(null)
 
   useEffect(() => {
     const supabase = createClient()
@@ -41,8 +42,8 @@ export default function StudentPortalLayout({ children }: { children: React.Reac
         try {
           const res = await fetch(`/api/escolas/${escolaId}/nome`, { cache: 'no-store' })
           const json = await res.json().catch(() => null)
-          const p = (json?.plano || null) as any
-          if (mounted && p && ['basico','standard','premium'].includes(p)) setPlan(p)
+          const p = json?.plano ?? null
+          if (mounted && p) setPlan(parsePlanTier(p))
         } catch {}
       } catch {}
     })()
@@ -88,7 +89,7 @@ export default function StudentPortalLayout({ children }: { children: React.Reac
             <button className="md:hidden p-2 rounded-lg bg-moxinexa-light/30" onClick={() => setOpen(true)}><Bars3Icon className="w-5 h-5" /></button>
             <h1 className="text-xl font-semibold">{active}</h1>
             {plan && (
-              <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-gray-100 border text-gray-600">Plano: {plan}</span>
+              <span className="text-[10px] uppercase px-2 py-1 rounded-full bg-gray-100 border text-gray-600">Plano: {PLAN_NAMES[plan]}</span>
             )}
           </div>
           <div className="flex items-center gap-4">

--- a/apps/web/src/components/super-admin/EscolaSettingsClient.tsx
+++ b/apps/web/src/components/super-admin/EscolaSettingsClient.tsx
@@ -2,16 +2,17 @@
 
 import { useState } from "react"
 import Button from "@/components/ui/Button"
+import { PLAN_NAMES, type PlanTier } from "@/config/plans"
 
 type Props = {
   escolaId: string
   initialAlunoPortalEnabled: boolean
-  initialPlano: 'basico'|'standard'|'premium'
+  initialPlano: PlanTier
 }
 
 export default function EscolaSettingsClient({ escolaId, initialAlunoPortalEnabled, initialPlano }: Props) {
   const [alunoPortalEnabled, setAlunoPortalEnabled] = useState(initialAlunoPortalEnabled)
-  const [plano, setPlano] = useState<'basico'|'standard'|'premium'>(initialPlano)
+  const [plano, setPlano] = useState<PlanTier>(initialPlano)
   const [saving, setSaving] = useState(false)
   const [msg, setMsg] = useState('')
 
@@ -21,15 +22,15 @@ export default function EscolaSettingsClient({ escolaId, initialAlunoPortalEnabl
       <div className="grid md:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">Plano</label>
-          <select value={plano} onChange={(e)=>setPlano(e.target.value as 'basico'|'standard'|'premium')} className="border rounded px-3 py-2 w-full">
-            <option value="basico">Básico (Financeiro Essencial)</option>
-            <option value="standard">Standard (Financeiro Avançado)</option>
-            <option value="premium">Premium (Financeiro + Fiscal)</option>
+          <select value={plano} onChange={(e)=>setPlano(e.target.value as PlanTier)} className="border rounded px-3 py-2 w-full">
+            <option value="essencial">{PLAN_NAMES.essencial} (Financeiro Essencial)</option>
+            <option value="profissional">{PLAN_NAMES.profissional} (Financeiro Avançado)</option>
+            <option value="premium">{PLAN_NAMES.premium} (Financeiro + Fiscal)</option>
           </select>
           <p className="text-xs text-gray-500 mt-2">
-            - Básico: cobranças internas, registros manuais, relatórios simples, despesas manuais.
+            - Essencial: cobranças internas, registros manuais, relatórios simples, despesas manuais.
             <br/>
-            - Standard: + boletos/links, relatórios detalhados, alertas automáticos, exportações.
+            - Profissional: + boletos/links, relatórios detalhados, alertas automáticos, exportações.
             <br/>
             - Premium: + módulo fiscal, integração contábil, dashboards avançados, multiunidades.
           </p>

--- a/apps/web/src/components/super-admin/escolas/SchoolRow.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolRow.tsx
@@ -134,9 +134,9 @@ export function SchoolRow({
       </td>
       <td className="py-3 px-4">{onboardingBadge()}</td>
       <td className="py-3 px-4">
-        <select className="border rounded-md px-2 py-1 text-sm" value={String(valueOrForm('plan', school.plan || 'Básico'))} onChange={(e) => onInputChange('plan', e.target.value)}>
-          <option value="Básico">Básico</option>
-          <option value="Standard">Standard</option>
+        <select className="border rounded-md px-2 py-1 text-sm" value={String(valueOrForm('plan', school.plan || 'Essencial'))} onChange={(e) => onInputChange('plan', e.target.value)}>
+          <option value="Essencial">Essencial</option>
+          <option value="Profissional">Profissional</option>
           <option value="Premium">Premium</option>
         </select>
       </td>

--- a/apps/web/src/components/super-admin/escolas/SchoolsFilters.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolsFilters.tsx
@@ -55,8 +55,8 @@ export function SchoolsFilters({
             className="border rounded px-2 py-2 text-sm"
           >
             <option value="all">Todos planos</option>
-            <option value="Básico">Básico</option>
-            <option value="Standard">Standard</option>
+            <option value="Essencial">Essencial</option>
+            <option value="Profissional">Profissional</option>
             <option value="Premium">Premium</option>
           </select>
         </div>

--- a/apps/web/src/components/super-admin/escolas/SchoolsTableClient.tsx
+++ b/apps/web/src/components/super-admin/escolas/SchoolsTableClient.tsx
@@ -11,6 +11,7 @@ import { SchoolsFilters } from "./SchoolsFilters";
 import { SchoolsTable } from "./SchoolsTable";
 import { SchoolsPagination } from "./SchoolsPagination";
 import type { SchoolsTableProps, School, OnboardingProgress, EditForm } from "./types";
+import { parsePlanTier, PLAN_NAMES, type PlanTier } from "@/config/plans";
 
 const BillingModal = dynamic(() => import("@/components/super-admin/SchoolBillingModal"))
 const ConfirmModal = dynamic(() => import("@/components/super-admin/ConfirmActionModal"))
@@ -63,18 +64,7 @@ export default function SchoolsTableClient({
       }
 
       // Normalize like server page.tsx does
-      const prettyPlan = (p?: string | null): string => {
-        switch ((p || '').toLowerCase()) {
-          case 'basico':
-            return 'Básico';
-          case 'standard':
-            return 'Standard';
-          case 'premium':
-            return 'Premium';
-          default:
-            return (p as any) || 'Básico';
-        }
-      }
+      const prettyPlan = (p?: string | null): string => PLAN_NAMES[parsePlanTier(p)];
 
       type RawSchool = { id: string; nome: string | null; status: string | null; plano: string | null; last_access: string | null; total_alunos: number; total_professores: number; cidade: string | null; estado: string | null };
       const normalized: School[] = (listJson.items as RawSchool[]).map(d => ({
@@ -216,21 +206,11 @@ export default function SchoolsTableClient({
       setSaving(schoolId);
       setErrorMsg(null);
 
-      const unPrettyPlan = (p?: string | null): string => {
-        switch ((p || '').toLowerCase()) {
-          case 'básico':
-          case 'basico':
-            return 'basico';
-          case 'standard':
-            return 'standard';
-          case 'premium':
-            return 'premium';
-          default:
-            return (p as any) || 'basico';
-        }
-      }
+      const unPrettyPlan = (p?: string | null): PlanTier => parsePlanTier(p);
 
-      const updates = { ...editForm, plan: unPrettyPlan(editForm.plan) };
+      const { plan, ...rest } = editForm;
+      const planTier = unPrettyPlan(plan);
+      const updates = { ...rest, plano: planTier };
 
       const res = await fetch(`/api/super-admin/escolas/${schoolId}/update`, {
         method: 'PATCH',

--- a/apps/web/src/components/super-admin/escolas/types.ts
+++ b/apps/web/src/components/super-admin/escolas/types.ts
@@ -2,7 +2,7 @@ export type School = {
   id: string | number;
   name: string;
   status: "ativa" | "suspensa" | "pendente" | string;
-  plan: "Básico" | "Standard" | "Premium" | string;
+  plan: "Essencial" | "Profissional" | "Premium" | string;
   lastAccess: string | null;
   students: number;
   teachers: number;

--- a/apps/web/src/config/plans.ts
+++ b/apps/web/src/config/plans.ts
@@ -1,0 +1,51 @@
+export const PLAN_VALUES = ["essencial", "profissional", "premium"] as const;
+export type PlanTier = (typeof PLAN_VALUES)[number];
+
+const PLAN_SET = new Set<string>(PLAN_VALUES);
+
+export function parsePlanTier(v: unknown): PlanTier {
+  if (typeof v !== "string") return "essencial";
+  const p = v.trim().toLowerCase();
+  return PLAN_SET.has(p) ? (p as PlanTier) : "essencial";
+}
+
+export type FeatureKey =
+  | "fin_recibo_pdf"
+  | "sec_upload_docs"
+  | "sec_matricula_online"
+  | "doc_qr_code"
+  | "app_whatsapp_auto"
+  | "suporte_prioritario";
+
+export const PLAN_NAMES: Record<PlanTier, string> = {
+  essencial: "Essencial",
+  profissional: "Profissional",
+  premium: "Premium",
+};
+
+export const PLAN_FEATURES: Record<PlanTier, Record<FeatureKey, boolean>> = {
+  essencial: {
+    fin_recibo_pdf: false,
+    sec_upload_docs: false,
+    sec_matricula_online: false,
+    doc_qr_code: false,
+    app_whatsapp_auto: false,
+    suporte_prioritario: false,
+  },
+  profissional: {
+    fin_recibo_pdf: true,
+    sec_upload_docs: true,
+    sec_matricula_online: false,
+    doc_qr_code: false,
+    app_whatsapp_auto: false,
+    suporte_prioritario: false,
+  },
+  premium: {
+    fin_recibo_pdf: true,
+    sec_upload_docs: true,
+    sec_matricula_online: true,
+    doc_qr_code: true,
+    app_whatsapp_auto: true,
+    suporte_prioritario: true,
+  },
+};

--- a/apps/web/src/hooks/usePlanFeature.ts
+++ b/apps/web/src/hooks/usePlanFeature.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  PLAN_FEATURES,
+  PLAN_NAMES,
+  type FeatureKey,
+  type PlanTier,
+  parsePlanTier,
+} from "@/config/plans";
+import { useUser } from "@/hooks/useUser";
+
+export function usePlanFeature(feature: FeatureKey) {
+  const { user, loading, error, escola } = useUser();
+
+  const currentPlan: PlanTier = useMemo(() => {
+    return parsePlanTier(escola?.plano_atual ?? (user as any)?.escola?.plano_atual);
+  }, [escola?.plano_atual, (user as any)?.escola?.plano_atual]);
+
+  const isEnabled = !loading && (PLAN_FEATURES[currentPlan]?.[feature] ?? false);
+  const enabledReason = loading ? "loading" : isEnabled ? "ok" : "not_allowed";
+
+  return {
+    isEnabled,
+    enabledReason,
+    currentPlan,
+    planName: PLAN_NAMES[currentPlan],
+    upgradeRequired: !loading && !isEnabled,
+    loading,
+    error,
+  };
+}

--- a/apps/web/src/hooks/useUser.ts
+++ b/apps/web/src/hooks/useUser.ts
@@ -1,0 +1,76 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { createClient } from "@/lib/supabaseClient";
+
+type UseUserResult = {
+  user: any;
+  escola: { id: string | null; plano_atual?: string | null } | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function useUser(): UseUserResult {
+  const [user, setUser] = useState<any>(null);
+  const [escola, setEscola] = useState<UseUserResult["escola"]>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    const supabase = createClient();
+
+    (async () => {
+      try {
+        setLoading(true);
+        setError(null);
+
+        const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+        if (sessionError) throw sessionError;
+
+        const currentUser = sessionData?.session?.user ?? null;
+        if (!active) return;
+
+        setUser(currentUser);
+
+        const escolaId =
+          ((currentUser?.app_metadata as any)?.escola_id as string | undefined) ??
+          null;
+
+        if (escolaId) {
+          setEscola({ id: escolaId, plano_atual: (currentUser as any)?.escola?.plano_atual });
+          return;
+        }
+
+        if (currentUser?.id) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("escola_id, current_escola_id")
+            .eq("user_id", currentUser.id)
+            .maybeSingle();
+
+          if (!active) return;
+
+          const resolvedId =
+            (profile as any)?.current_escola_id ?? (profile as any)?.escola_id ?? null;
+          setEscola(resolvedId ? { id: String(resolvedId), plano_atual: null } : null);
+        } else {
+          setEscola(null);
+        }
+      } catch (e) {
+        if (!active) return;
+        setError(e instanceof Error ? e.message : "Erro ao carregar usuário");
+        setUser(null);
+        setEscola(null);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return { user, escola, loading, error };
+}

--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,0 +1,10 @@
+export class HttpError extends Error {
+  status: number;
+  code: string;
+
+  constructor(status: number, code: string, message?: string) {
+    super(message ?? code);
+    this.status = status;
+    this.code = code;
+  }
+}

--- a/apps/web/src/lib/plan/requireFeature.ts
+++ b/apps/web/src/lib/plan/requireFeature.ts
@@ -1,0 +1,87 @@
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+import type { FeatureKey } from "@/config/plans";
+import { HttpError } from "@/lib/errors";
+import type { Database } from "~types/supabase";
+
+type DBWithFeature = Database & {
+  public: Omit<Database["public"], "Tables" | "Functions"> & {
+    Tables: Database["public"]["Tables"] & {
+      escolas: Database["public"]["Tables"]["escolas"] & {
+        Row: Database["public"]["Tables"]["escolas"]["Row"] & { plano_atual?: string | null };
+      };
+    };
+    Functions: Database["public"]["Functions"] & {
+      escola_has_feature: {
+        Args: { p_escola_id: string; p_feature: FeatureKey };
+        Returns: boolean;
+      };
+    };
+  };
+};
+
+type RequireFeatureResult = {
+  escolaId: string;
+  plano: string | null;
+  userId: string;
+};
+
+export async function requireFeature(feature: FeatureKey): Promise<RequireFeatureResult> {
+  const supabase = await supabaseServerTyped<DBWithFeature>();
+
+  const { data, error: authError } = await supabase.auth.getUser();
+  const user = data?.user;
+
+  if (authError || !user) {
+    throw new HttpError(401, "UNAUTHENTICATED", "Faça login para continuar.");
+  }
+
+  const { data: profile, error: profileError } = await supabase
+    .from("profiles")
+    .select("escola_id, current_escola_id")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (profileError) {
+    throw new HttpError(500, "PROFILE_FETCH_FAILED", "Falha ao obter perfil.");
+  }
+
+  const escolaId = (profile as any)?.current_escola_id ?? (profile as any)?.escola_id ?? null;
+  if (!escolaId) {
+    throw new HttpError(403, "NO_SCHOOL", "Usuário sem escola associada.");
+  }
+
+  const { data: escolaRow, error: escolaError } = await supabase
+    .from("escolas")
+    .select("id, plano_atual, plano")
+    .eq("id", escolaId)
+    .maybeSingle();
+
+  if (escolaError) {
+    throw new HttpError(500, "SCHOOL_FETCH_FAILED", "Falha ao carregar escola.");
+  }
+
+  if (!escolaRow) {
+    throw new HttpError(404, "SCHOOL_NOT_FOUND", "Escola não encontrada.");
+  }
+
+  const { data: allowed, error: rpcError } = await supabase.rpc("escola_has_feature", {
+    p_escola_id: escolaId,
+    p_feature: feature,
+  });
+
+  if (rpcError) {
+    throw new HttpError(500, "FEATURE_CHECK_FAILED", "Falha ao validar plano.");
+  }
+
+  if (!allowed) {
+    throw new HttpError(403, "FORBIDDEN", "Seu plano não inclui esta funcionalidade.");
+  }
+
+  const planoAtual = (escolaRow as any)?.plano_atual ?? (escolaRow as any)?.plano ?? null;
+
+  return {
+    escolaId,
+    plano: planoAtual,
+    userId: user.id,
+  };
+}

--- a/supabase/migrations/20251220090000_plan_tiers_enum.sql
+++ b/supabase/migrations/20251220090000_plan_tiers_enum.sql
@@ -1,0 +1,140 @@
+-- Idempotent migration to normalize school plans
+BEGIN;
+
+-- 1) Create ENUM (idempotent)
+DO $$ BEGIN
+  CREATE TYPE public.app_plan_tier AS ENUM ('essencial', 'profissional', 'premium');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+-- 1.1) Drop legacy constraint that still enforces basico/standard/premium
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_column_usage
+    WHERE table_schema = 'public'
+      AND table_name = 'escolas'
+      AND column_name = 'plano'
+      AND constraint_name = 'escolas_plano_check'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.escolas DROP CONSTRAINT IF EXISTS escolas_plano_check';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.constraint_column_usage
+    WHERE table_schema = 'public'
+      AND table_name = 'escolas'
+      AND column_name = 'plano_atual'
+      AND constraint_name = 'escolas_plano_check'
+  ) THEN
+    EXECUTE 'ALTER TABLE public.escolas DROP CONSTRAINT IF EXISTS escolas_plano_check';
+  END IF;
+END $$;
+
+-- 2) Case A: legacy column "plano"
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='escolas' AND column_name='plano'
+  ) THEN
+    EXECUTE $q$
+      UPDATE public.escolas
+      SET plano = CASE
+        WHEN plano IS NULL THEN 'essencial'
+        WHEN lower(btrim(plano)) IN ('basico', 'básico') THEN 'essencial'
+        WHEN lower(btrim(plano)) IN ('standard', 'padrao', 'padrão') THEN 'profissional'
+        WHEN lower(btrim(plano)) IN ('essencial','profissional','premium') THEN lower(btrim(plano))
+        ELSE 'essencial'
+      END
+    $q$;
+
+    EXECUTE 'ALTER TABLE public.escolas RENAME COLUMN plano TO plano_atual';
+  END IF;
+END $$;
+
+-- 3) Case B: ensure plano_atual exists and uses enum type
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema='public' AND table_name='escolas' AND column_name='plano_atual'
+  ) THEN
+    IF EXISTS (
+      SELECT 1
+      FROM information_schema.columns
+      WHERE table_schema='public' AND table_name='escolas' AND column_name='plano_atual'
+        AND udt_name <> 'app_plan_tier'
+    ) THEN
+      EXECUTE 'ALTER TABLE public.escolas ALTER COLUMN plano_atual DROP DEFAULT';
+      EXECUTE 'ALTER TABLE public.escolas ALTER COLUMN plano_atual TYPE public.app_plan_tier USING lower(btrim(plano_atual::text))::public.app_plan_tier';
+    END IF;
+
+    EXECUTE 'ALTER TABLE public.escolas ALTER COLUMN plano_atual SET DEFAULT ''essencial''';
+    EXECUTE 'ALTER TABLE public.escolas ALTER COLUMN plano_atual SET NOT NULL';
+  ELSE
+    EXECUTE 'ALTER TABLE public.escolas ADD COLUMN plano_atual public.app_plan_tier NOT NULL DEFAULT ''essencial''';
+  END IF;
+END $$;
+
+-- 4) View compatibility (retains legacy columns)
+CREATE OR REPLACE VIEW public.escolas_view AS
+SELECT
+  e.id,
+  e.nome,
+  e.status,
+  e.plano_atual,
+  e.plano_atual::text AS plano,
+  NULL::timestamp AS last_access,
+  COALESCE(a.total_alunos, 0) AS total_alunos,
+  COALESCE(pf.total_professores, 0) AS total_professores,
+  e.endereco AS cidade,
+  NULL::text AS estado
+FROM public.escolas e
+LEFT JOIN (
+  SELECT escola_id, COUNT(*)::int AS total_alunos
+  FROM public.alunos
+  GROUP BY escola_id
+) a ON a.escola_id = e.id
+LEFT JOIN (
+  SELECT p.escola_id, COUNT(*)::int AS total_professores
+  FROM public.profiles p
+  WHERE p.role = 'professor'
+  GROUP BY p.escola_id
+) pf ON pf.escola_id = e.id;
+
+-- 5) Feature check helper
+CREATE OR REPLACE FUNCTION public.escola_has_feature(p_escola_id uuid, p_feature text)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_plan public.app_plan_tier := 'essencial';
+  v_feature text := lower(btrim(coalesce(p_feature, '')));
+BEGIN
+  SELECT plano_atual INTO v_plan FROM public.escolas WHERE id = p_escola_id LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+
+  CASE v_feature
+    WHEN 'fin_recibo_pdf' THEN RETURN v_plan IN ('profissional', 'premium');
+    WHEN 'sec_upload_docs' THEN RETURN v_plan IN ('profissional', 'premium');
+    WHEN 'sec_matricula_online' THEN RETURN v_plan = 'premium';
+    WHEN 'doc_qr_code' THEN RETURN v_plan = 'premium';
+    WHEN 'app_whatsapp_auto' THEN RETURN v_plan = 'premium';
+    WHEN 'suporte_prioritario' THEN RETURN v_plan = 'premium';
+    ELSE RETURN FALSE;
+  END CASE;
+END;
+$$;
+
+-- 6) Ensure API layers refresh schemas
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20251221103000_documentos_emitidos_and_recibos.sql
+++ b/supabase/migrations/20251221103000_documentos_emitidos_and_recibos.sql
@@ -1,0 +1,228 @@
+-- Documentos emitidos + RPCs de emissão/validação (idempotente)
+BEGIN;
+
+-- Extensões
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Enum dos tipos de documento
+DO $$ BEGIN
+  CREATE TYPE public.tipo_documento AS ENUM ('recibo', 'declaracao', 'certificado', 'historico');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- Tabela append-only para documentos emitidos
+CREATE TABLE IF NOT EXISTS public.documentos_emitidos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  public_id uuid NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  aluno_id uuid NOT NULL REFERENCES public.alunos(id) ON DELETE RESTRICT,
+  mensalidade_id uuid NULL REFERENCES public.mensalidades(id) ON DELETE SET NULL, -- apenas para recibos
+
+  tipo public.tipo_documento NOT NULL,
+  dados_snapshot jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid NULL, -- auth.uid()
+  revoked_at timestamptz NULL,
+  revoked_by uuid NULL,
+
+  CONSTRAINT chk_revoked_consistency CHECK (
+    (revoked_at IS NULL AND revoked_by IS NULL)
+    OR (revoked_at IS NOT NULL AND revoked_by IS NOT NULL)
+  )
+);
+
+-- Idempotência e performance
+CREATE UNIQUE INDEX IF NOT EXISTS uq_documentos_recibo_por_mensalidade
+  ON public.documentos_emitidos (mensalidade_id)
+  WHERE (tipo = 'recibo' AND mensalidade_id IS NOT NULL);
+
+CREATE INDEX IF NOT EXISTS idx_docs_public_id ON public.documentos_emitidos (public_id);
+CREATE INDEX IF NOT EXISTS idx_docs_escola_created ON public.documentos_emitidos (escola_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_docs_aluno_created ON public.documentos_emitidos (aluno_id, created_at DESC);
+
+ALTER TABLE public.documentos_emitidos ENABLE ROW LEVEL SECURITY;
+
+-- Política: SELECT apenas para membros da escola (ou super_admin)
+DO $policy$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'documentos_emitidos' AND policyname = 'docs_select_school'
+  ) THEN
+    CREATE POLICY "docs_select_school"
+    ON public.documentos_emitidos
+    FOR SELECT
+    TO authenticated
+    USING (
+      public.is_super_admin()
+      OR EXISTS (
+        SELECT 1
+        FROM public.profiles p
+        WHERE p.user_id = auth.uid()
+          AND (p.escola_id = documentos_emitidos.escola_id OR p.current_escola_id = documentos_emitidos.escola_id)
+      )
+    );
+  END IF;
+END
+$policy$;
+
+-- Política: INSERT apenas para membros da escola (ou super_admin)
+DO $policy$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'documentos_emitidos' AND policyname = 'docs_insert_school'
+  ) THEN
+    CREATE POLICY "docs_insert_school"
+    ON public.documentos_emitidos
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+      public.is_super_admin()
+      OR EXISTS (
+        SELECT 1
+        FROM public.profiles p
+        WHERE p.user_id = auth.uid()
+          AND (p.escola_id = documentos_emitidos.escola_id OR p.current_escola_id = documentos_emitidos.escola_id)
+      )
+    );
+  END IF;
+END
+$policy$;
+
+-- RPC: emitir recibo (idempotente e segura)
+CREATE OR REPLACE FUNCTION public.emitir_recibo(p_mensalidade_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_id uuid;
+  v_m public.mensalidades%ROWTYPE;
+  v_doc record;
+BEGIN
+  v_user_id := auth.uid();
+  IF v_user_id IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'erro', 'UNAUTHENTICATED');
+  END IF;
+
+  SELECT *
+    INTO v_m
+  FROM public.mensalidades
+  WHERE id = p_mensalidade_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'erro', 'Mensalidade não encontrada');
+  END IF;
+
+  -- User deve pertencer à escola da mensalidade
+  IF NOT EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.user_id = v_user_id
+      AND (p.escola_id = v_m.escola_id OR p.current_escola_id = v_m.escola_id)
+  ) THEN
+    RETURN jsonb_build_object('ok', false, 'erro', 'FORBIDDEN');
+  END IF;
+
+  -- Plano precisa liberar o recurso
+  IF NOT public.escola_has_feature(v_m.escola_id, 'fin_recibo_pdf') THEN
+    RETURN jsonb_build_object('ok', false, 'erro', 'Plano não inclui Recibo PDF');
+  END IF;
+
+  -- Apenas mensalidades pagas
+  IF v_m.status <> 'pago' THEN
+    RETURN jsonb_build_object('ok', false, 'erro', 'Mensalidade não está paga');
+  END IF;
+
+  -- Idempotência: retorna recibo existente
+  SELECT id, public_id, created_at
+    INTO v_doc
+  FROM public.documentos_emitidos
+  WHERE tipo = 'recibo'
+    AND mensalidade_id = p_mensalidade_id
+  LIMIT 1;
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'ok', true,
+      'doc_id', v_doc.id,
+      'public_id', v_doc.public_id,
+      'emitido_em', v_doc.created_at
+    );
+  END IF;
+
+  -- Cria snapshot do recibo
+  INSERT INTO public.documentos_emitidos (
+    escola_id, aluno_id, mensalidade_id, tipo, dados_snapshot, created_by
+  ) VALUES (
+    v_m.escola_id,
+    v_m.aluno_id,
+    v_m.id,
+    'recibo',
+    jsonb_build_object(
+      'mensalidade_id', v_m.id,
+      'referencia', to_char(make_date(v_m.ano_referencia, v_m.mes_referencia, 1), 'TMMon/YYYY'),
+      'valor_pago', v_m.valor_pago_total,
+      'data_pagamento', v_m.data_pagamento_efetiva,
+      'metodo', v_m.metodo_pagamento
+    ),
+    v_user_id
+  )
+  RETURNING id, public_id, created_at INTO v_doc;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'doc_id', v_doc.id,
+    'public_id', v_doc.public_id,
+    'emitido_em', v_doc.created_at
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.emitir_recibo(uuid) TO authenticated;
+
+-- RPC: verificar documento público via public_id
+CREATE OR REPLACE FUNCTION public.verificar_documento_publico(p_public_id uuid)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_doc record;
+  v_escola_nome text;
+  v_aluno_nome text;
+BEGIN
+  SELECT de.public_id, de.tipo, de.created_at, de.revoked_at, de.escola_id, de.dados_snapshot, a.nome_completo
+    INTO v_doc
+  FROM public.documentos_emitidos de
+  JOIN public.alunos a ON a.id = de.aluno_id
+  WHERE de.public_id = p_public_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('valido', false, 'mensagem', 'Documento não encontrado');
+  END IF;
+
+  SELECT nome INTO v_escola_nome
+  FROM public.escolas
+  WHERE id = v_doc.escola_id;
+
+  v_aluno_nome := coalesce(v_doc.nome_completo, '');
+
+  RETURN jsonb_build_object(
+    'valido', (v_doc.revoked_at IS NULL),
+    'status', CASE WHEN v_doc.revoked_at IS NULL THEN 'VALIDO' ELSE 'REVOGADO' END,
+    'tipo', v_doc.tipo,
+    'emitido_em', v_doc.created_at,
+    'escola', v_escola_nome,
+    'aluno', regexp_replace(v_aluno_nome, '(^.).*( .*$)', '\\1***\\2'),
+    'referencia', v_doc.dados_snapshot->>'referencia',
+    'valor_pago', v_doc.dados_snapshot->>'valor_pago'
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.verificar_documento_publico(uuid) TO anon;
+GRANT EXECUTE ON FUNCTION public.verificar_documento_publico(uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- add idempotent migration to normalize school plan tiers into enum app_plan_tier and refresh escolas_view
- introduce plan config (values, parser, feature flags, display names) plus a usePlanFeature hook for UI gating
- add HttpError helper, server-side requireFeature guard using escola_has_feature RPC, and a minimal useUser hook exposing escola context
- create documentos_emitidos table with RLS, enum tipo_documento, indexes, and secure RPCs for emitir_recibo and verificar_documento_publico (idempotent and feature-gated)
- align super-admin/finance/secretaria portals and related APIs to the new plan tiers (essencial/profissional/premium) using plano_atual and normalized gating

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69498215ccd48326b5418576c358c5df)