### PR TITLE
Add batch generation for boletim/certificado, matricula finalization hardening, and transitar RPCs

### DIFF
--- a/apps/web/src/app/api/secretaria/documentos/boletim/batch/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos/boletim/batch/route.ts
@@ -1,0 +1,133 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { supabaseServerTyped } from '@/lib/supabaseServer'
+import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
+import { requireRoleInSchool } from '@/lib/authz'
+
+export const dynamic = 'force-dynamic'
+
+const BodySchema = z.object({
+  turma_id: z.string().uuid(),
+  alunos_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function POST(request: Request) {
+  const supabase = await supabaseServerTyped<any>()
+  const { data: auth } = await supabase.auth.getUser()
+  const user = auth?.user
+  if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+  const parsed = BodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { turma_id, alunos_ids } = parsed.data
+
+  const { data: turma, error: turmaError } = await supabase
+    .from('turmas')
+    .select('id, escola_id, ano_letivo')
+    .eq('id', turma_id)
+    .single()
+
+  if (turmaError || !turma?.escola_id) {
+    return NextResponse.json({ ok: false, error: 'Turma não encontrada' }, { status: 404 })
+  }
+
+  const escolaId = turma.escola_id as string
+  const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId)
+  if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
+    return NextResponse.json({ ok: false, error: 'Escola inválida' }, { status: 403 })
+  }
+
+  const { error: authError } = await requireRoleInSchool({
+    supabase,
+    escolaId,
+    roles: ['secretaria', 'admin', 'admin_escola', 'staff_admin'],
+  })
+  if (authError) return authError
+
+  let query = supabase
+    .from('matriculas')
+    .select('id, aluno_id')
+    .eq('escola_id', escolaId)
+    .eq('turma_id', turma_id)
+    .in('status', ['concluido', 'reprovado'])
+
+  if (alunos_ids && alunos_ids.length > 0) query = query.in('aluno_id', alunos_ids)
+
+  const { data: matriculas, error: matError } = await query
+  if (matError) return NextResponse.json({ ok: false, error: matError.message }, { status: 400 })
+
+  const { data: turmaDisciplinas } = await supabase
+    .from('turma_disciplinas')
+    .select('id, conta_para_media_med, curso_matriz(disciplina_id, disciplinas_catalogo(nome))')
+    .eq('escola_id', escolaId)
+    .eq('turma_id', turma_id)
+
+  const tdMap = new Map<string, { nome: string; conta: boolean; disciplina_id: string | null }>()
+  for (const td of turmaDisciplinas || []) {
+    tdMap.set(td.id, {
+      nome: (td as any)?.curso_matriz?.disciplinas_catalogo?.nome ?? 'Disciplina',
+      conta: (td as any)?.conta_para_media_med !== false,
+      disciplina_id: (td as any)?.curso_matriz?.disciplina_id ?? null,
+    })
+  }
+
+  const snapshots: any[] = []
+
+  for (const m of matriculas || []) {
+    const { data: docRes, error: emitError } = await supabase.rpc('emitir_documento_final', {
+      p_escola_id: escolaId,
+      p_aluno_id: m.aluno_id,
+      p_ano_letivo: Number(turma.ano_letivo),
+      p_tipo_documento: 'declaracao_notas',
+    })
+    if (emitError || !docRes?.docId) continue
+
+    const { data: row } = await supabase
+      .from('documentos_emitidos')
+      .select('dados_snapshot, hash_validacao')
+      .eq('id', docRes.docId)
+      .eq('escola_id', escolaId)
+      .maybeSingle()
+
+    const { data: boletimRows } = await supabase
+      .from('vw_boletim_por_matricula')
+      .select('turma_disciplina_id, trimestre, nota_final')
+      .eq('escola_id', escolaId)
+      .eq('matricula_id', m.id)
+
+    const notasByDisciplina = new Map<string, { t1?: number | null; t2?: number | null; t3?: number | null }>()
+    for (const rowNota of boletimRows || []) {
+      const td = tdMap.get((rowNota as any).turma_disciplina_id)
+      if (!td?.disciplina_id) continue
+      const current = notasByDisciplina.get(td.disciplina_id) ?? {}
+      const tri = Number((rowNota as any).trimestre)
+      if (tri === 1) current.t1 = (rowNota as any).nota_final
+      if (tri === 2) current.t2 = (rowNota as any).nota_final
+      if (tri === 3) current.t3 = (rowNota as any).nota_final
+      notasByDisciplina.set(td.disciplina_id, current)
+    }
+
+    const disciplinas = Array.from(tdMap.values()).map((disc) => {
+      const notas = disc.disciplina_id ? notasByDisciplina.get(disc.disciplina_id) : undefined
+      return {
+        nome: disc.nome,
+        conta_para_media_med: disc.conta,
+        t1: notas?.t1 ?? null,
+        t2: notas?.t2 ?? null,
+        t3: notas?.t3 ?? null,
+      }
+    })
+
+    const snapshot = (row?.dados_snapshot || {}) as Record<string, any>
+    snapshots.push({
+      ...snapshot,
+      hash_validacao: row?.hash_validacao ?? snapshot.hash_validacao ?? null,
+      disciplinas,
+    })
+  }
+
+  return NextResponse.json({ ok: true, snapshots })
+}

--- a/apps/web/src/app/api/secretaria/documentos/certificado/batch/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos/certificado/batch/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { supabaseServerTyped } from '@/lib/supabaseServer'
+import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
+import { requireRoleInSchool } from '@/lib/authz'
+
+export const dynamic = 'force-dynamic'
+
+const BodySchema = z.object({
+  turma_id: z.string().uuid(),
+  alunos_ids: z.array(z.string().uuid()).optional(),
+})
+
+export async function POST(request: Request) {
+  const supabase = await supabaseServerTyped<any>()
+  const { data: auth } = await supabase.auth.getUser()
+  const user = auth?.user
+  if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+
+  const parsed = BodySchema.safeParse(await request.json().catch(() => null))
+  if (!parsed.success) {
+    return NextResponse.json({ ok: false, error: parsed.error.flatten() }, { status: 400 })
+  }
+
+  const { turma_id, alunos_ids } = parsed.data
+
+  const { data: turma, error: turmaError } = await supabase
+    .from('turmas')
+    .select('id, escola_id, ano_letivo')
+    .eq('id', turma_id)
+    .single()
+
+  if (turmaError || !turma?.escola_id) {
+    return NextResponse.json({ ok: false, error: 'Turma não encontrada' }, { status: 404 })
+  }
+
+  const escolaId = turma.escola_id as string
+  const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId)
+  if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
+    return NextResponse.json({ ok: false, error: 'Escola inválida' }, { status: 403 })
+  }
+
+  const { error: authError } = await requireRoleInSchool({
+    supabase,
+    escolaId,
+    roles: ['secretaria', 'admin', 'admin_escola', 'staff_admin'],
+  })
+  if (authError) return authError
+
+  let query = supabase
+    .from('matriculas')
+    .select('id, aluno_id')
+    .eq('escola_id', escolaId)
+    .eq('turma_id', turma_id)
+    .in('status', ['concluido', 'reprovado'])
+
+  if (alunos_ids && alunos_ids.length > 0) {
+    query = query.in('aluno_id', alunos_ids)
+  }
+
+  const { data: matriculas, error: matError } = await query
+  if (matError) return NextResponse.json({ ok: false, error: matError.message }, { status: 400 })
+
+  const snapshots: any[] = []
+  for (const m of matriculas || []) {
+    const { data: docRes, error: emitError } = await supabase.rpc('emitir_documento_final', {
+      p_escola_id: escolaId,
+      p_aluno_id: m.aluno_id,
+      p_ano_letivo: Number(turma.ano_letivo),
+      p_tipo_documento: 'certificado',
+    })
+    if (emitError || !docRes?.docId) continue
+
+    const { data: row } = await supabase
+      .from('documentos_emitidos')
+      .select('dados_snapshot, hash_validacao')
+      .eq('id', docRes.docId)
+      .eq('escola_id', escolaId)
+      .maybeSingle()
+
+    const snapshot = (row?.dados_snapshot || {}) as Record<string, any>
+    snapshots.push({ ...snapshot, hash_validacao: row?.hash_validacao ?? snapshot.hash_validacao ?? null })
+  }
+
+  return NextResponse.json({ ok: true, snapshots })
+}

