### PR TITLE
Persist curriculum metadata, notify finance, enforce class ranges, and enhance StructureMarketplace

### DIFF
--- a/apps/web/src/app/api/escolas/[id]/cursos/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/cursos/route.ts
@@ -48,14 +48,14 @@ export async function GET(
     {
       const { data, error } = await (admin as any)
         .from('cursos')
-        .select('id, nome, nivel, descricao')
+        .select('id, nome, nivel, descricao, codigo, course_code, curriculum_key, tipo')
         .eq('escola_id', escolaId)
         .order('nome', { ascending: true });
       if (!error) rows = data || [];
       else {
         const retry = await (admin as any)
           .from('cursos')
-          .select('id, nome')
+          .select('id, nome, codigo')
           .eq('escola_id', escolaId)
           .order('nome', { ascending: true });
         if (retry.error) return NextResponse.json({ ok: false, error: retry.error.message }, { status: 400 });
@@ -67,12 +67,14 @@ export async function GET(
     const payload = rows.map((r: any) => ({
       id: r.id,
       nome: r.nome,
-      tipo: 'core',
+      tipo: r.tipo ?? "geral",
       periodo_id: undefined,
       semestre_id: undefined,
       professor_id: undefined,
       nivel: r.nivel ?? undefined,
       descricao: r.descricao ?? undefined,
+      codigo: r.course_code || r.codigo || undefined,
+      curriculum_key: r.curriculum_key ?? undefined,
     }));
     return NextResponse.json({ ok: true, data: payload });
   } catch (e) {
@@ -110,6 +112,8 @@ export async function POST(
       nivel: z.string().trim().nullable().optional(),
       descricao: z.string().trim().nullable().optional(),
       codigo: z.string().trim().nullable().optional(),
+      course_code: z.string().trim().nullable().optional(),
+      curriculum_key: z.string().trim().nullable().optional(),
       tipo: z.string().trim().nullable().optional(),
     });
     const parsed = schema.safeParse(body);
@@ -117,6 +121,9 @@ export async function POST(
       const msg = parsed.error.issues?.[0]?.message || 'Dados inválidos';
       return NextResponse.json({ ok: false, error: msg }, { status: 400 });
     }
+
+    const courseCodeFinal =
+      parsed.data.course_code || parsed.data.curriculum_key || null;
 
     const payload: any = {
       escola_id: escolaId,
@@ -126,13 +133,28 @@ export async function POST(
     if (parsed.data.nivel !== undefined) payload.nivel = parsed.data.nivel;
     if (parsed.data.descricao !== undefined) payload.descricao = parsed.data.descricao;
     if (parsed.data.tipo !== undefined) payload.tipo = parsed.data.tipo;
+    if (parsed.data.curriculum_key !== undefined) payload.curriculum_key = parsed.data.curriculum_key;
+    if (courseCodeFinal !== null) payload.course_code = courseCodeFinal;
 
     const { data: ins, error } = await (admin as any)
       .from('cursos')
       .insert(payload)
-      .select('id, nome, nivel, descricao, codigo, tipo')
+      .select('id, nome, nivel, descricao, codigo, course_code, curriculum_key, tipo')
       .single();
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+
+    try {
+      await (admin as any).from("notifications").insert({
+        escola_id: escolaId,
+        target_role: "financeiro",
+        tipo: "curso_precos_pendentes",
+        titulo: `Novo curso criado: ${ins?.nome || parsed.data.nome}`,
+        mensagem: "Configure a tabela de preços para liberar matrículas e propinas.",
+        link_acao: "/financeiro/configuracoes/precos",
+      });
+    } catch (notifyError) {
+      console.warn("Falha ao notificar financeiro:", notifyError);
+    }
 
     return NextResponse.json({ ok: true, data: ins });
   } catch (e) {

--- a/supabase/migrations/20260509090000_enforce_course_class_range.sql
+++ b/supabase/migrations/20260509090000_enforce_course_class_range.sql
@@ -1,0 +1,111 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.assert_course_class_range(
+  p_curriculum_key text,
+  p_class_num int
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_min int;
+  v_max int;
+BEGIN
+  IF p_curriculum_key IS NULL THEN
+    RETURN;
+  END IF;
+
+  CASE p_curriculum_key
+    WHEN 'primario_base', 'primario_avancado' THEN v_min := 1; v_max := 6;
+    WHEN 'ciclo1' THEN v_min := 7; v_max := 9;
+    WHEN 'puniv', 'economicas' THEN v_min := 10; v_max := 12;
+    WHEN 'tecnico_informatica', 'tecnico_gestao', 'tecnico_construcao', 'tecnico_base', 'saude_enfermagem', 'saude_farmacia_analises' THEN v_min := 10; v_max := 13;
+    ELSE
+      RETURN;
+  END CASE;
+
+  IF p_class_num < v_min OR p_class_num > v_max THEN
+    RAISE EXCEPTION 'Classe % fora do intervalo permitido (%-%) para currículo %', p_class_num, v_min, v_max, p_curriculum_key
+      USING ERRCODE = '22023';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.create_or_get_turma_by_code(
+  p_escola_id uuid,
+  p_ano_letivo int,
+  p_turma_code text
+)
+RETURNS public.turmas
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_code text := upper(regexp_replace(trim(p_turma_code), '\\s+', '', 'g'));
+  v_course_code text;
+  v_class_num int;
+  v_shift text;
+  v_section text;
+  v_curso_id uuid;
+  v_curriculum_key text;
+  v_turma public.turmas;
+BEGIN
+  IF p_escola_id IS NULL THEN
+    RAISE EXCEPTION 'escola_id é obrigatório' USING ERRCODE = '22023';
+  END IF;
+
+  IF p_ano_letivo IS NULL THEN
+    RAISE EXCEPTION 'ano_letivo é obrigatório' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_code !~ '^[A-Z0-9]{2,8}-\\d{1,2}-(M|T|N)-[A-Z]{1,2}$' THEN
+    RAISE EXCEPTION 'Código da Turma inválido: % (ex: TI-10-M-A)', p_turma_code
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_course_code := split_part(v_code, '-', 1);
+  v_class_num   := split_part(v_code, '-', 2)::int;
+  v_shift       := split_part(v_code, '-', 3);
+  v_section     := split_part(v_code, '-', 4);
+
+  IF v_class_num < 1 OR v_class_num > 13 THEN
+    RAISE EXCEPTION 'Classe inválida no código: %', v_class_num USING ERRCODE = '22023';
+  END IF;
+
+  SELECT c.id, c.curriculum_key INTO v_curso_id, v_curriculum_key
+    FROM public.cursos c
+   WHERE c.escola_id = p_escola_id
+     AND c.course_code = v_course_code
+   LIMIT 1;
+
+  IF v_curso_id IS NULL THEN
+    RAISE EXCEPTION 'Curso não encontrado para course_code=% na escola', v_course_code USING ERRCODE = '23503';
+  END IF;
+
+  PERFORM public.assert_course_class_range(v_curriculum_key, v_class_num);
+
+  INSERT INTO public.turmas (
+    escola_id, ano_letivo, turma_code,
+    curso_id, classe_num, turno, letra,
+    turma_codigo, nome
+  )
+  VALUES (
+    p_escola_id, p_ano_letivo, v_code,
+    v_curso_id, v_class_num, v_shift, v_section,
+    v_code, coalesce(v_code || ' (Auto)', v_code)
+  )
+  ON CONFLICT (escola_id, ano_letivo, turma_code)
+  DO UPDATE SET
+    curso_id   = EXCLUDED.curso_id,
+    classe_num = EXCLUDED.classe_num,
+    turno      = EXCLUDED.turno,
+    letra      = EXCLUDED.letra,
+    turma_codigo = COALESCE(public.turmas.turma_codigo, EXCLUDED.turma_codigo),
+    nome       = COALESCE(public.turmas.nome, EXCLUDED.nome)
+  RETURNING * INTO v_turma;
+
+  RETURN v_turma;
+END;
+$$;
+
+COMMIT;


### PR DESCRIPTION
### Motivation

- Ensure courses created via the StructureMarketplace are persisted with curriculum metadata and prompt finance to configure pricing for enrollments.  
- Guarantee that disciplines are properly linked to the correct classes and that turmas and turnos are created as the admin expects.  
- Prevent creation of classes/turmas outside allowed grade ranges for courses that use curriculum presets to keep data consistent across app and DB.  
- Improve the admin experience when installing presets or creating custom courses by making the workflow explicit and safer.

### Description

- Persist curriculum metadata and notify finance: `POST /api/escolas/[id]/cursos` and the stats endpoint now accept and persist `curriculum_key` and `course_code`, expose these fields in list responses, and insert a notification into `notifications` for `target_role: "financeiro"` after course creation.  
- StructureMarketplace UX/flow: `StructureMarketplace.tsx` now builds disciplines per class (for presets), supports selecting `turnos` in the create modal, and creates classes/turmas for each selected turno when installing presets or saving custom courses.  
- Server-side class validation: added `parseClasseNumero`, `CURRICULUM_CLASS_RANGES`, and server-side validation in `apps/web/src/app/api/escolas/[id]/classes/route.ts` that loads the course and returns `400/404` when class names are invalid or out-of-range for curriculum presets.  
- Database enforcement: added migration `supabase/migrations/20260509090000_enforce_course_class_range.sql` which creates `public.assert_course_class_range(p_curriculum_key, p_class_num)` and `public.create_or_get_turma_by_code(...)` to validate curriculum ranges and insert/update `turmas` atomically at the DB level.

### Testing

- No automated tests were executed as part of this change.  
- CI/integration test runs were not triggered during this rollout.  
- Please run the DB migration on a staging environment and exercise `classes`/`turmas` flows with both preset and custom courses to validate end-to-end behavior.  
- Recommend adding integration tests that cover: course creation notifications, class-range validation for preset courses, and `create_or_get_turma_by_code` behavior under conflict conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952cfbf05d88326bd0e2cd9bc3761e2)