### PR TITLE
Add PDF metadata headers and update Pauta PDFs (rotate discipline headers and grade cells)

### DIFF
--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/modelo/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/modelo/route.ts
@@ -58,6 +58,8 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     const pdfBuffer = await renderPautaAnualBuffer(payload)
     const headers = new Headers({
       "Content-Type": "application/pdf",
+      "X-Klasse-Pdf-Template": "PautaAnualV1",
+      "X-Klasse-Pdf-Kind": "anual-modelo",
       "Content-Disposition": `attachment; filename=Modelo_Pauta_Anual_${payload.metadata.turma}.pdf`,
     })
 

--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/oficial/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/oficial/route.ts
@@ -5,7 +5,6 @@ import { supabaseServerTyped } from "@/lib/supabaseServer"
 import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser"
 import { authorizeTurmasManage } from "@/lib/escola/disciplinas"
 import { buildPautaAnualPayload, renderPautaAnualBuffer } from "@/lib/pedagogico/pauta-anual"
-import type { Database } from "~types/supabase"
 import { requireFeature } from "@/lib/plan/requireFeature"
 import { HttpError } from "@/lib/errors"
 
@@ -62,7 +61,13 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
       }
 
       if (mode === "json") {
-        return NextResponse.json({ ok: true, status: "SUCCESS", download_url: signed.signedUrl })
+        return NextResponse.json({
+          ok: true,
+          status: "SUCCESS",
+          download_url: signed.signedUrl,
+          pdf_template: "PautaAnualV1",
+          pdf_kind: "anual-oficial",
+        })
       }
       return NextResponse.redirect(signed.signedUrl)
     }

--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-anual/route.ts
@@ -40,6 +40,8 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     const pdfBuffer = await renderPautaAnualBuffer(payload)
     const headers = new Headers({
       "Content-Type": "application/pdf",
+      "X-Klasse-Pdf-Template": "PautaAnualV1",
+      "X-Klasse-Pdf-Kind": "anual",
       "Content-Disposition": `attachment; filename=Pauta_Anual_${payload.metadata.turma}.pdf`,
     })
 

--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/modelo/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/modelo/route.ts
@@ -50,6 +50,8 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     const pdfBuffer = await renderPautaGeralBuffer(payload)
     const headers = new Headers({
       "Content-Type": "application/pdf",
+      "X-Klasse-Pdf-Template": "PautaGeralV1",
+      "X-Klasse-Pdf-Kind": "trimestral-modelo",
       "Content-Disposition": `attachment; filename=Modelo_Pauta_Geral_${payload.metadata.turma}.pdf`,
     })
 

--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/oficial/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/oficial/route.ts
@@ -4,7 +4,6 @@ import { randomUUID } from "crypto"
 import { supabaseServerTyped } from "@/lib/supabaseServer"
 import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser"
 import { authorizeTurmasManage } from "@/lib/escola/disciplinas"
-import type { Database } from "~types/supabase"
 import { buildPautaGeralPayload, renderPautaGeralBuffer } from "@/lib/pedagogico/pauta-geral"
 import { requireFeature } from "@/lib/plan/requireFeature"
 import { HttpError } from "@/lib/errors"
@@ -12,6 +11,7 @@ import { HttpError } from "@/lib/errors"
 export const dynamic = "force-dynamic"
 export const revalidate = 0
 export const fetchCache = "force-no-store"
+export const runtime = "nodejs"
 
 const Query = z.object({
   periodoLetivoId: z.string().uuid(),
@@ -61,7 +61,13 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
       }
 
       if (mode === "json") {
-        return NextResponse.json({ ok: true, status: "SUCCESS", download_url: signed.signedUrl })
+        return NextResponse.json({
+          ok: true,
+          status: "SUCCESS",
+          download_url: signed.signedUrl,
+          pdf_template: "PautaGeralV1",
+          pdf_kind: "trimestral-oficial",
+        })
       }
       return NextResponse.redirect(signed.signedUrl)
     }

--- a/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/pauta-geral/route.ts
@@ -65,6 +65,8 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     const pdfBuffer = await renderPautaGeralBuffer(payload)
     const headers = new Headers({
       "Content-Type": "application/pdf",
+      "X-Klasse-Pdf-Template": "PautaGeralV1",
+      "X-Klasse-Pdf-Kind": "trimestral-geral",
       "Content-Disposition": `attachment; filename=Pauta_Geral_${payload.metadata.turma}_${numero}T.pdf`,
     })
 

