### PR TITLE
Add composite roles 'secretaria_financeiro' and 'admin_financeiro' with permissions, UI, API and DB changes

### DIFF
--- a/apps/web/src/app/(auth)/login/actions.ts
+++ b/apps/web/src/app/(auth)/login/actions.ts
@@ -75,6 +75,18 @@ export async function loginAction(_: unknown, formData: FormData) {
         }
       } else if (papelNormalizado === "financeiro") {
         redirect("/financeiro");
+      } else if (papelNormalizado === "secretaria_financeiro") {
+        if (escola_id) {
+          redirect(`/escola/${escola_id}/secretaria?modo=balcao`);
+        } else {
+          redirect("/secretaria");
+        }
+      } else if (papelNormalizado === "admin_financeiro") {
+        if (escola_id) {
+          redirect(`/escola/${escola_id}/admin/dashboard?tab=financeiro`);
+        } else {
+          redirect("/admin");
+        }
       } else if (papelNormalizado === "professor") {
         redirect("/professor");
       } else if (papelNormalizado === "aluno") {

--- a/apps/web/src/app/(auth)/redirect/page.tsx
+++ b/apps/web/src/app/(auth)/redirect/page.tsx
@@ -128,6 +128,26 @@ export default function RedirectPage() {
             case "financeiro":
               router.replace("/financeiro");
               break;
+            case "secretaria_financeiro": {
+              if (resolvedEscolaId) {
+                let modo = 'balcao'
+                try {
+                  const saved = localStorage.getItem('klasse_modo_secretaria')
+                  if (saved === 'balcao' || saved === 'financeiro') modo = saved
+                } catch {}
+                router.replace(`/escola/${resolvedEscolaId}/secretaria?modo=${modo}`)
+              } else {
+                router.replace('/secretaria')
+              }
+              break;
+            }
+            case "admin_financeiro":
+              if (resolvedEscolaId) {
+                router.replace(`/escola/${resolvedEscolaId}/admin/dashboard?tab=financeiro`)
+              } else {
+                router.replace('/admin')
+              }
+              break;
             default:
               router.replace("/");
               break;

--- a/apps/web/src/app/(guards)/RequireSecretaria.tsx
+++ b/apps/web/src/app/(guards)/RequireSecretaria.tsx
@@ -35,7 +35,7 @@ export default function RequireSecretaria({
       const { data: vinculos, error } = await vinculoQuery.limit(10);
       const hasSecretaria = (vinculos || []).some((v: Tables<'escola_users'>) => {
         const papel = v.papel ?? v.role ?? null;
-        return papel === "secretaria" || papel === "admin";
+        return papel === "secretaria" || papel === "admin" || papel === "secretaria_financeiro" || papel === "admin_financeiro" || papel === "financeiro";
       });
       if (error || !hasSecretaria) { router.replace("/"); return; }
 

--- a/apps/web/src/app/api/escolas/[id]/usuarios/invite/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/usuarios/invite/route.ts
@@ -6,6 +6,7 @@ import { createRouteClient } from '@/lib/supabase/route-client'
 import { recordAuditServer } from '@/lib/audit'
 import { hasPermission, mapPapelToGlobalRole, normalizePapel } from '@/lib/permissions'
 import { sanitizeEmail } from '@/lib/sanitize'
+import { papelEscolaSchema } from '@/lib/roles'
 import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
 import { callAuthAdminJob } from '@/lib/auth-admin-job'
 
@@ -15,8 +16,7 @@ const BodySchema = z.object({
   email: z.string().email(),
   nome: z.string().trim().min(1),
   telefone: z.string().trim().nullable().optional(),
-  papel: z.enum(['admin','staff_admin','secretaria','financeiro','professor','aluno'])
-    .default('secretaria'),
+  papel: papelEscolaSchema.default('secretaria'),
 })
 
 export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {

--- a/apps/web/src/app/api/escolas/[id]/usuarios/toggle/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/usuarios/toggle/route.ts
@@ -5,13 +5,14 @@ import { createRouteClient } from '@/lib/supabase/route-client'
 import { recordAuditServer } from '@/lib/audit'
 import { mapPapelToGlobalRole } from '@/lib/permissions'
 import { hasPermission } from '@/lib/permissions'
+import { papelEscolaSchema } from '@/lib/roles'
 import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
 import { callAuthAdminJob } from '@/lib/auth-admin-job'
 
 const BodySchema = z.object({
   email: z.string().email(),
   ativo: z.boolean(),
-  papel: z.enum(['admin','staff_admin','secretaria','financeiro','professor','aluno']).optional(),
+  papel: papelEscolaSchema.optional(),
 })
 
 export async function POST(req: NextRequest, context: { params: Promise<{ id: string }> }) {

--- a/apps/web/src/app/api/escolas/[id]/usuarios/update/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/usuarios/update/route.ts
@@ -3,15 +3,17 @@ import { z } from 'zod'
 import { createRouteClient } from '@/lib/supabase/route-client'
 import { recordAuditServer } from '@/lib/audit'
 import { mapPapelToGlobalRole } from '@/lib/permissions'
+import { papelEscolaSchema } from '@/lib/roles'
 import { hasPermission } from '@/lib/permissions'
 import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
 import { callAuthAdminJob } from '@/lib/auth-admin-job'
 
 const BodySchema = z.object({
   email: z.string().email(),
-  papel: z.enum(['admin','staff_admin','secretaria','financeiro','professor','aluno']).optional(),
-  roleEnum: z.enum(['super_admin','admin','professor','aluno','secretaria','financeiro','global_admin','guest']).optional(),
+  papel: papelEscolaSchema.optional(),
+  roleEnum: z.enum(['super_admin','admin','professor','aluno','secretaria','financeiro','secretaria_financeiro','admin_financeiro','global_admin','guest']).optional(),
 })
+
 
 export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id: escolaId } = await context.params

--- a/apps/web/src/app/api/super-admin/users/create/route.ts
+++ b/apps/web/src/app/api/super-admin/users/create/route.ts
@@ -4,6 +4,7 @@ import type { Database } from "~types/supabase";
 import { recordAuditServer } from "@/lib/audit";
 import { supabaseServerTyped } from "@/lib/supabaseServer";
 import { callAuthAdminJob } from "@/lib/auth-admin-job";
+import { allowedPapeisSet } from "@/lib/roles";
 // ❌ REMOVIDO: import { generateNumeroLogin } from "@/lib/generateNumeroLogin";
 
 // top-level não deve criar client
@@ -50,15 +51,7 @@ export async function POST(request: Request) {
       return mapped as any;
     };
 
-    const allowedPapeis = new Set([
-      "admin",
-      "staff_admin",
-      "financeiro",
-      "secretaria",
-      "aluno",
-      "professor",
-      "admin_escola",
-    ]);
+    const allowedPapeis = allowedPapeisSet;
     const papelDb = normalizePapel(String(papel || "").trim());
     if (!allowedPapeis.has(papelDb)) {
       return NextResponse.json(

--- a/apps/web/src/app/api/super-admin/users/update/route.ts
+++ b/apps/web/src/app/api/super-admin/users/update/route.ts
@@ -3,6 +3,7 @@ import { supabaseServer } from '@/lib/supabaseServer'
 import type { Database } from '~types/supabase'
 import { recordAuditServer } from '@/lib/audit'
 import { isSuperAdminRole } from '@/lib/auth/requireSuperAdminAccess'
+import { allowedPapeisSet } from '@/lib/roles'
 
 export async function POST(request: Request) {
   try {
@@ -60,7 +61,7 @@ export async function POST(request: Request) {
       }
       return (legacyMap[p] || p)
     }
-    const allowedPapeis = new Set(['admin','staff_admin','financeiro','secretaria','aluno','professor','admin_escola'])
+    const allowedPapeis = allowedPapeisSet
 
     if (updates.escola_id !== undefined) {
       const escolaId = updates.escola_id

--- a/apps/web/src/app/escola/[id]/funcionarios/novo/page.tsx
+++ b/apps/web/src/app/escola/[id]/funcionarios/novo/page.tsx
@@ -12,7 +12,7 @@ import {
   ClipboardDocumentCheckIcon,
 } from "@heroicons/react/24/outline";
 
-type Papel = "admin" | "staff_admin" | "secretaria" | "financeiro";
+type Papel = "admin" | "staff_admin" | "secretaria" | "financeiro" | "secretaria_financeiro" | "admin_financeiro";
 
 export default function NovoFuncionarioPage({ embedded = false }: { embedded?: boolean } = {}) {
   const router = useRouter();
@@ -181,6 +181,8 @@ export default function NovoFuncionarioPage({ embedded = false }: { embedded?: b
               >
                 <option value="secretaria">Secretaria</option>
                 <option value="financeiro">Financeiro</option>
+                <option value="secretaria_financeiro">Secretaria + Financeiro</option>
+                <option value="admin_financeiro">Admin + Financeiro</option>
                 <option value="staff_admin">Staff Admin</option>
                 <option value="admin">Administrador</option>
               </select>

--- a/apps/web/src/app/escola/[id]/page.tsx
+++ b/apps/web/src/app/escola/[id]/page.tsx
@@ -34,6 +34,14 @@ export default async function EscolaIdPage({ params }: { params: Promise<{ id: s
     return redirect(`/escola/${id}/admin/dashboard`);
   }
 
+  if (escolaUsuario.papel === 'secretaria_financeiro') {
+    return redirect(`/escola/${id}/secretaria?modo=balcao`);
+  }
+
+  if (escolaUsuario.papel === 'admin_financeiro') {
+    return redirect(`/escola/${id}/admin/dashboard?tab=financeiro`);
+  }
+
   if (escolaUsuario.papel === 'professor') {
     return redirect('/professor');
   }

--- a/apps/web/src/app/escola/[id]/secretaria/(portal-secretaria)/page.tsx
+++ b/apps/web/src/app/escola/[id]/secretaria/(portal-secretaria)/page.tsx
@@ -1,1 +1,45 @@
-export { default } from "@/app/secretaria/(portal-secretaria)/page";
+import SecretariaDashboardPage from "@/app/secretaria/(portal-secretaria)/page";
+import FinanceiroDashboardPage from "@/app/financeiro/page";
+import KlasseSecretariaUnificada from "@/components/secretaria/KlasseSecretariaUnificada";
+import { supabaseServer } from "@/lib/supabaseServer";
+
+export default async function SecretariaLandingPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams?: Promise<{ aluno?: string; view?: string; modo?: string }>;
+}) {
+  const { id: escolaId } = await params;
+  const sp = searchParams ? await searchParams : undefined;
+  const supabase = await supabaseServer();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) return <SecretariaDashboardPage />;
+
+  const { data: vinculo } = await supabase
+    .from("escola_users")
+    .select("papel")
+    .eq("escola_id", escolaId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  const papel = (vinculo?.papel ?? null) as string | null;
+
+  if (papel === "secretaria_financeiro") {
+    return (
+      <KlasseSecretariaUnificada
+        balcaoContent={<SecretariaDashboardPage />}
+        financeiroContent={<FinanceiroDashboardPage searchParams={Promise.resolve(sp ?? {})} />}
+      />
+    );
+  }
+
+  if (papel === "financeiro") {
+    return <FinanceiroDashboardPage searchParams={Promise.resolve(sp ?? {})} />;
+  }
+
+  return <SecretariaDashboardPage />;
+}

--- a/apps/web/src/components/secretaria/KlasseSecretariaUnificada.tsx
+++ b/apps/web/src/components/secretaria/KlasseSecretariaUnificada.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type ModoSecretaria = "balcao" | "financeiro";
+
+function normalizeModo(value: string | null | undefined): ModoSecretaria | null {
+  if (value === "balcao" || value === "financeiro") return value;
+  return null;
+}
+
+export default function KlasseSecretariaUnificada({
+  balcaoContent,
+  financeiroContent,
+}: {
+  balcaoContent: React.ReactNode;
+  financeiroContent: React.ReactNode;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const modeFromQuery = normalizeModo(searchParams.get("modo"));
+  const [activeMode, setActiveMode] = useState<ModoSecretaria>(modeFromQuery ?? "balcao");
+
+  useEffect(() => {
+    if (modeFromQuery) {
+      setActiveMode(modeFromQuery);
+      try {
+        localStorage.setItem("klasse_modo_secretaria", modeFromQuery);
+      } catch {}
+      return;
+    }
+
+    try {
+      const saved = normalizeModo(localStorage.getItem("klasse_modo_secretaria"));
+      if (saved) {
+        setActiveMode(saved);
+        const next = new URLSearchParams(searchParams.toString());
+        next.set("modo", saved);
+        router.replace(`${pathname}?${next.toString()}`);
+      }
+    } catch {}
+  }, [modeFromQuery, pathname, router, searchParams]);
+
+  const setMode = (mode: ModoSecretaria) => {
+    setActiveMode(mode);
+    try {
+      localStorage.setItem("klasse_modo_secretaria", mode);
+    } catch {}
+    const next = new URLSearchParams(searchParams.toString());
+    next.set("modo", mode);
+    router.replace(`${pathname}?${next.toString()}`);
+  };
+
+  const current = useMemo(() => (activeMode === "financeiro" ? financeiroContent : balcaoContent), [activeMode, balcaoContent, financeiroContent]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 border-b border-slate-200 pb-3">
+        <button
+          type="button"
+          onClick={() => setMode("balcao")}
+          className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
+            activeMode === "balcao"
+              ? "bg-emerald-600 text-white"
+              : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+          }`}
+        >
+          Balcão
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode("financeiro")}
+          className={`rounded-lg px-3 py-2 text-sm font-semibold transition-colors ${
+            activeMode === "financeiro"
+              ? "bg-emerald-600 text-white"
+              : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+          }`}
+        >
+          Financeiro
+        </button>
+      </div>
+
+      {current}
+    </div>
+  );
+}

--- a/apps/web/src/components/super-admin/UsuariosListClient.tsx
+++ b/apps/web/src/components/super-admin/UsuariosListClient.tsx
@@ -45,6 +45,7 @@ const PAPEL_LABEL: Record<string, string> = {
   financeiro:             "Financeiro",
   secretaria:             "Secretário(a)",
   secretaria_financeiro:  "Sec. + Financeiro",
+  admin_financeiro:       "Admin + Financeiro",
   professor:              "Professor(a)",
 };
 
@@ -459,6 +460,7 @@ function ListaUsuarios() {
                             <option value="financeiro">Financeiro</option>
                             <option value="secretaria">Secretário(a)</option>
                             <option value="secretaria_financeiro">Sec. + Financeiro</option>
+                            <option value="admin_financeiro">Admin + Financeiro</option>
                             <option value="professor">Professor(a)</option>
                           </select>
                         ) : (

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -1,7 +1,16 @@
 // Centralized role-permission mapping and helpers
 // Source: roles and permissions provided by product spec
 
-export type Papel = 'admin' | 'staff_admin' | 'financeiro' | 'secretaria' | 'aluno' | 'professor' | 'admin_escola'
+export type Papel =
+  | 'admin'
+  | 'staff_admin'
+  | 'financeiro'
+  | 'secretaria'
+  | 'secretaria_financeiro'
+  | 'admin_financeiro'
+  | 'aluno'
+  | 'professor'
+  | 'admin_escola'
 
 // Enumerate known permissions to get type-safety across the app
 export type Permission =
@@ -39,7 +48,17 @@ export type Permission =
   | 'enviar_mensagem'
 
 // Global role enum as used in profiles/app_metadata
-export type GlobalRole = 'super_admin' | 'admin' | 'professor' | 'aluno' | 'secretaria' | 'financeiro' | 'global_admin' | 'guest'
+export type GlobalRole =
+  | 'super_admin'
+  | 'admin'
+  | 'professor'
+  | 'aluno'
+  | 'secretaria'
+  | 'financeiro'
+  | 'secretaria_financeiro'
+  | 'admin_financeiro'
+  | 'global_admin'
+  | 'guest'
 
 export function normalizePapel(papel: Papel | string | null | undefined): Papel | null {
   if (!papel || typeof papel !== 'string') return null
@@ -54,6 +73,8 @@ export function normalizePapel(papel: Papel | string | null | undefined): Papel 
     secretaria: 'secretaria',
     secretario: 'secretaria',
     financeiro: 'financeiro',
+    secretaria_financeiro: 'secretaria_financeiro',
+    admin_financeiro: 'admin_financeiro',
     professor: 'professor',
     aluno: 'aluno',
   }
@@ -106,6 +127,46 @@ const ROLE_PERMISSIONS: Record<Papel, ReadonlySet<Permission>> = {
     'visualizar_relatorios_academicos',
   ]),
 
+  secretaria_financeiro: new Set<Permission>([
+    'criar_cobranca',
+    'editar_cobranca',
+    'registrar_pagamento',
+    'emitir_recibo',
+    'emitir_nota_fiscal',
+    'gerenciar_despesas',
+    'visualizar_fluxo_caixa',
+    'exportar_relatorios_contabeis',
+    'criar_matricula',
+    'editar_matricula',
+    'gerenciar_transferencias',
+    'gerenciar_turmas',
+    'lançar_notas',
+    'registrar_frequencia',
+    'emitir_documentos',
+    'enviar_comunicado',
+    'visualizar_relatorios_academicos',
+  ]),
+
+  admin_financeiro: new Set<Permission>([
+    'criar_usuario',
+    'editar_usuario',
+    'remover_usuario',
+    'configurar_escola',
+    'gerenciar_disciplinas',
+    'visualizar_relatorios_globais',
+    'visualizar_financeiro',
+    'visualizar_academico',
+    'registrar_pagamento',
+    'criar_matricula',
+    'criar_cobranca',
+    'editar_cobranca',
+    'emitir_recibo',
+    'emitir_nota_fiscal',
+    'gerenciar_despesas',
+    'visualizar_fluxo_caixa',
+    'exportar_relatorios_contabeis',
+  ]),
+
   professor: new Set<Permission>([
     'lançar_notas',
     'registrar_frequencia',
@@ -146,6 +207,29 @@ export function hasAnyPermission(papel: Papel | string | null | undefined, perms
   return false
 }
 
+
+export function temAcessoFinanceiro(role: GlobalRole | string | null | undefined): boolean {
+  return [
+    'financeiro',
+    'secretaria_financeiro',
+    'admin_financeiro',
+    'admin',
+    'super_admin',
+    'global_admin',
+  ].includes(String(role ?? ''))
+}
+
+export function temAcessoSecretaria(role: GlobalRole | string | null | undefined): boolean {
+  return [
+    'secretaria',
+    'secretaria_financeiro',
+    'admin_financeiro',
+    'admin',
+    'super_admin',
+    'global_admin',
+  ].includes(String(role ?? ''))
+}
+
 // Map papel (vínculo na escola) to global role to keep middleware/portals consistent
 export function mapPapelToGlobalRole(papel: Papel | string | null | undefined): GlobalRole {
   const normalized = normalizePapel(papel)
@@ -158,6 +242,10 @@ export function mapPapelToGlobalRole(papel: Papel | string | null | undefined): 
       return 'secretaria'
     case 'financeiro':
       return 'financeiro'
+    case 'secretaria_financeiro':
+      return 'secretaria_financeiro'
+    case 'admin_financeiro':
+      return 'admin_financeiro'
     case 'professor':
       return 'professor'
     case 'aluno':

--- a/apps/web/src/lib/roles.ts
+++ b/apps/web/src/lib/roles.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+export const PAPEIS_ESCOLA_VALIDOS = [
+  'admin_escola',
+  'admin',
+  'staff_admin',
+  'secretaria',
+  'financeiro',
+  'secretaria_financeiro',
+  'admin_financeiro',
+  'professor',
+  'aluno',
+] as const
+
+export type PapelEscola = (typeof PAPEIS_ESCOLA_VALIDOS)[number]
+
+export const papelEscolaSchema = z.enum(PAPEIS_ESCOLA_VALIDOS)
+
+export const allowedPapeisSet = new Set<string>(PAPEIS_ESCOLA_VALIDOS)

--- a/supabase/migrations/20260228120000_add_composite_user_roles.sql
+++ b/supabase/migrations/20260228120000_add_composite_user_roles.sql
@@ -1,0 +1,2 @@
+ALTER TYPE public.user_role ADD VALUE IF NOT EXISTS 'secretaria_financeiro';
+ALTER TYPE public.user_role ADD VALUE IF NOT EXISTS 'admin_financeiro';

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -11881,6 +11881,8 @@ export type Database = {
         | "aluno"
         | "secretaria"
         | "financeiro"
+        | "secretaria_financeiro"
+        | "admin_financeiro"
         | "encarregado"
     }
     CompositeTypes: {
@@ -12124,6 +12126,8 @@ export const Constants = {
         "aluno",
         "secretaria",
         "financeiro",
+        "secretaria_financeiro",
+        "admin_financeiro",
         "encarregado",
       ],
     },


### PR DESCRIPTION
### Motivation
- Introduce composite roles that combine secretaria and financeiro responsibilities so users can operate both portals and receive appropriate permissions and routing.
- Validate and centralize allowed school roles to prevent inconsistencies across APIs and admin tooling.

### Description
- Add `lib/roles.ts` with `PAPEIS_ESCOLA_VALIDOS`, `papelEscolaSchema` and `allowedPapeisSet`, and include a DB migration to add enum values `secretaria_financeiro` and `admin_financeiro` to `public.user_role`.
- Extend `lib/permissions.ts` to support new papel types, update `normalizePapel`, `ROLE_PERMISSIONS`, `mapPapelToGlobalRole`, and add helper checks `temAcessoFinanceiro` and `temAcessoSecretaria`.
- Update API request validation to use the new `papelEscolaSchema` and replace scattered allowed-role sets with `allowedPapeisSet` in super-admin and user update/create endpoints.
- Add UI and routing changes: new options in employee creation form, support in admin/super-admin user lists, login/redirect logic and school landing redirects for the new roles, plus a unified secretaria component `KlasseSecretariaUnificada` that toggles between "balcão" and "financeiro" modes and persists mode in `localStorage`.
- Update type definitions in `types/supabase.ts` to include the new enum values so TypeScript reflects DB changes.

### Testing
- Ran TypeScript check (`tsc --noEmit`) against the workspace and the build type updates succeeded.
- Executed the test suite (`yarn test`) and unit tests covering permissions and role-mapping passed.
- Performed a local Next.js build (`yarn build`) to validate bundling and page imports and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a313f68f1483288397be7fc0c700c6)