--- a/apps/web/src/app/api/secretaria/matriculas/[matriculaId]/finalizar/route.ts
+++ b/apps/web/src/app/api/secretaria/matriculas/[matriculaId]/finalizar/route.ts
@@ -2,25 +2,27 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { supabaseServerTyped } from "@/lib/supabaseServer";
 import { requireRoleInSchool } from "@/lib/authz";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
 
 export const dynamic = "force-dynamic";
 
 const BodySchema = z.object({
-  novo_status: z.string().min(3),
-  motivo: z.string().optional(),
+  motivo: z.string().max(500).optional(),
+  is_override_manual: z.boolean().default(false),
+  status_override: z
+    .enum(["TRANSFERIDO", "ANULADO", "REPROVADO_POR_FALTAS"])
+    .optional(),
 });
 
-const ALLOWED_ROLES = ["secretaria", "admin", "admin_escola"] as const;
+const ALLOWED_ROLES = ["secretaria", "admin", "admin_escola", "staff_admin"] as const;
+const OVERRIDE_ROLES = ["admin", "admin_escola", "staff_admin"] as const;
 
 export async function POST(
   request: Request,
   { params }: { params: { matriculaId: string } }
 ) {
   try {
-    const { matriculaId } = params;
-    const body = await request.json();
-    const parsed = BodySchema.safeParse(body);
-
+    const parsed = BodySchema.safeParse(await request.json().catch(() => null));
     if (!parsed.success) {
       return NextResponse.json(
         { ok: false, error: parsed.error.issues?.[0]?.message || "Payload inválido" },
@@ -29,42 +31,85 @@ export async function POST(
     }
 
     const supabase = await supabaseServerTyped<any>();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
 
-    // 1. Get escola_id from matricula
-    const { data: matriculaData, error: matriculaError } = await supabase
-      .from('matriculas')
-      .select('escola_id')
-      .eq('id', matriculaId)
-      .single();
-
-    if (matriculaError || !matriculaData) {
-      return NextResponse.json({ ok: false, error: 'Matrícula não encontrada.' }, { status: 404 });
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
     }
 
-    const escolaId = matriculaData.escola_id;
+    const matriculaId = params.matriculaId;
+    const { data: matriculaData, error: matriculaError } = await supabase
+      .from("matriculas")
+      .select("escola_id")
+      .eq("id", matriculaId)
+      .single();
 
-    // 2. Authorization (check role in that school)
+    if (matriculaError || !matriculaData?.escola_id) {
+      return NextResponse.json({ ok: false, error: "Matrícula não encontrada." }, { status: 404 });
+    }
+
+    const escolaId = matriculaData.escola_id as string;
+    const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId);
+    if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
+      return NextResponse.json({ ok: false, error: "Escola inválida" }, { status: 403 });
+    }
+
     const { error: authError } = await requireRoleInSchool({
       supabase,
-      escolaId, // Pass the already resolved escolaId
+      escolaId,
       roles: [...ALLOWED_ROLES],
     });
     if (authError) return authError;
 
-    // Call RPC
-    const { error: rpcError } = await supabase.rpc("finalizar_matricula_anual", {
+    const isOverride = parsed.data.is_override_manual;
+    const overrideStatus = parsed.data.status_override;
+
+    if (isOverride && !overrideStatus) {
+      return NextResponse.json(
+        { ok: false, error: "status_override é obrigatório quando is_override_manual=true" },
+        { status: 400 }
+      );
+    }
+
+    if (isOverride) {
+      const { error: overrideAuthError } = await requireRoleInSchool({
+        supabase,
+        escolaId,
+        roles: [...OVERRIDE_ROLES],
+      });
+      if (overrideAuthError) {
+        return NextResponse.json(
+          { ok: false, error: "Apenas Admin/Direção pode aplicar override manual" },
+          { status: 403 }
+        );
+      }
+    }
+
+    const { data: result, error: rpcError } = await supabase.rpc("finalizar_matricula_blindada", {
       p_escola_id: escolaId,
       p_matricula_id: matriculaId,
-      p_novo_status: parsed.data.novo_status,
-      p_motivo: parsed.data.motivo,
+      p_motivo: parsed.data.motivo ?? null,
+      p_is_override_manual: isOverride,
+      p_status_override: isOverride ? overrideStatus?.toLowerCase() ?? null : null,
     });
 
     if (rpcError) {
+      if (rpcError.message.includes("Não é possível finalizar")) {
+        return NextResponse.json({ ok: false, error: rpcError.message }, { status: 422 });
+      }
+      if (rpcError.message.includes("Conflito de concorrência")) {
+        return NextResponse.json({ ok: false, error: rpcError.message }, { status: 409 });
+      }
       return NextResponse.json({ ok: false, error: rpcError.message }, { status: 400 });
     }
 
-    return NextResponse.json({ ok: true });
+    if (!result?.ok && result?.status === "incompleto") {
+      return NextResponse.json({ ok: false, error: result.message, motivos: result.motivos }, { status: 422 });
+    }
 
+    return NextResponse.json({ ok: true, status: result?.status, origem: result?.status_fecho_origem });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/apps/web/src/app/api/secretaria/matriculas/transitar/route.ts
+++ b/apps/web/src/app/api/secretaria/matriculas/transitar/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+import { requireRoleInSchool } from "@/lib/authz";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+
+export const dynamic = "force-dynamic";
+
+const BodySchema = z.object({
+  turma_origem_id: z.string().uuid(),
+  turma_destino_id: z.string().uuid(),
+  ano_letivo_origem: z.number().int(),
+  ano_letivo_destino: z.number().int(),
+  aluno_ids: z.array(z.string().uuid()).min(1),
+});
+
+const ALLOWED_ROLES = ["secretaria", "admin", "admin_escola", "staff_admin"] as const;
+
+export async function POST(request: Request) {
+  try {
+    const parsed = BodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { ok: false, error: parsed.error.issues?.[0]?.message || "Payload inválido" },
+        { status: 400 }
+      );
+    }
+
+    const supabase = await supabaseServerTyped<any>();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
+    }
+
+    const { data: turmaOrigem, error: turmaError } = await supabase
+      .from("turmas")
+      .select("escola_id")
+      .eq("id", parsed.data.turma_origem_id)
+      .single();
+
+    if (turmaError || !turmaOrigem?.escola_id) {
+      return NextResponse.json({ ok: false, error: "Turma de origem não encontrada." }, { status: 404 });
+    }
+
+    const escolaId = turmaOrigem.escola_id as string;
+    const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId);
+    if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
+      return NextResponse.json({ ok: false, error: "Escola inválida" }, { status: 403 });
+    }
+
+    const { error: authError } = await requireRoleInSchool({
+      supabase,
+      escolaId,
+      roles: [...ALLOWED_ROLES],
+    });
+    if (authError) return authError;
+
+    const { data: result, error: rpcError } = await supabase.rpc("fn_transitar_alunos", {
+      p_escola_id: escolaId,
+      p_turma_origem_id: parsed.data.turma_origem_id,
+      p_turma_destino_id: parsed.data.turma_destino_id,
+      p_ano_letivo_origem: parsed.data.ano_letivo_origem,
+      p_ano_letivo_dest: parsed.data.ano_letivo_destino,
+      p_aluno_ids: parsed.data.aluno_ids,
+    });
+
+    if (rpcError) {
+      return NextResponse.json({ ok: false, error: rpcError.message }, { status: 400 });
+    }
+
+    const rows = Array.isArray(result) ? result : [];
+    const sucesso = rows.filter((row: any) => row?.sucesso === true).length;
+    const falhas = rows.length - sucesso;
+
+    return NextResponse.json({
+      ok: true,
+      total: rows.length,
+      sucesso,
+      falhas,
+      resultados: rows,
+    });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/secretaria/DocumentosOficiaisBatchClient.tsx
+++ b/apps/web/src/components/secretaria/DocumentosOficiaisBatchClient.tsx
@@ -17,6 +17,7 @@ import {
 import { useEscolaId } from "@/hooks/useEscolaId";
 import { ModalShell } from "@/components/ui/ModalShell";
 import { PautaRapidaModal } from "@/components/secretaria/PautaRapidaModal";
+import { useOfficialDocs } from "@/hooks/useOfficialDocs";
 
 type TurmaItem = {
   id: string;
@@ -80,7 +81,7 @@ export default function DocumentosOficiaisBatchClient() {
   const [turmas, setTurmas] = useState<TurmaItem[]>([]);
   const [periodos, setPeriodos] = useState<PeriodoItem[]>([]);
   const [periodoId, setPeriodoId] = useState<string>("");
-  const [tipo, setTipo] = useState<"trimestral" | "anual">("trimestral");
+  const [tipo, setTipo] = useState<"trimestral" | "anual" | "boletim" | "certificado">("trimestral");
   const [hidePendencias, setHidePendencias] = useState(true);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [loading, setLoading] = useState(true);
@@ -103,6 +104,8 @@ export default function DocumentosOficiaisBatchClient() {
   const [pendenciasLoading, setPendenciasLoading] = useState(false);
   const [pendencias, setPendencias] = useState<PendenciaItem[]>([]);
   const [selectedPendencia, setSelectedPendencia] = useState<PendenciaItem | null>(null);
+
+  const { gerarBoletimBatch, gerarCertificadoBatch } = useOfficialDocs();
 
   const pendingPeriodoNumeros = useMemo(() => {
     const numeros = new Set<number>();
@@ -253,13 +256,24 @@ export default function DocumentosOficiaisBatchClient() {
       setToast({ message: "Selecione o trimestre.", type: "error" });
       return;
     }
-    if (tipo !== "trimestral" && tipo !== "anual") {
-      setToast({ message: "Tipo ainda não disponível.", type: "error" });
-      return;
-    }
+
     setSubmitting(true);
     setOptimisticJob("RUNNING");
     try {
+      if (tipo === "certificado" || tipo === "boletim") {
+        for (const turmaId of Array.from(selected)) {
+          if (tipo === "certificado") {
+            await gerarCertificadoBatch(turmaId, []);
+          } else {
+            await gerarBoletimBatch(turmaId, []);
+          }
+        }
+        setToast({ message: `PDFs de ${tipo} gerados com sucesso.`, type: "success" });
+        setSelected(new Set());
+        setOptimisticJob(null);
+        return;
+      }
+
       const res = await fetch("/api/secretaria/documentos-oficiais/lote", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -407,13 +421,13 @@ export default function DocumentosOficiaisBatchClient() {
         <div className="flex items-center gap-3">
           <select
             value={tipo}
-            onChange={(e) => setTipo(e.target.value as "trimestral" | "anual")}
+            onChange={(e) => setTipo(e.target.value as "trimestral" | "anual" | "boletim" | "certificado")}
             className="bg-white border border-slate-200 rounded-xl px-4 py-2 text-sm text-slate-700 outline-none focus:ring-2 focus:ring-[#1F6B3B]/20"
           >
             <option value="trimestral">Pauta Trimestral</option>
             <option value="anual">Pauta Anual</option>
-            <option value="boletim" disabled>Boletins (em breve)</option>
-            <option value="certificado" disabled>Certificados (em breve)</option>
+            <option value="boletim">Boletim</option>
+            <option value="certificado">Certificado</option>
           </select>
           <button
             className="flex items-center gap-2 bg-white border border-slate-200 px-4 py-2 rounded-xl text-sm font-medium text-slate-600 hover:bg-slate-50 transition-colors"
@@ -509,7 +523,7 @@ export default function DocumentosOficiaisBatchClient() {
             <option key={p.id} value={p.id}>{`Trimestre ${p.numero}`}</option>
           ))}
         </select>
-        <span className="text-[11px] text-slate-400">Boletins e certificados: em breve.</span>
+        <span className="text-[11px] text-slate-400">Boletins e certificados disponíveis em lote.</span>
         <button
           type="button"
           onClick={() => setManualRefresh(true)}

--- a/apps/web/src/hooks/useOfficialDocs.tsx
+++ b/apps/web/src/hooks/useOfficialDocs.tsx
@@ -3,6 +3,9 @@
 import { pdf } from '@react-pdf/renderer'
 import { MiniPautaV2 } from '@/templates/pdf/ministerio/MiniPautaV2'
 import { PautaTrimestralV1 } from '@/templates/pdf/ministerio/PautaTrimestralV1'
+import { CertificadoBatchV1, type CertificadoSnapshot } from '@/templates/pdf/ministerio/CertificadoBatchV1'
+import { BoletimBatchV1, type BoletimSnapshot } from '@/templates/pdf/ministerio/BoletimBatchV1'
+import { notaParaExtensoPTAO } from '@/lib/academico/extenso'
 
 type NotaTrimestre = {
   mac: number | null
@@ -52,6 +55,9 @@ const downloadBlob = (blob: Blob, filename: string) => {
   window.URL.revokeObjectURL(url)
 }
 
+const buildQrDataUrl = (value: string) =>
+  `https://quickchart.io/qr?text=${encodeURIComponent(value)}&margin=1&size=240`
+
 export const useOfficialDocs = () => {
   const gerarMiniPauta = async (payload: MiniPautaPayload, filename?: string) => {
     const blob = await pdf(<MiniPautaV2 {...payload} />).toBlob()
@@ -71,5 +77,53 @@ export const useOfficialDocs = () => {
     return blob
   }
 
-  return { gerarMiniPauta, gerarPautaTrimestral }
+  const gerarCertificadoBatch = async (turmaId: string, alunosIds: string[] = []) => {
+    const res = await fetch('/api/secretaria/documentos/certificado/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ turma_id: turmaId, alunos_ids: alunosIds }),
+    })
+    const json = await res.json().catch(() => null)
+    if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao carregar certificados')
+
+    const snapshots = ((json?.snapshots || []) as CertificadoSnapshot[]).map((item) => {
+      const mediaFinal = typeof item.media_final === 'number' ? item.media_final : null
+      return {
+        ...item,
+        media_extenso:
+          item.media_extenso ?? (typeof mediaFinal === 'number' ? notaParaExtensoPTAO(mediaFinal) : null),
+        qrCodeDataUrl: item.hash_validacao ? buildQrDataUrl(item.hash_validacao) : null,
+      }
+    })
+
+    const blob = await pdf(<CertificadoBatchV1 snapshots={snapshots} />).toBlob()
+    downloadBlob(blob, `Certificados_${turmaId}_${Date.now()}.pdf`)
+    return blob
+  }
+
+  const gerarBoletimBatch = async (turmaId: string, alunosIds: string[] = []) => {
+    const res = await fetch('/api/secretaria/documentos/boletim/batch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ turma_id: turmaId, alunos_ids: alunosIds }),
+    })
+    const json = await res.json().catch(() => null)
+    if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao carregar boletins')
+
+    const snapshots = ((json?.snapshots || []) as BoletimSnapshot[]).map((item) => {
+      const mediaFinal = typeof item.media_final === 'number' ? item.media_final : null
+      return {
+        ...item,
+        media_extenso:
+          item.media_extenso ?? (typeof mediaFinal === 'number' ? notaParaExtensoPTAO(mediaFinal) : null),
+        qrCodeDataUrl: item.hash_validacao ? buildQrDataUrl(item.hash_validacao) : null,
+      }
+    })
+
+    const blob = await pdf(<BoletimBatchV1 snapshots={snapshots} />).toBlob()
+    downloadBlob(blob, `Boletins_${turmaId}_${Date.now()}.pdf`)
+    return blob
+  }
+
+  return { gerarMiniPauta, gerarPautaTrimestral, gerarCertificadoBatch, gerarBoletimBatch }
 }

--- a/apps/web/src/lib/academico/extenso.ts
+++ b/apps/web/src/lib/academico/extenso.ts
@@ -1,0 +1,29 @@
+export function notaParaExtensoPTAO(nota: number): string {
+  const notaArredondada = Math.round(nota)
+  const mapa = [
+    'Zero',
+    'Um',
+    'Dois',
+    'Três',
+    'Quatro',
+    'Cinco',
+    'Seis',
+    'Sete',
+    'Oito',
+    'Nove',
+    'Dez',
+    'Onze',
+    'Doze',
+    'Treze',
+    'Catorze',
+    'Quinze',
+    'Dezasseis',
+    'Dezassete',
+    'Dezoito',
+    'Dezanove',
+    'Vinte',
+  ]
+
+  if (notaArredondada < 0 || notaArredondada > 20) return 'Nota inválida'
+  return `${mapa[notaArredondada]} valores`
+}

--- a/apps/web/src/templates/pdf/ministerio/BoletimBatchV1.tsx
+++ b/apps/web/src/templates/pdf/ministerio/BoletimBatchV1.tsx
@@ -1,0 +1,66 @@
+import { Document, Page, StyleSheet, Text, View, Image } from '@react-pdf/renderer'
+
+export type BoletimDisciplina = {
+  nome: string
+  conta_para_media_med: boolean
+  t1?: number | null
+  t2?: number | null
+  t3?: number | null
+}
+
+export type BoletimSnapshot = {
+  aluno_nome: string
+  turma_nome?: string | null
+  ano_letivo?: number | string | null
+  media_final?: number | null
+  media_extenso?: string | null
+  hash_validacao?: string | null
+  qrCodeDataUrl?: string | null
+  disciplinas: BoletimDisciplina[]
+}
+
+const s = StyleSheet.create({
+  page: { padding: 24, fontSize: 10, fontFamily: 'Helvetica' },
+  title: { fontSize: 16, marginBottom: 8, fontWeight: 700 },
+  row: { marginBottom: 4 },
+  tableHeader: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#d1d5db', marginTop: 8, paddingBottom: 4 },
+  tableRow: { flexDirection: 'row', borderBottomWidth: 1, borderBottomColor: '#f1f5f9', paddingVertical: 4 },
+})
+
+export function BoletimBatchV1({ snapshots }: { snapshots: BoletimSnapshot[] }) {
+  return (
+    <Document>
+      {snapshots.map((item, idx) => (
+        <Page key={`${item.aluno_nome}-${idx}`} size="A4" style={s.page}>
+          <Text style={s.title}>Boletim Escolar</Text>
+          <View style={s.row}><Text>Aluno: {item.aluno_nome}</Text></View>
+          <View style={s.row}><Text>Turma: {item.turma_nome ?? '—'} • Ano letivo: {String(item.ano_letivo ?? '—')}</Text></View>
+          <View style={s.row}><Text>Média final: {item.media_final ?? '—'} ({item.media_extenso ?? '—'})</Text></View>
+
+          <View style={s.tableHeader}>
+            <Text style={{ width: '52%' }}>Disciplina</Text>
+            <Text style={{ width: '12%' }}>T1</Text>
+            <Text style={{ width: '12%' }}>T2</Text>
+            <Text style={{ width: '12%' }}>T3</Text>
+            <Text style={{ width: '12%' }}>Tipo</Text>
+          </View>
+
+          {item.disciplinas.map((d, i) => (
+            <View key={`${d.nome}-${i}`} style={s.tableRow}>
+              <Text style={{ width: '52%' }}>{d.nome}</Text>
+              <Text style={{ width: '12%' }}>{d.t1 ?? '—'}</Text>
+              <Text style={{ width: '12%' }}>{d.t2 ?? '—'}</Text>
+              <Text style={{ width: '12%' }}>{d.t3 ?? '—'}</Text>
+              <Text style={{ width: '12%' }}>{d.conta_para_media_med ? 'Oficial' : 'Não oficial'}</Text>
+            </View>
+          ))}
+
+          <View style={{ marginTop: 16, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' }}>
+            <Text>Hash validação: {item.hash_validacao ?? '—'}</Text>
+            {item.qrCodeDataUrl ? <Image src={item.qrCodeDataUrl} style={{ width: 76, height: 76 }} /> : <Text>QR indisponível</Text>}
+          </View>
+        </Page>
+      ))}
+    </Document>
+  )
+}

--- a/apps/web/src/templates/pdf/ministerio/CertificadoBatchV1.tsx
+++ b/apps/web/src/templates/pdf/ministerio/CertificadoBatchV1.tsx
@@ -1,0 +1,46 @@
+import { Document, Page, StyleSheet, Text, View, Image } from '@react-pdf/renderer'
+
+export type CertificadoSnapshot = {
+  aluno_nome: string
+  aluno_bi?: string | null
+  turma_nome?: string | null
+  ano_letivo?: number | string | null
+  media_final?: number | null
+  media_extenso?: string | null
+  hash_validacao?: string | null
+  qrCodeDataUrl?: string | null
+}
+
+const s = StyleSheet.create({
+  page: { padding: 28, fontSize: 11, fontFamily: 'Helvetica' },
+  title: { fontSize: 18, marginBottom: 8, fontWeight: 700 },
+  subtitle: { marginBottom: 16 },
+  row: { marginBottom: 6 },
+  label: { fontWeight: 700 },
+  footer: { marginTop: 24, display: 'flex', flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
+})
+
+export function CertificadoBatchV1({ snapshots }: { snapshots: CertificadoSnapshot[] }) {
+  return (
+    <Document>
+      {snapshots.map((item, idx) => (
+        <Page key={`${item.aluno_nome}-${idx}`} size="A4" style={s.page}>
+          <Text style={s.title}>Certificado de Habilitações</Text>
+          <Text style={s.subtitle}>Documento oficial emitido digitalmente.</Text>
+
+          <View style={s.row}><Text><Text style={s.label}>Aluno:</Text> {item.aluno_nome}</Text></View>
+          <View style={s.row}><Text><Text style={s.label}>BI:</Text> {item.aluno_bi ?? '—'}</Text></View>
+          <View style={s.row}><Text><Text style={s.label}>Turma:</Text> {item.turma_nome ?? '—'}</Text></View>
+          <View style={s.row}><Text><Text style={s.label}>Ano letivo:</Text> {String(item.ano_letivo ?? '—')}</Text></View>
+          <View style={s.row}><Text><Text style={s.label}>Média final:</Text> {item.media_final ?? '—'}</Text></View>
+          <View style={s.row}><Text><Text style={s.label}>Média por extenso:</Text> {item.media_extenso ?? '—'}</Text></View>
+
+          <View style={s.footer}>
+            <Text>Hash validação: {item.hash_validacao ?? '—'}</Text>
+            {item.qrCodeDataUrl ? <Image src={item.qrCodeDataUrl} style={{ width: 82, height: 82 }} /> : <Text>QR indisponível</Text>}
+          </View>
+        </Page>
+      ))}
+    </Document>
+  )
+}

--- a/supabase/migrations/20261201090000_matriculas_gradeengine_transicao_hardening.sql
+++ b/supabase/migrations/20261201090000_matriculas_gradeengine_transicao_hardening.sql
@@ -1,0 +1,489 @@
+BEGIN;
+
+ALTER TABLE public.matriculas
+  ADD COLUMN IF NOT EXISTS motivo_fecho text,
+  ADD COLUMN IF NOT EXISTS data_fecho timestamptz,
+  ADD COLUMN IF NOT EXISTS status_fecho_origem text DEFAULT 'manual',
+  ADD COLUMN IF NOT EXISTS origem_transicao_matricula_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'matriculas_status_fecho_origem_check'
+      AND conrelid = 'public.matriculas'::regclass
+  ) THEN
+    ALTER TABLE public.matriculas
+      ADD CONSTRAINT matriculas_status_fecho_origem_check
+      CHECK (status_fecho_origem IN ('gradeengine', 'override_admin', 'manual'));
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'matriculas_status_check'
+      AND conrelid = 'public.matriculas'::regclass
+  ) THEN
+    ALTER TABLE public.matriculas DROP CONSTRAINT matriculas_status_check;
+  END IF;
+END;
+$$;
+
+ALTER TABLE public.matriculas
+  ADD CONSTRAINT matriculas_status_check
+  CHECK (
+    status = ANY (ARRAY[
+      'pendente'::text,
+      'ativa'::text,
+      'ativo'::text,
+      'inativo'::text,
+      'concluido'::text,
+      'reprovado'::text,
+      'transferido'::text,
+      'anulado'::text,
+      'reprovado_por_faltas'::text,
+      'trancado'::text,
+      'desistente'::text,
+      'indefinido'::text,
+      'rascunho'::text
+    ])
+  );
+
+ALTER TABLE public.matriculas
+  ADD CONSTRAINT matriculas_origem_transicao_fk
+  FOREIGN KEY (origem_transicao_matricula_id)
+  REFERENCES public.matriculas(id)
+  ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_matriculas_origem_transicao
+  ON public.matriculas (origem_transicao_matricula_id)
+  WHERE origem_transicao_matricula_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.canonicalize_matricula_status_text(input text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE PARALLEL SAFE
+SET search_path TO 'public'
+AS $$
+DECLARE v text := lower(trim(coalesce(input, '')));
+BEGIN
+  IF v = '' THEN RETURN 'indefinido'; END IF;
+
+  IF v IN ('ativa','ativo','active','em_andamento','matriculado') THEN RETURN 'ativa'; END IF;
+  IF v IN ('concluida','concluido','graduado','aprovado') THEN RETURN 'concluido'; END IF;
+  IF v IN ('reprovada','reprovado') THEN RETURN 'reprovado'; END IF;
+  IF v IN ('reprovado_por_faltas') THEN RETURN 'reprovado_por_faltas'; END IF;
+  IF v IN ('transferido','transferida') THEN RETURN 'transferido'; END IF;
+  IF v IN ('anulado','anulada') THEN RETURN 'anulado'; END IF;
+  IF v IN ('pendente','aguardando') THEN RETURN 'pendente'; END IF;
+  IF v IN ('trancado','suspenso','desistente','inativo') THEN RETURN 'inativo'; END IF;
+  RETURN 'indefinido';
+END
+$$;
+
+CREATE TABLE IF NOT EXISTS public.matriculas_status_audit (
+  id bigserial PRIMARY KEY,
+  matricula_id uuid NOT NULL REFERENCES public.matriculas(id) ON DELETE CASCADE,
+  status_anterior text NOT NULL,
+  status_novo text NOT NULL,
+  alterado_por uuid NULL,
+  origem text NOT NULL,
+  motivo text NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.trg_matriculas_status_audit()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    INSERT INTO public.matriculas_status_audit (
+      matricula_id,
+      status_anterior,
+      status_novo,
+      alterado_por,
+      origem,
+      motivo
+    ) VALUES (
+      NEW.id,
+      OLD.status,
+      NEW.status,
+      nullif(current_setting('request.jwt.claim.sub', true), '')::uuid,
+      COALESCE(NEW.status_fecho_origem, 'sql_direct'),
+      NEW.motivo_fecho
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS t_matriculas_status_audit ON public.matriculas;
+CREATE TRIGGER t_matriculas_status_audit
+BEFORE UPDATE OF status ON public.matriculas
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_matriculas_status_audit();
+
+CREATE OR REPLACE FUNCTION public.gradeengine_calcular_situacao(
+  p_matricula_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_escola_id uuid := public.current_tenant_escola_id();
+  v_matricula record;
+  v_missing_count bigint := 0;
+  v_has_reprovacao boolean := false;
+BEGIN
+  IF v_escola_id IS NULL THEN
+    RAISE EXCEPTION 'AUTH: escola_id inválido.';
+  END IF;
+
+  IF NOT public.user_has_role_in_school(v_escola_id, ARRAY['secretaria', 'admin', 'admin_escola', 'staff_admin']) THEN
+    RAISE EXCEPTION 'AUTH: Permissão negada.';
+  END IF;
+
+  SELECT id, escola_id
+  INTO v_matricula
+  FROM public.matriculas
+  WHERE id = p_matricula_id
+    AND escola_id = v_escola_id;
+
+  IF v_matricula.id IS NULL THEN
+    RAISE EXCEPTION 'DATA: Matrícula não encontrada.';
+  END IF;
+
+  SELECT COALESCE(SUM(missing_count), 0)
+  INTO v_missing_count
+  FROM public.vw_boletim_por_matricula
+  WHERE matricula_id = p_matricula_id;
+
+  IF v_missing_count > 0 THEN
+    RETURN jsonb_build_object(
+      'situacao_final', 'incompleto',
+      'motivos', jsonb_build_array('Existem disciplinas sem notas lançadas ou pautas abertas.')
+    );
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT disciplina_id,
+             COUNT(*) FILTER (WHERE nota_final IS NOT NULL) AS trimestres_com_nota,
+             AVG(nota_final) FILTER (WHERE nota_final IS NOT NULL) AS media_final
+      FROM public.vw_boletim_por_matricula
+      WHERE matricula_id = p_matricula_id
+      GROUP BY disciplina_id
+    ) s
+    WHERE s.trimestres_com_nota < 3 OR s.media_final IS NULL
+  ) THEN
+    RETURN jsonb_build_object(
+      'situacao_final', 'incompleto',
+      'motivos', jsonb_build_array('Não existem notas fechadas para todos os trimestres.')
+    );
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM (
+      SELECT disciplina_id,
+             AVG(nota_final) FILTER (WHERE nota_final IS NOT NULL) AS media_final
+      FROM public.vw_boletim_por_matricula
+      WHERE matricula_id = p_matricula_id
+      GROUP BY disciplina_id
+    ) s
+    WHERE s.media_final < 10
+  )
+  INTO v_has_reprovacao;
+
+  RETURN jsonb_build_object(
+    'situacao_final', CASE WHEN v_has_reprovacao THEN 'reprovado' ELSE 'aprovado' END,
+    'motivos', jsonb_build_array()
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.finalizar_matricula_blindada(
+  p_escola_id uuid,
+  p_matricula_id uuid,
+  p_motivo text DEFAULT NULL,
+  p_is_override_manual boolean DEFAULT false,
+  p_status_override text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_escola_id uuid := public.current_tenant_escola_id();
+  v_actor_id uuid := auth.uid();
+  v_matricula record;
+  v_has_role boolean := false;
+  v_is_admin boolean := false;
+  v_status_calculado text;
+  v_origem text;
+  v_grade jsonb;
+BEGIN
+  IF v_escola_id IS NULL OR p_escola_id IS DISTINCT FROM v_escola_id THEN
+    RAISE EXCEPTION 'AUTH: escola_id inválido.';
+  END IF;
+
+  SELECT public.user_has_role_in_school(v_escola_id, ARRAY['secretaria', 'admin', 'admin_escola', 'staff_admin']) INTO v_has_role;
+  IF NOT v_has_role THEN
+    RAISE EXCEPTION 'AUTH: Permissão negada.';
+  END IF;
+
+  SELECT * INTO v_matricula
+  FROM public.matriculas
+  WHERE id = p_matricula_id
+    AND escola_id = v_escola_id
+  FOR UPDATE;
+
+  IF v_matricula.id IS NULL THEN
+    RAISE EXCEPTION 'DATA: Matrícula não encontrada.';
+  END IF;
+
+  IF public.canonicalize_matricula_status_text(v_matricula.status) NOT IN ('ativa', 'pendente') THEN
+    RAISE EXCEPTION 'LOGIC: Esta matrícula já foi finalizada ou não está em andamento.';
+  END IF;
+
+  IF p_is_override_manual THEN
+    SELECT public.user_has_role_in_school(v_escola_id, ARRAY['admin', 'admin_escola', 'staff_admin']) INTO v_is_admin;
+    IF NOT v_is_admin THEN
+      RAISE EXCEPTION 'AUTH: Apenas admin/direção pode aplicar override manual.';
+    END IF;
+
+    IF p_status_override IS NULL THEN
+      RAISE EXCEPTION 'LOGIC: status_override é obrigatório quando override manual está activo.';
+    END IF;
+
+    v_status_calculado := public.canonicalize_matricula_status_text(p_status_override);
+    IF v_status_calculado NOT IN ('transferido', 'anulado', 'reprovado_por_faltas') THEN
+      RAISE EXCEPTION 'LOGIC: Override inválido. Use transferido, anulado ou reprovado_por_faltas.';
+    END IF;
+    v_origem := 'override_admin';
+  ELSE
+    v_grade := public.gradeengine_calcular_situacao(p_matricula_id);
+
+    IF COALESCE(v_grade->>'situacao_final', '') = 'incompleto' THEN
+      RETURN jsonb_build_object(
+        'ok', false,
+        'status', 'incompleto',
+        'message', 'Não é possível finalizar. Existem disciplinas sem notas lançadas ou pautas abertas.',
+        'motivos', COALESCE(v_grade->'motivos', '[]'::jsonb)
+      );
+    END IF;
+
+    IF v_grade->>'situacao_final' = 'aprovado' THEN
+      v_status_calculado := 'concluido';
+    ELSIF v_grade->>'situacao_final' = 'reprovado' THEN
+      v_status_calculado := 'reprovado';
+    ELSE
+      RAISE EXCEPTION 'LOGIC: Situação final desconhecida retornada pelo GradeEngine.';
+    END IF;
+
+    v_origem := 'gradeengine';
+  END IF;
+
+  UPDATE public.matriculas
+  SET status = v_status_calculado,
+      motivo_fecho = NULLIF(trim(p_motivo), ''),
+      data_fecho = now(),
+      status_fecho_origem = v_origem,
+      updated_at = now()
+  WHERE id = p_matricula_id
+    AND escola_id = v_escola_id
+    AND public.canonicalize_matricula_status_text(status) IN ('ativa', 'pendente');
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'LOGIC: Conflito de concorrência ao finalizar matrícula.';
+  END IF;
+
+  INSERT INTO public.audit_logs (escola_id, actor_id, action, entity, entity_id, portal, details)
+  VALUES (
+    v_escola_id,
+    v_actor_id,
+    'MATRICULA_FINALIZADA_BLINDADA',
+    'matriculas',
+    p_matricula_id::text,
+    'secretaria',
+    jsonb_build_object(
+      'status', v_status_calculado,
+      'origem', v_origem,
+      'motivo', NULLIF(trim(p_motivo), '')
+    )
+  );
+
+  IF v_status_calculado IN ('concluido', 'reprovado') THEN
+    PERFORM public.gerar_historico_anual(p_matricula_id);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'status', v_status_calculado,
+    'status_fecho_origem', v_origem
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_transitar_alunos(
+  p_escola_id uuid,
+  p_turma_origem_id uuid,
+  p_turma_destino_id uuid,
+  p_ano_letivo_origem int,
+  p_ano_letivo_dest int,
+  p_aluno_ids uuid[]
+)
+RETURNS TABLE (
+  aluno_id uuid,
+  sucesso boolean,
+  erro text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_escola_id uuid := public.current_tenant_escola_id();
+  v_aluno_id uuid;
+  v_matricula_origem record;
+  v_turma_destino record;
+  v_tem_curriculo_publicado boolean;
+  v_total_em_atraso numeric(14,2);
+BEGIN
+  IF v_escola_id IS NULL OR p_escola_id IS DISTINCT FROM v_escola_id THEN
+    RAISE EXCEPTION 'AUTH: escola_id inválido.';
+  END IF;
+
+  IF NOT public.user_has_role_in_school(v_escola_id, ARRAY['secretaria', 'admin', 'admin_escola', 'staff_admin']) THEN
+    RAISE EXCEPTION 'AUTH: Permissão negada.';
+  END IF;
+
+  SELECT t.id, t.curso_id, t.classe_id, t.ano_letivo
+  INTO v_turma_destino
+  FROM public.turmas t
+  WHERE t.id = p_turma_destino_id
+    AND t.escola_id = p_escola_id;
+
+  IF v_turma_destino.id IS NULL THEN
+    RAISE EXCEPTION 'DATA: Turma de destino não encontrada.';
+  END IF;
+
+  IF v_turma_destino.ano_letivo <> p_ano_letivo_dest THEN
+    RAISE EXCEPTION 'LOGIC: Turma de destino fora do ano letivo de destino.';
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.anos_letivos al
+    JOIN public.curso_curriculos cc ON cc.ano_letivo_id = al.id
+    WHERE al.escola_id = p_escola_id
+      AND al.ano = p_ano_letivo_dest
+      AND cc.escola_id = p_escola_id
+      AND cc.curso_id = v_turma_destino.curso_id
+      AND (cc.classe_id IS NULL OR cc.classe_id = v_turma_destino.classe_id)
+      AND cc.status = 'published'
+  ) INTO v_tem_curriculo_publicado;
+
+  IF NOT v_tem_curriculo_publicado THEN
+    RAISE EXCEPTION 'LOGIC: Estrutura académica do ano destino não está pronta (currículo não publicado).';
+  END IF;
+
+  FOREACH v_aluno_id IN ARRAY p_aluno_ids LOOP
+    BEGIN
+      SELECT m.id, m.status, m.aluno_id
+      INTO v_matricula_origem
+      FROM public.matriculas m
+      WHERE m.aluno_id = v_aluno_id
+        AND m.turma_id = p_turma_origem_id
+        AND m.ano_letivo = p_ano_letivo_origem
+        AND m.escola_id = p_escola_id
+      LIMIT 1;
+
+      IF v_matricula_origem.id IS NULL THEN
+        RETURN QUERY SELECT v_aluno_id, false, 'Matrícula de origem não encontrada';
+        CONTINUE;
+      END IF;
+
+      IF public.canonicalize_matricula_status_text(v_matricula_origem.status) <> 'concluido' THEN
+        IF public.canonicalize_matricula_status_text(v_matricula_origem.status) = 'reprovado' THEN
+          RETURN QUERY SELECT v_aluno_id, false, 'Aluno reprovado na classe de origem';
+        ELSE
+          RETURN QUERY SELECT v_aluno_id, false, 'Notas incompletas ou matrícula não concluída';
+        END IF;
+        CONTINUE;
+      END IF;
+
+      SELECT COALESCE(SUM(GREATEST(COALESCE(m.valor_previsto, m.valor, 0) - COALESCE(m.valor_pago_total, 0), 0)), 0)
+      INTO v_total_em_atraso
+      FROM public.mensalidades m
+      WHERE m.escola_id = p_escola_id
+        AND m.matricula_id = v_matricula_origem.id
+        AND m.status NOT IN ('pago', 'isento', 'cancelado');
+
+      IF COALESCE(v_total_em_atraso, 0) > 0 THEN
+        RETURN QUERY SELECT v_aluno_id, false, 'Dívidas em aberto na matrícula anterior';
+        CONTINUE;
+      END IF;
+
+      IF EXISTS (
+        SELECT 1
+        FROM public.matriculas m
+        WHERE m.escola_id = p_escola_id
+          AND m.aluno_id = v_aluno_id
+          AND m.ano_letivo = p_ano_letivo_dest
+          AND m.turma_id = p_turma_destino_id
+      ) THEN
+        RETURN QUERY SELECT v_aluno_id, false, 'Aluno já possui matrícula na turma de destino';
+        CONTINUE;
+      END IF;
+
+      INSERT INTO public.matriculas (
+        escola_id,
+        aluno_id,
+        turma_id,
+        ano_letivo,
+        status,
+        ativo,
+        data_matricula,
+        origem_transicao_matricula_id,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        p_escola_id,
+        v_aluno_id,
+        p_turma_destino_id,
+        p_ano_letivo_dest,
+        'pendente',
+        true,
+        CURRENT_DATE,
+        v_matricula_origem.id,
+        now(),
+        now()
+      );
+
+      RETURN QUERY SELECT v_aluno_id, true, NULL::text;
+    EXCEPTION
+      WHEN OTHERS THEN
+        RETURN QUERY SELECT v_aluno_id, false, SQLERRM;
+    END;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.gradeengine_calcular_situacao(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.finalizar_matricula_blindada(uuid, uuid, text, boolean, text) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_transitar_alunos(uuid, uuid, uuid, int, int, uuid[]) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20261201100000_snapshot_media_extenso_documentos.sql
+++ b/supabase/migrations/20261201100000_snapshot_media_extenso_documentos.sql
@@ -1,0 +1,132 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.nota_para_extenso_ptao(p_nota numeric)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_nota int := ROUND(COALESCE(p_nota, 0));
+BEGIN
+  IF v_nota < 0 OR v_nota > 20 THEN
+    RETURN 'Nota inválida';
+  END IF;
+
+  RETURN (
+    ARRAY[
+      'Zero', 'Um', 'Dois', 'Três', 'Quatro', 'Cinco', 'Seis', 'Sete', 'Oito', 'Nove',
+      'Dez', 'Onze', 'Doze', 'Treze', 'Catorze', 'Quinze', 'Dezasseis', 'Dezassete', 'Dezoito', 'Dezanove', 'Vinte'
+    ]
+  )[v_nota + 1] || ' valores';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.emitir_documento_final(
+  p_escola_id uuid,
+  p_aluno_id uuid,
+  p_ano_letivo int,
+  p_tipo_documento text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_has_permission boolean;
+  v_historico_ano record;
+  v_aluno record;
+  v_turma record;
+  v_documento_emitido record;
+  v_numero_sequencial int;
+  v_hash_validacao text;
+  v_snapshot jsonb;
+  v_escola_id uuid := public.current_tenant_escola_id();
+  v_media_final numeric(6,2);
+  v_media_extenso text;
+BEGIN
+  IF v_escola_id IS NULL OR p_escola_id IS DISTINCT FROM v_escola_id THEN
+    RAISE EXCEPTION 'AUTH: escola_id inválido.';
+  END IF;
+
+  SELECT public.user_has_role_in_school(v_escola_id, ARRAY['secretaria', 'admin', 'admin_escola'])
+  INTO v_has_permission;
+  IF NOT v_has_permission THEN
+    RAISE EXCEPTION 'AUTH: Permissão negada.';
+  END IF;
+
+  SELECT * INTO v_historico_ano FROM public.historico_anos
+  WHERE escola_id = v_escola_id AND aluno_id = p_aluno_id AND ano_letivo = p_ano_letivo;
+
+  IF v_historico_ano.id IS NULL THEN
+    RAISE EXCEPTION 'DATA: Histórico para o ano letivo % não encontrado para este aluno. O ano precisa ser finalizado primeiro.', p_ano_letivo;
+  END IF;
+
+  SELECT nome, bi_numero INTO v_aluno FROM public.alunos WHERE id = p_aluno_id;
+  SELECT nome, turno INTO v_turma FROM public.turmas WHERE id = v_historico_ano.turma_id;
+
+  v_media_final := COALESCE(
+    v_historico_ano.media_geral,
+    (
+      SELECT ROUND(AVG(hd.media_final))::numeric(6,2)
+      FROM public.historico_disciplinas hd
+      WHERE hd.historico_ano_id = v_historico_ano.id
+    ),
+    0
+  );
+  v_media_extenso := public.nota_para_extenso_ptao(v_media_final);
+
+  SELECT public.next_documento_numero(v_escola_id) INTO v_numero_sequencial;
+  v_hash_validacao := encode(sha256(random()::text::bytea), 'hex');
+
+  v_snapshot := jsonb_build_object(
+    'aluno_id', p_aluno_id,
+    'aluno_nome', v_aluno.nome,
+    'aluno_bi', v_aluno.bi_numero,
+    'matricula_id', v_historico_ano.matricula_id,
+    'turma_id', v_historico_ano.turma_id,
+    'turma_nome', v_turma.nome,
+    'turma_turno', v_turma.turno,
+    'ano_letivo', v_historico_ano.ano_letivo,
+    'status_final', v_historico_ano.status_final,
+    'media_final', v_media_final,
+    'media_extenso', v_media_extenso,
+    'tipo_documento', p_tipo_documento,
+    'numero_sequencial', v_numero_sequencial,
+    'hash_validacao', v_hash_validacao
+  );
+
+  INSERT INTO public.documentos_emitidos
+    (escola_id, aluno_id, numero_sequencial, tipo, dados_snapshot, created_by, hash_validacao)
+  VALUES
+    (v_escola_id, p_aluno_id, v_numero_sequencial, p_tipo_documento, v_snapshot, v_actor_id, v_hash_validacao)
+  RETURNING * INTO v_documento_emitido;
+
+  INSERT INTO public.audit_logs (escola_id, actor_id, action, entity, entity_id, portal, details)
+  VALUES (
+    v_escola_id,
+    v_actor_id,
+    'DOCUMENTO_FINAL_EMITIDO',
+    'documentos_emitidos',
+    v_documento_emitido.id::text,
+    'secretaria',
+    v_snapshot
+  );
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'docId', v_documento_emitido.id,
+    'publicId', v_documento_emitido.public_id,
+    'hash', v_documento_emitido.hash_validacao,
+    'tipo', v_documento_emitido.tipo,
+    'media_final', v_media_final,
+    'media_extenso', v_media_extenso
+  );
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.nota_para_extenso_ptao(numeric) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation

- Provide bulk generation of official documents (`boletim` and `certificado`) and client-side download support for schools. 
- Harden matrícula finalization with grade-engine validation and optional admin override flows to avoid incorrect state transitions. 
- Add a safe, auditable transition flow for moving students between turmas and centralize document issuance logic in the DB. 

### Description

- Adds two new API endpoints `POST /api/secretaria/documentos/boletim/batch` and `POST /api/secretaria/documentos/certificado/batch` which call the new RPC `emitir_documento_final` and return snapshots used to build PDFs. 
- Introduces client-side support via `useOfficialDocs` and updates `DocumentosOficiaisBatchClient` to allow selecting `boletim` and `certificado` and to call `gerarBoletimBatch` / `gerarCertificadoBatch`; also adds PDF templates `BoletimBatchV1` and `CertificadoBatchV1` and QR/hash helpers. 
- Enhances matrícula finalization endpoint to use `finalizar_matricula_blindada` RPC, add manual override support (`is_override_manual`, `status_override`) restricted to admin roles, improve error mappings (422/409), and validate tenant access via `resolveEscolaIdForUser`. 
- Adds new endpoint `POST /api/secretaria/matriculas/transitar` which invokes `fn_transitar_alunos` RPC to transit multiple students between turmas with per-aluno results. 
- Adds utility `notaParaExtensoPTAO` on both DB (`nota_para_extenso_ptao`) and frontend (`lib/academico/extenso.ts`) and integrates it into PDFs; creates/updates many DB objects and functions in migrations including `finalizar_matricula_blindada`, `gradeengine_calcular_situacao`, `fn_transitar_alunos`, `emitir_documento_final`, status auditing table/trigger, and schema hardening for `matriculas`. 

### Testing

- Ran a full TypeScript build via `yarn nx build web` to ensure types and bundles compile successfully and it completed without errors. 
- Executed the frontend unit tests with `yarn test` and they passed. 
- Applied and validated the SQL migrations in a local dev database and exercised key RPCs (`finalizar_matricula_blindada`, `fn_transitar_alunos`, `emitir_documento_final`) returning expected results in integration checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3476afb1c83289a1ddea2cf3de640)