### PR TITLE
feat(super-admin): histórico consolidado de receitas no super-admin

### DIFF
--- a/apps/web/src/app/api/super-admin/billing/historico/route.ts
+++ b/apps/web/src/app/api/super-admin/billing/historico/route.ts
@@ -1,0 +1,290 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabaseServer';
+import { isSuperAdminRole } from '@/lib/auth/requireSuperAdminAccess';
+import { recordAuditServer } from '@/lib/audit';
+
+export const dynamic = 'force-dynamic';
+
+type BillingHistoricoStatus = 'pendente' | 'confirmado' | 'falhado';
+
+function parseMonthBounds(periodo: string | null) {
+  if (!periodo || !/^\d{4}-\d{2}$/.test(periodo)) {
+    return null;
+  }
+
+  const start = new Date(`${periodo}-01T00:00:00.000Z`);
+  if (Number.isNaN(start.getTime())) {
+    return null;
+  }
+
+  const end = new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() + 1, 1));
+
+  return {
+    start: start.toISOString().slice(0, 10),
+    end: end.toISOString().slice(0, 10),
+  };
+}
+
+function toCsvCell(value: unknown) {
+  const text = String(value ?? '');
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+async function checkSuperAdmin(supabase: Awaited<ReturnType<typeof supabaseServer>>, userId: string) {
+  const { data: rows } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('user_id', userId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const role = (rows?.[0] as { role?: string } | undefined)?.role;
+  return isSuperAdminRole(role);
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const s = await supabaseServer();
+    const { data: sessionData } = await s.auth.getUser();
+    const user = sessionData?.user;
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 });
+    }
+
+    if (!(await checkSuperAdmin(s, user.id))) {
+      return NextResponse.json({ ok: false, error: 'Somente Super Admin' }, { status: 403 });
+    }
+
+    const url = req.nextUrl;
+    const escolaId = url.searchParams.get('escola_id') || '';
+    const status = (url.searchParams.get('status') || '').trim();
+    const periodo = parseMonthBounds(url.searchParams.get('periodo'));
+    const format = (url.searchParams.get('format') || 'json').toLowerCase();
+
+    const page = Math.max(Number.parseInt(url.searchParams.get('page') || '1', 10), 1);
+    const pageSize = Math.min(Math.max(Number.parseInt(url.searchParams.get('page_size') || '20', 10), 1), 50);
+
+    const baseQuery = () => {
+      const query = s
+        .from('pagamentos_saas')
+        .select(
+          `
+          id,
+          escola_id,
+          assinatura_id,
+          valor_kz,
+          metodo,
+          status,
+          referencia_ext,
+          confirmado_por,
+          confirmado_em,
+          periodo_inicio,
+          periodo_fim,
+          created_at,
+          escolas:escola_id (id, nome),
+          assinaturas:assinatura_id (plano, ciclo)
+        `,
+          { count: 'exact' },
+        )
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: false });
+
+      if (escolaId) {
+        query.eq('escola_id', escolaId);
+      }
+
+      if (status) {
+        query.eq('status', status);
+      }
+
+      if (periodo) {
+        query.gte('periodo_inicio', periodo.start);
+        query.lt('periodo_inicio', periodo.end);
+      }
+
+      return query;
+    };
+
+    if (format === 'csv') {
+      const { data, error } = await baseQuery().limit(5000);
+      if (error) throw error;
+
+      const header = [
+        'escola',
+        'plano',
+        'ciclo',
+        'valor_kz',
+        'status',
+        'metodo',
+        'referencia',
+        'data_evento',
+        'actor',
+      ];
+
+      const rows = (data || []).map((row) => {
+        const escolaNome = (row.escolas as { nome?: string } | null)?.nome || 'Escola sem nome';
+        const assinatura = (row.assinaturas as { plano?: string; ciclo?: string } | null) || {};
+
+        return [
+          escolaNome,
+          assinatura.plano || '',
+          assinatura.ciclo || '',
+          row.valor_kz,
+          row.status,
+          row.metodo,
+          row.referencia_ext || '',
+          row.confirmado_em || row.created_at,
+          row.confirmado_por || '',
+        ];
+      });
+
+      const csv = [
+        header.map(toCsvCell).join(','),
+        ...rows.map((line) => line.map(toCsvCell).join(',')),
+      ].join('\n');
+
+      return new NextResponse(csv, {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/csv; charset=utf-8',
+          'Content-Disposition': 'attachment; filename="historico-receitas.csv"',
+        },
+      });
+    }
+
+    const from = (page - 1) * pageSize;
+    const to = from + pageSize - 1;
+
+    const { data, error, count } = await baseQuery().range(from, to);
+    if (error) throw error;
+
+    const actorIds = Array.from(new Set((data || []).map((item) => item.confirmado_por).filter(Boolean)));
+    const actorNameMap = new Map<string, string>();
+
+    if (actorIds.length > 0) {
+      const { data: actors } = await s
+        .from('profiles')
+        .select('user_id, full_name, email')
+        .in('user_id', actorIds);
+
+      for (const actor of actors || []) {
+        actorNameMap.set(actor.user_id, actor.full_name || actor.email || actor.user_id);
+      }
+    }
+
+    const items = (data || []).map((row) => {
+      const escola = (row.escolas as { id?: string; nome?: string } | null) || {};
+      const assinatura = (row.assinaturas as { plano?: string; ciclo?: string } | null) || {};
+      const actorId = row.confirmado_por || null;
+
+      return {
+        id: row.id,
+        escola_id: row.escola_id,
+        escola_nome: escola.nome || 'Escola sem nome',
+        plano: assinatura.plano || null,
+        ciclo: assinatura.ciclo || null,
+        valor_kz: row.valor_kz,
+        status: row.status,
+        metodo: row.metodo,
+        referencia: row.referencia_ext,
+        data_evento: row.confirmado_em || row.created_at,
+        actor_id: actorId,
+        actor_nome: actorId ? actorNameMap.get(actorId) || actorId : 'Sistema',
+        periodo_inicio: row.periodo_inicio,
+        periodo_fim: row.periodo_fim,
+      };
+    });
+
+    return NextResponse.json({
+      ok: true,
+      items,
+      pagination: {
+        page,
+        page_size: pageSize,
+        total: count || 0,
+        total_pages: Math.max(Math.ceil((count || 0) / pageSize), 1),
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: NextRequest) {
+  try {
+    const s = await supabaseServer();
+    const { data: sessionData } = await s.auth.getUser();
+    const user = sessionData?.user;
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 });
+    }
+
+    if (!(await checkSuperAdmin(s, user.id))) {
+      return NextResponse.json({ ok: false, error: 'Somente Super Admin' }, { status: 403 });
+    }
+
+    const body = await req.json();
+    const pagamentoId = String(body?.id || '').trim();
+    const novoStatus = String(body?.status || '').trim() as BillingHistoricoStatus;
+    const novoMetodo = typeof body?.metodo === 'string' ? body.metodo.trim() : undefined;
+    const novaReferencia = typeof body?.referencia_ext === 'string' ? body.referencia_ext.trim() : undefined;
+
+    if (!pagamentoId) {
+      return NextResponse.json({ ok: false, error: 'ID de pagamento é obrigatório' }, { status: 400 });
+    }
+
+    if (!novoStatus || !['pendente', 'confirmado', 'falhado'].includes(novoStatus)) {
+      return NextResponse.json({ ok: false, error: 'Status inválido' }, { status: 400 });
+    }
+
+    const { data: before, error: beforeError } = await s
+      .from('pagamentos_saas')
+      .select('id, escola_id, status, metodo, referencia_ext, confirmado_em, confirmado_por')
+      .eq('id', pagamentoId)
+      .single();
+
+    if (beforeError || !before) {
+      return NextResponse.json({ ok: false, error: 'Pagamento não encontrado' }, { status: 404 });
+    }
+
+    const payload: Record<string, unknown> = {
+      status: novoStatus,
+      confirmado_por: user.id,
+      confirmado_em: new Date().toISOString(),
+    };
+
+    if (novoMetodo !== undefined) payload.metodo = novoMetodo;
+    if (novaReferencia !== undefined) payload.referencia_ext = novaReferencia;
+
+    const { error: updateError } = await s
+      .from('pagamentos_saas')
+      .update(payload)
+      .eq('id', pagamentoId);
+
+    if (updateError) throw updateError;
+
+    await recordAuditServer({
+      escolaId: before.escola_id,
+      portal: 'super_admin',
+      acao: 'BILLING_HISTORY_ADJUSTMENT',
+      entity: 'pagamentos_saas',
+      entityId: pagamentoId,
+      details: {
+        before,
+        after: {
+          status: novoStatus,
+          metodo: payload.metodo ?? before.metodo,
+          referencia_ext: payload.referencia_ext ?? before.referencia_ext,
+        },
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/super-admin/cobrancas/page.tsx
+++ b/apps/web/src/app/super-admin/cobrancas/page.tsx
@@ -1,4 +1,5 @@
 import CobrancasListClient from "@/components/super-admin/cobrancas/CobrancasListClient";
+import HistoricoReceitasClient from "@/components/super-admin/cobrancas/HistoricoReceitasClient";
 import AuditPageView from "@/components/audit/AuditPageView";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -34,13 +35,7 @@ export default async function Page() {
         </TabsContent>
 
         <TabsContent value="historico" className="mt-6 border-none p-0">
-          <div className="rounded-2xl bg-white border border-slate-200 p-12 text-center shadow-sm">
-            <div className="w-12 h-12 rounded-full bg-slate-50 flex items-center justify-center mx-auto mb-4 border border-slate-100">
-              <span className="text-xl">📜</span>
-            </div>
-            <h3 className="text-slate-900 font-bold mb-1">Módulo de Auditoria Consolidada</h3>
-            <p className="text-slate-500 text-sm max-w-xs mx-auto italic">O histórico detalhado de receitas globais e projeções de fluxo está agendado para a Fase 2 da implementação.</p>
-          </div>
+          <HistoricoReceitasClient />
         </TabsContent>
       </Tabs>
     </div>

--- a/apps/web/src/components/super-admin/cobrancas/HistoricoReceitasClient.tsx
+++ b/apps/web/src/components/super-admin/cobrancas/HistoricoReceitasClient.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { format } from 'date-fns';
+import { toast } from 'sonner';
+
+type HistoricoRow = {
+  id: string;
+  escola_id: string;
+  escola_nome: string;
+  plano: string | null;
+  ciclo: string | null;
+  valor_kz: number;
+  status: 'pendente' | 'confirmado' | 'falhado';
+  metodo: string;
+  referencia: string | null;
+  data_evento: string;
+  actor_id: string | null;
+  actor_nome: string;
+  periodo_inicio: string;
+  periodo_fim: string;
+};
+
+type PaginationPayload = {
+  page: number;
+  page_size: number;
+  total: number;
+  total_pages: number;
+};
+
+const STATUSES = [
+  { label: 'Todos os status', value: '' },
+  { label: 'Pendente', value: 'pendente' },
+  { label: 'Confirmado', value: 'confirmado' },
+  { label: 'Falhado', value: 'falhado' },
+];
+
+export default function HistoricoReceitasClient() {
+  const [items, setItems] = useState<HistoricoRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exportingCsv, setExportingCsv] = useState(false);
+  const [adjustingId, setAdjustingId] = useState<string | null>(null);
+
+  const [periodo, setPeriodo] = useState('');
+  const [status, setStatus] = useState('');
+  const [escola, setEscola] = useState('');
+
+  const [pagination, setPagination] = useState<PaginationPayload>({
+    page: 1,
+    page_size: 20,
+    total: 0,
+    total_pages: 1,
+  });
+
+  const escolas = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const item of items) {
+      map.set(item.escola_id, item.escola_nome);
+    }
+    return Array.from(map.entries()).map(([id, nome]) => ({ id, nome }));
+  }, [items]);
+
+  const buildQueryString = useCallback(
+    (pageValue: number, formatType: 'json' | 'csv' = 'json') => {
+      const params = new URLSearchParams();
+      params.set('page', String(pageValue));
+      params.set('page_size', String(pagination.page_size));
+      params.set('format', formatType);
+      if (periodo) params.set('periodo', periodo);
+      if (status) params.set('status', status);
+      if (escola) params.set('escola_id', escola);
+      return params.toString();
+    },
+    [pagination.page_size, periodo, status, escola],
+  );
+
+  const loadData = useCallback(
+    async (pageValue = 1) => {
+      try {
+        setLoading(true);
+        const query = buildQueryString(pageValue);
+        const res = await fetch(`/api/super-admin/billing/historico?${query}`);
+        const json = await res.json();
+
+        if (!res.ok || !json?.ok) {
+          throw new Error(json?.error || 'Falha ao carregar histórico de receitas');
+        }
+
+        setItems(json.items || []);
+        setPagination(json.pagination || { page: 1, page_size: 20, total: 0, total_pages: 1 });
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        toast.error(message);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [buildQueryString],
+  );
+
+  useEffect(() => {
+    loadData(1);
+  }, [loadData]);
+
+  const handleExportCsv = async () => {
+    try {
+      setExportingCsv(true);
+      const query = buildQueryString(1, 'csv');
+      const res = await fetch(`/api/super-admin/billing/historico?${query}`);
+      if (!res.ok) {
+        const fallback = await res.json().catch(() => ({}));
+        throw new Error((fallback as { error?: string }).error || 'Não foi possível exportar o CSV');
+      }
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `historico-receitas-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(message);
+    } finally {
+      setExportingCsv(false);
+    }
+  };
+
+  const handleAdjustStatus = async (item: HistoricoRow) => {
+    const nextStatus = item.status === 'confirmado' ? 'pendente' : 'confirmado';
+    try {
+      setAdjustingId(item.id);
+      const res = await fetch('/api/super-admin/billing/historico', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: item.id, status: nextStatus }),
+      });
+
+      const json = await res.json();
+      if (!res.ok || !json?.ok) {
+        throw new Error(json?.error || 'Falha ao aplicar ajuste');
+      }
+
+      toast.success('Ajuste aplicado e auditado com sucesso.');
+      await loadData(pagination.page);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.error(message);
+    } finally {
+      setAdjustingId(null);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-4">
+          <label className="text-xs text-slate-600">
+            <span className="mb-1 block font-semibold">Período (mês)</span>
+            <input
+              type="month"
+              value={periodo}
+              onChange={(e) => setPeriodo(e.target.value)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            />
+          </label>
+
+          <label className="text-xs text-slate-600">
+            <span className="mb-1 block font-semibold">Status</span>
+            <select
+              value={status}
+              onChange={(e) => setStatus(e.target.value)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            >
+              {STATUSES.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="text-xs text-slate-600">
+            <span className="mb-1 block font-semibold">Escola</span>
+            <select
+              value={escola}
+              onChange={(e) => setEscola(e.target.value)}
+              className="w-full rounded-lg border border-slate-200 px-3 py-2 text-sm"
+            >
+              <option value="">Todas as escolas</option>
+              {escolas.map((option) => (
+                <option key={option.id} value={option.id}>
+                  {option.nome}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="flex items-end gap-2">
+            <button
+              onClick={() => loadData(1)}
+              className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold uppercase text-slate-600"
+            >
+              Filtrar
+            </button>
+            <button
+              onClick={handleExportCsv}
+              disabled={exportingCsv}
+              className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-semibold uppercase text-emerald-700 disabled:opacity-50"
+            >
+              {exportingCsv ? 'A exportar...' : 'Exportar CSV'}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-50 text-left text-[11px] uppercase tracking-wide text-slate-500">
+                <th className="px-4 py-3">Escola</th>
+                <th className="px-4 py-3">Plano / Ciclo</th>
+                <th className="px-4 py-3">Valor</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3">Método</th>
+                <th className="px-4 py-3">Referência</th>
+                <th className="px-4 py-3">Data</th>
+                <th className="px-4 py-3">Actor</th>
+                <th className="px-4 py-3">Ajuste</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {loading && (
+                <tr>
+                  <td className="px-4 py-8 text-center text-slate-400" colSpan={9}>
+                    A carregar histórico...
+                  </td>
+                </tr>
+              )}
+
+              {!loading && items.length === 0 && (
+                <tr>
+                  <td className="px-4 py-8 text-center text-slate-400" colSpan={9}>
+                    Nenhum evento encontrado para os filtros seleccionados.
+                  </td>
+                </tr>
+              )}
+
+              {!loading &&
+                items.map((item) => (
+                  <tr key={item.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-800">{item.escola_nome}</td>
+                    <td className="px-4 py-3 text-slate-600">{item.plano || '—'} / {item.ciclo || '—'}</td>
+                    <td className="px-4 py-3 font-semibold text-slate-900">Kz {item.valor_kz.toLocaleString()}</td>
+                    <td className="px-4 py-3 uppercase text-slate-700">{item.status}</td>
+                    <td className="px-4 py-3 text-slate-700">{item.metodo}</td>
+                    <td className="px-4 py-3 font-mono text-xs text-slate-600">{item.referencia || '—'}</td>
+                    <td className="px-4 py-3 text-slate-600">{format(new Date(item.data_evento), 'dd/MM/yyyy HH:mm')}</td>
+                    <td className="px-4 py-3 text-slate-600">{item.actor_nome}</td>
+                    <td className="px-4 py-3">
+                      <button
+                        onClick={() => handleAdjustStatus(item)}
+                        disabled={adjustingId === item.id}
+                        className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] font-semibold uppercase text-amber-700 disabled:opacity-50"
+                      >
+                        {adjustingId === item.id ? 'Ajustando...' : 'Alternar status'}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex items-center justify-between border-t border-slate-100 px-4 py-3 text-xs text-slate-500">
+          <p>
+            Página {pagination.page} de {pagination.total_pages} — {pagination.total} registos
+          </p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => loadData(Math.max(pagination.page - 1, 1))}
+              disabled={pagination.page <= 1 || loading}
+              className="rounded border border-slate-200 px-2 py-1 disabled:opacity-50"
+            >
+              Anterior
+            </button>
+            <button
+              onClick={() => loadData(Math.min(pagination.page + 1, pagination.total_pages))}
+              disabled={pagination.page >= pagination.total_pages || loading}
+              className="rounded border border-slate-200 px-2 py-1 disabled:opacity-50"
+            >
+              Próxima
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Fornecer ao portal Super Admin um histórico operacional e conciliável de eventos financeiros por escola, período e status, com filtros, paginação e export CSV.
- Garantir que qualquer ajuste feito na aba histórica fique auditado no backend para rastreabilidade e conformidade.

### Description
- Adiciona endpoint server-side `GET`/`PATCH` em `apps/web/src/app/api/super-admin/billing/historico/route.ts` com autenticação de super-admin, filtros por `periodo`/`status`/`escola_id`, paginação (`page`, `page_size`) e opção de export CSV (`format=csv`).
- Implementa gravação de auditoria via `recordAuditServer` ao aplicar ajustes (`PATCH`) em `pagamentos_saas`, incluindo snapshot `before`/`after` e preenchimento de `confirmado_por`/`confirmado_em`.
- Cria o componente cliente `HistoricoReceitasClient` em `apps/web/src/components/super-admin/cobrancas/HistoricoReceitasClient.tsx` com tabela (escola, plano/ciclo, valor, status, método, referência, data, actor), filtros, paginação, botão de exportação CSV e ação de ajuste de status por linha.
- Substitui o placeholder da aba `historico` por `HistoricoReceitasClient` em `apps/web/src/app/super-admin/cobrancas/page.tsx` e marca as rotas como `force-dynamic` para garantir dados frescos.

### Testing
- Executado `pnpm -w --filter web lint`, que falhou por problemas de baseline do repositório não relacionados a estas alterações (warnings/errors preexistentes). (failed)
- Levantado `pnpm dev` para validação local da aplicação e render da página `/super-admin/cobrancas`. (succeeded)
- Captura visual via Playwright da rota `/super-admin/cobrancas` para comprovar a substituição do placeholder e o novo componente (screenshot gerada). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a410fc88bc8328b642fa0d454da8ab)