### PR TITLE
feat(billing): permitir rejeição de pagamentos pendentes com motivo

### DIFF
--- a/apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts
+++ b/apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts
@@ -22,6 +22,14 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
     const body = await req.json();
     const { action, ...updates } = body;
 
+    const { data: assBefore } = await s
+      .from('assinaturas')
+      .select('id, escola_id, status, ciclo, data_renovacao, notas_internas')
+      .eq('id', id)
+      .single();
+
+    if (!assBefore) return NextResponse.json({ ok: false, error: 'Assinatura não encontrada' }, { status: 404 });
+
     // 1. Acção Especial: Reenviar Instruções por Email
     if (action === 'resend_instructions') {
       const { data: ass } = await s
@@ -47,7 +55,7 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
 
       await sendMail({ to: admin.email, subject, html, text });
       
-      recordAuditServer({ 
+      await recordAuditServer({ 
         escolaId: ass.escola_id, 
         portal: 'super_admin', 
         acao: 'BILLING_INSTRUCTIONS_RESENT', 
@@ -58,15 +66,131 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
       return NextResponse.json({ ok: true, message: 'Instruções enviadas com sucesso' });
     }
 
+    // 1.1 Acção Especial: Confirmar pagamento pendente
+    if (action === 'confirm_payment') {
+      const { data: latestPayment, error: latestPaymentError } = await s
+        .from('pagamentos_saas')
+        .select('id, status, created_at')
+        .eq('assinatura_id', id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (latestPaymentError) throw latestPaymentError;
+      if (!latestPayment) {
+        return NextResponse.json({ ok: false, error: 'Pagamento não encontrado para esta assinatura' }, { status: 404 });
+      }
+
+      const novaDataRenovacao = new Date(assBefore.data_renovacao);
+      if (assBefore.ciclo === 'mensal') novaDataRenovacao.setMonth(novaDataRenovacao.getMonth() + 1);
+      else novaDataRenovacao.setFullYear(novaDataRenovacao.getFullYear() + 1);
+
+      const { error: assError } = await s
+        .from('assinaturas')
+        .update({
+          status: 'activa',
+          data_renovacao: novaDataRenovacao.toISOString(),
+        })
+        .eq('id', id);
+
+      if (assError) throw assError;
+
+      const { error: paymentError } = await s
+        .from('pagamentos_saas')
+        .update({
+          status: 'confirmado',
+          confirmado_por: sess.user.id,
+          confirmado_em: new Date().toISOString(),
+        })
+        .eq('id', latestPayment.id);
+
+      if (paymentError) throw paymentError;
+
+      await recordAuditServer({
+        escolaId: assBefore.escola_id,
+        portal: 'super_admin',
+        acao: 'BILLING_PAYMENT_CONFIRMED',
+        entity: 'assinaturas',
+        entityId: id,
+        details: {
+          previous_status: assBefore.status,
+          new_status: 'activa',
+          payment_id: latestPayment.id,
+          payment_previous_status: latestPayment.status,
+          payment_new_status: 'confirmado',
+        },
+      });
+
+      return NextResponse.json({ ok: true, message: 'Pagamento confirmado e assinatura activada' });
+    }
+
+    // 1.2 Acção Especial: Rejeitar pagamento pendente (motivo obrigatório)
+    if (action === 'reject_payment') {
+      const motivo = String(body.motivo ?? '').trim();
+      if (!motivo) {
+        return NextResponse.json({ ok: false, error: 'Motivo de rejeição é obrigatório' }, { status: 400 });
+      }
+
+      const { data: latestPayment, error: latestPaymentError } = await s
+        .from('pagamentos_saas')
+        .select('id, status, created_at')
+        .eq('assinatura_id', id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (latestPaymentError) throw latestPaymentError;
+      if (!latestPayment) {
+        return NextResponse.json({ ok: false, error: 'Pagamento não encontrado para esta assinatura' }, { status: 404 });
+      }
+
+      const rejectedAt = new Date().toISOString();
+      const notaRejeicao = `[${new Date(rejectedAt).toLocaleString('pt-PT')}] Rejeição de pagamento: ${motivo}`;
+      const notasInternas = assBefore.notas_internas
+        ? `${assBefore.notas_internas}\n${notaRejeicao}`
+        : notaRejeicao;
+
+      const { error: assError } = await s
+        .from('assinaturas')
+        .update({
+          status: 'suspensa',
+          notas_internas: notasInternas,
+        })
+        .eq('id', id);
+
+      if (assError) throw assError;
+
+      const { error: paymentError } = await s
+        .from('pagamentos_saas')
+        .update({
+          status: 'falhado',
+          confirmado_por: sess.user.id,
+          confirmado_em: rejectedAt,
+        })
+        .eq('id', latestPayment.id);
+
+      if (paymentError) throw paymentError;
+
+      await recordAuditServer({
+        escolaId: assBefore.escola_id,
+        portal: 'super_admin',
+        acao: 'BILLING_PAYMENT_REJECTED',
+        entity: 'assinaturas',
+        entityId: id,
+        details: {
+          motivo,
+          previous_status: assBefore.status,
+          new_status: 'suspensa',
+          payment_id: latestPayment.id,
+          payment_previous_status: latestPayment.status,
+          payment_new_status: 'falhado',
+        },
+      });
+
+      return NextResponse.json({ ok: true, message: 'Pagamento rejeitado' });
+    }
+
     // 2. Actualizações Genéricas (Plano, Ciclo, Notas, Status)
-    const { data: assBefore } = await s
-      .from('assinaturas')
-      .select('escola_id')
-      .eq('id', id)
-      .single();
-
-    if (!assBefore) return NextResponse.json({ ok: false, error: 'Assinatura não encontrada' }, { status: 404 });
-
     // Iniciar transação lógica (updates em paralelo ou sequência)
     const { error: errorAss } = await s
       .from('assinaturas')
@@ -85,12 +209,16 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
       if (errorEsc) throw errorEsc;
     }
 
-    recordAuditServer({ 
+    await recordAuditServer({ 
+      escolaId: assBefore.escola_id,
       portal: 'super_admin', 
       acao: 'BILLING_SUBSCRIPTION_UPDATED', 
       entity: 'assinaturas', 
       entityId: id, 
-      details: updates 
+      details: {
+        previous_status: assBefore.status,
+        ...updates,
+      },
     });
 
     return NextResponse.json({ ok: true });

--- a/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
+++ b/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
@@ -6,7 +6,7 @@
  * Tokens KLASSE: #1F6B3B (green), #E3B23C (gold).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import { toast } from "sonner";
 import { format } from "date-fns";
@@ -83,7 +83,9 @@ export default function CobrancasListClient() {
   const [loading, setLoading] = useState(true);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [erro, setErro] = useState<string | null>(null);
-  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [processingId, setProcessingId] = useState<string | null>(null);
+  const [rejectingItem, setRejectingItem] = useState<AssinaturaPendente | null>(null);
+  const [rejectReason, setRejectReason] = useState('');
   const [syncing, setSyncing] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
@@ -163,45 +165,59 @@ export default function CobrancasListClient() {
 
   const handleConfirmar = async (item: AssinaturaPendente) => {
     if (!confirm('Deseja confirmar o pagamento desta subscrição?')) return;
-    
+
     try {
-      setConfirmingId(item.id);
-      
-      const novaDataRenovacao = new Date(item.data_renovacao);
-      if (item.ciclo === 'mensal') novaDataRenovacao.setMonth(novaDataRenovacao.getMonth() + 1);
-      else novaDataRenovacao.setFullYear(novaDataRenovacao.getFullYear() + 1);
+      setProcessingId(item.id);
+      const res = await fetch(`/api/super-admin/billing/assinaturas/${item.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'confirm_payment', ciclo: item.ciclo }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) throw new Error(json?.error || 'Erro ao confirmar pagamento');
 
-      const { error: assError } = await supabase
-        .from('assinaturas')
-        .update({
-          status: 'activa',
-          data_renovacao: novaDataRenovacao.toISOString()
-        })
-        .eq('id', item.id);
-
-      if (assError) throw assError;
-
-      if (item.pagamento_id) {
-        const { error: pgError } = await supabase
-          .from('pagamentos_saas')
-          .update({
-            status: 'confirmado',
-            confirmado_por: (await supabase.auth.getUser()).data.user?.id,
-            confirmado_em: new Date().toISOString()
-          })
-          .eq('id', item.pagamento_id);
-        
-        if (pgError) throw pgError;
-      }
-
-      toast.success(`Subscrição de ${item.escola_nome} activada!`);
-      loadData();
+      toast.success(json?.message || `Subscrição de ${item.escola_nome} activada!`);
+      await loadData();
     } catch (err: any) {
       toast.error('Erro ao confirmar: ' + err.message);
     } finally {
-      setConfirmingId(null);
+      setProcessingId(null);
     }
   };
+
+  const handleRejeitar = async () => {
+    if (!rejectingItem) return;
+    const motivo = rejectReason.trim();
+    if (!motivo) {
+      toast.error('Informe o motivo da rejeição.');
+      return;
+    }
+
+    try {
+      setProcessingId(rejectingItem.id);
+      const res = await fetch(`/api/super-admin/billing/assinaturas/${rejectingItem.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'reject_payment', motivo }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) throw new Error(json?.error || 'Erro ao rejeitar pagamento');
+
+      toast.success(`Pagamento de ${rejectingItem.escola_nome} rejeitado.`);
+      setRejectingItem(null);
+      setRejectReason('');
+      await loadData();
+    } catch (err: any) {
+      toast.error('Erro ao rejeitar: ' + err.message);
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  const rejectingPreview = useMemo(() => {
+    if (!rejectingItem) return null;
+    return `${rejectingItem.escola_nome} · ${PLAN_NAMES[rejectingItem.plano]} (${rejectingItem.ciclo})`;
+  }, [rejectingItem]);
 
   const cols = ["Escola", "Plano / Ciclo", "Valor", "Status", "Pagamento", "Renovação", "Acções"];
 
@@ -325,13 +341,25 @@ export default function CobrancasListClient() {
                   <td className="py-4 px-6">
                     <div className="flex gap-2">
                       {item.status === 'pendente' && (
-                        <button
-                          disabled={confirmingId === item.id}
-                          onClick={() => handleConfirmar(item)}
-                          className="px-3 py-1.5 rounded-lg bg-[#1F6B3B] hover:bg-[#1F6B3B]/90 text-white text-[10px] font-bold uppercase transition-colors disabled:opacity-50 shadow-sm"
-                        >
-                          {confirmingId === item.id ? '...' : 'Activar'}
-                        </button>
+                        <>
+                          <button
+                            disabled={processingId === item.id}
+                            onClick={() => handleConfirmar(item)}
+                            className="px-3 py-1.5 rounded-lg bg-[#1F6B3B] hover:bg-[#1F6B3B]/90 text-white text-[10px] font-bold uppercase transition-colors disabled:opacity-50 shadow-sm"
+                          >
+                            {processingId === item.id ? '...' : 'Activar'}
+                          </button>
+                          <button
+                            disabled={processingId === item.id}
+                            onClick={() => {
+                              setRejectingItem(item);
+                              setRejectReason('');
+                            }}
+                            className="px-3 py-1.5 rounded-lg bg-red-50 border border-red-200 hover:bg-red-100 text-red-700 text-[10px] font-bold uppercase transition-colors disabled:opacity-50"
+                          >
+                            Rejeitar
+                          </button>
+                        </>
                       )}
                       <button 
                         onClick={() => setSelectedId(item.id)}
@@ -347,6 +375,44 @@ export default function CobrancasListClient() {
           </table>
         </div>
       </div>
+
+
+      {rejectingItem && (
+        <div className="fixed inset-0 z-[80] flex items-center justify-center">
+          <div className="absolute inset-0 bg-black/40" onClick={() => setRejectingItem(null)} />
+          <div className="relative w-full max-w-md rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl">
+            <h3 className="text-sm font-bold text-slate-900 uppercase tracking-wider">Rejeitar pagamento</h3>
+            <p className="mt-2 text-xs text-slate-500">{rejectingPreview}</p>
+            <label className="mt-4 block text-[10px] font-bold uppercase tracking-widest text-slate-500">
+              Motivo obrigatório
+            </label>
+            <textarea
+              value={rejectReason}
+              onChange={(e) => setRejectReason(e.target.value)}
+              rows={4}
+              placeholder="Ex.: comprovativo ilegível ou valor divergente."
+              className="mt-2 w-full rounded-xl border border-slate-200 p-3 text-sm text-slate-700 focus:border-red-300 focus:outline-none"
+            />
+            <div className="mt-4 flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setRejectingItem(null)}
+                className="px-3 py-1.5 rounded-lg bg-white border border-slate-200 text-slate-600 text-[10px] font-bold uppercase"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                disabled={processingId === rejectingItem.id}
+                onClick={handleRejeitar}
+                className="px-3 py-1.5 rounded-lg bg-red-600 hover:bg-red-700 text-white text-[10px] font-bold uppercase disabled:opacity-50"
+              >
+                {processingId === rejectingItem.id ? 'A rejeitar...' : 'Confirmar rejeição'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* ── Slideover de Detalhes ── */}
       {selectedId && (


### PR DESCRIPTION
### Motivation
- Permitir que operadoras do portal Super Admin rejeitem pagamentos pendentes com um motivo obrigatório para suportar disputas e fluxo operacional.
- Centralizar a lógica de confirmação/rejeição de pagamentos no backend para garantir consistência do estado e registo de auditoria.

### Description
- Frontend: adiciona botão `Rejeitar`, modal com motivo obrigatório, estados de processamento e chamadas ao backend em `apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx`.
- Frontend: altera o fluxo de activação para usar a API (`action: 'confirm_payment'`) em vez de actualizar tabelas directamente no cliente in `CobrancasListClient.tsx`.
- Backend: implementa no endpoint `PATCH /api/super-admin/billing/assinaturas/[id]` as actions `confirm_payment` e `reject_payment` e centraliza as actualizações de `assinaturas` e `pagamentos_saas` em `apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts`.
- Audit & data changes: em rejeição actualiza `pagamentos_saas.status` para `falhado`, grava `confirmado_por`/`confirmado_em`, anexa nota com o motivo em `assinaturas.notas_internas`, e grava eventos de auditoria com estado anterior e posterior via `recordAuditServer`.

### Testing
- Executed targeted lint on changed files with `pnpm --filter web exec eslint src/components/super-admin/cobrancas/CobrancasListClient.tsx src/app/api/super-admin/billing/assinaturas/[id]/route.ts` and it completed with no errors (only warnings reported in the repository at large).
- Ran the workspace lint `pnpm lint` which failed due to preexisting repository-wide issues unrelated to these changes, so focused checks were used for validation.
- Started the dev server with `pnpm dev` and captured a UI screenshot of `/super-admin/cobrancas` using Playwright; the screenshot artifact is available at `browser:/tmp/codex_browser_invocations/.../artifacts/cobrancas-rejeitar.png` and was produced successfully.
- Verified the new API flows by exercising `confirm_payment` and `reject_payment` through the updated UI and observed success/error toasts and data refreshes in the client during manual validation in the running dev instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a411cca58483288ff51964307f9bfc)