--- a/apps/web/src/templates/pdf/ministerio/PautaAnualV1.tsx
+++ b/apps/web/src/templates/pdf/ministerio/PautaAnualV1.tsx
@@ -30,13 +30,16 @@ const s = StyleSheet.create({
     textAlign: "center",
   },
   table: {
+    width: "100%",
     borderWidth: 1,
     borderColor: "#1f2937",
+    marginTop: 6,
   },
   row: {
     flexDirection: "row",
     borderBottomWidth: 1,
     borderBottomColor: "#1f2937",
+    alignItems: "center",
   },
   cell: {
     borderRightWidth: 1,
@@ -54,6 +57,38 @@ const s = StyleSheet.create({
   },
   disciplinaHeader: {
     backgroundColor: "#f8fafc",
+  },
+  rotatedContainer: {
+    width: "100%",
+    height: 90,
+    borderBottomWidth: 1,
+    borderBottomColor: "#1f2937",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    paddingBottom: 4,
+  },
+  rotatedText: {
+    fontSize: 7,
+    textTransform: "uppercase",
+    transform: "rotate(-90deg)",
+    width: 90,
+    textAlign: "left",
+  },
+  gradesWrapper: {
+    flexDirection: "row",
+    width: "100%",
+    height: 16,
+  },
+  gradeCell: {
+    flex: 1,
+    borderRightWidth: 1,
+    borderRightColor: "#1f2937",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  fixedHeaderCell: {
+    height: 106,
+    justifyContent: "center",
   },
   footer: {
     marginTop: 10,
@@ -88,7 +123,6 @@ const toPercent = (value: number) => `${value.toFixed(2)}%`
 export function PautaAnualV1({ metadata, disciplinas, alunos }: Props) {
   const fixedWidth = 6 + 28 + 5 + 4 + 10
   const disciplinaWidth = disciplinas.length > 0 ? (100 - fixedWidth) / disciplinas.length : 0
-  const disciplinaCellWidth = disciplinaWidth / 4
   const pages = chunkRows(alunos, ROWS_PER_PAGE)
 
   return (
@@ -109,43 +143,47 @@ export function PautaAnualV1({ metadata, disciplinas, alunos }: Props) {
 
           <View style={s.table}>
             <View style={[s.row, s.disciplinaHeader]} wrap={false}>
-              <View style={[s.cell, { width: toPercent(6) }]}>
+              <View style={[s.cell, s.fixedHeaderCell, { width: toPercent(6) }]}> 
                 <Text style={[s.cellHeader, s.cellCenter]}>Nº</Text>
               </View>
-              <View style={[s.cell, { width: toPercent(28) }]}>
+              <View style={[s.cell, s.fixedHeaderCell, { width: toPercent(28) }]}> 
                 <Text style={[s.cellHeader, s.cellCenter]}>Nome Completo do Aluno</Text>
               </View>
-              <View style={[s.cell, { width: toPercent(5) }]}>
+              <View style={[s.cell, s.fixedHeaderCell, { width: toPercent(5) }]}> 
                 <Text style={[s.cellHeader, s.cellCenter]}>Idade</Text>
               </View>
-              <View style={[s.cell, { width: toPercent(4) }]}>
+              <View style={[s.cell, s.fixedHeaderCell, { width: toPercent(4) }]}> 
                 <Text style={[s.cellHeader, s.cellCenter]}>Sexo</Text>
               </View>
               {disciplinas.map((disciplina) => (
-                <View key={disciplina.id} style={[s.cell, { width: toPercent(disciplinaWidth) }]}>
-                  <Text style={[s.cellHeader, s.cellCenter]}>{disciplina.nome}</Text>
+                <View key={disciplina.id} style={[s.cell, { width: toPercent(disciplinaWidth), paddingHorizontal: 0, paddingVertical: 0 }]}> 
+                  <View style={s.rotatedContainer}>
+                    <Text style={s.rotatedText}>{disciplina.nome}</Text>
+                  </View>
+                  <View style={s.gradesWrapper}>
+                    {[
+                      "MT1",
+                      "MT2",
+                      "MT3",
+                      "MFD",
+                    ].map((label) => (
+                      <View
+                        key={`${disciplina.id}-${label}`}
+                        style={[
+                          s.gradeCell,
+                          { flex: 1 },
+                          label === "MFD" ? { borderRightWidth: 0 } : {},
+                        ]}
+                      >
+                        <Text style={[s.cellHeader, s.cellCenter]}>{label}</Text>
+                      </View>
+                    ))}
+                  </View>
                 </View>
               ))}
-              <View style={[s.cell, { width: toPercent(10) }]}>
+              <View style={[s.cell, s.fixedHeaderCell, { width: toPercent(10), borderRightWidth: 0 }]}> 
                 <Text style={[s.cellHeader, s.cellCenter]}>Resultado Final</Text>
               </View>
-            </View>
-
-            <View style={[s.row, s.disciplinaHeader]} wrap={false}>
-              <View style={[s.cell, { width: toPercent(6) }]} />
-              <View style={[s.cell, { width: toPercent(28) }]} />
-              <View style={[s.cell, { width: toPercent(5) }]} />
-              <View style={[s.cell, { width: toPercent(4) }]} />
-              {disciplinas.map((disciplina) => (
-                <View key={`sub-${disciplina.id}`} style={{ flexDirection: "row", width: toPercent(disciplinaWidth) }}>
-                  {["MT1", "MT2", "MT3", "MFD"].map((label) => (
-                    <View key={`${disciplina.id}-${label}`} style={[s.cell, { width: toPercent(disciplinaCellWidth) }]}> 
-                      <Text style={[s.cellHeader, s.cellCenter]}>{label}</Text>
-                    </View>
-                  ))}
-                </View>
-              ))}
-              <View style={[s.cell, { width: toPercent(10) }]} />
             </View>
 
             {pageRows.map((aluno) => (
@@ -168,14 +206,21 @@ export function PautaAnualV1({ metadata, disciplinas, alunos }: Props) {
                   return (
                     <View key={`${aluno.aluno_id}-${disciplina.id}`} style={{ flexDirection: "row", width: toPercent(disciplinaWidth) }}>
                       {values.map((valor, idx) => (
-                        <View key={`${aluno.aluno_id}-${disciplina.id}-${idx}`} style={[s.cell, { width: toPercent(disciplinaCellWidth) }]}> 
+                        <View
+                          key={`${aluno.aluno_id}-${disciplina.id}-${idx}`}
+                          style={[
+                            s.cell,
+                            { flex: 1 },
+                            idx === values.length - 1 ? { borderRightWidth: 0 } : {},
+                          ]}
+                        >
                           <Text style={[s.cellCenter]}>{valor}</Text>
                         </View>
                       ))}
                     </View>
                   )
                 })}
-                <View style={[s.cell, { width: toPercent(10) }]}>
+                <View style={[s.cell, { width: toPercent(10), borderRightWidth: 0 }]}> 
                   <Text style={[s.cellCenter]}>{aluno.resultado_final}</Text>
                 </View>
               </View>


### PR DESCRIPTION
### Motivation

- Include machine-readable metadata in PDF HTTP responses to help downstream services identify template and kind. 
- Improve the visual layout of the annual grade sheet to fit discipline names and per-discipline grade columns more compactly. 
- Replace the two-row header with a rotated discipline name plus compact grade subcells to save vertical space and simplify rendering.

### Description

- Add response headers `X-Klasse-Pdf-Template` and `X-Klasse-Pdf-Kind` to `pauta-anual`, `pauta-anual/modelo`, `pauta-geral`, and `pauta-geral/modelo` routes to expose the PDF template name and kind. 
- Revise `PautaAnualV1` template: introduce new styles (`rotatedContainer`, `rotatedText`, `gradesWrapper`, `gradeCell`, `fixedHeaderCell`) and adjust `table`/`row` styles for width, alignment and spacing. 
- Replace the former two-row discipline header with a single header that renders rotated discipline names and an inline row of grade labels (`MT1`, `MT2`, `MT3`, `MFD`), and update student-grade cell rendering to match the new layout. 
- Adjust column width calculations and border handling (remove separate `disciplinaCellWidth`, use flexible grade cells and remove redundant borders on last columns).

### Testing

- Ran TypeScript typecheck (`tsc`) and linting and fixed issues introduced by the changes; these checks passed. 
- Executed the test suite (`pnpm test`) and the web build (`pnpm -w build`) as a smoke verification; both completed successfully. 
- Performed a local PDF generation smoke test for `PautaAnualV1` to verify layout and headers were emitted as expected; the generated PDF opened and contained the rotated headers and added HTTP headers.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f28b19f4c8326b8ddce3563a661b0)