### PR TITLE
feat(billing): add aggregated KPI summary endpoint and wire cobranças dashboard

### DIFF
--- a/apps/web/src/app/api/super-admin/billing/dashboard/summary/route.ts
+++ b/apps/web/src/app/api/super-admin/billing/dashboard/summary/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { supabaseServer } from '@/lib/supabaseServer';
+import { isSuperAdminRole } from '@/lib/auth/requireSuperAdminAccess';
+import { buildBillingDashboardSummary } from '@/lib/super-admin/billing-dashboard-summary';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const s = await supabaseServer();
+    const { data: sess } = await s.auth.getUser();
+    const user = sess?.user;
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 });
+    }
+
+    const { data: rows } = await s
+      .from('profiles')
+      .select('role')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    const role = (rows?.[0] as { role?: string } | undefined)?.role;
+    if (!isSuperAdminRole(role)) {
+      return NextResponse.json({ ok: false, error: 'Somente Super Admin' }, { status: 403 });
+    }
+
+    const { data: assinaturas, error: assinaturasError } = await s
+      .from('assinaturas')
+      .select('id, ciclo, status, valor_kz, data_renovacao, created_at');
+
+    if (assinaturasError) {
+      throw assinaturasError;
+    }
+
+    const { data: pagamentos, error: pagamentosError } = await s
+      .from('pagamentos_saas')
+      .select('assinatura_id, status, comprovativo_url, periodo_fim, created_at');
+
+    if (pagamentosError) {
+      throw pagamentosError;
+    }
+
+    const normalizedAssinaturas = (assinaturas ?? []).map((row) => ({
+      id: row.id,
+      ciclo: row.ciclo === 'anual' ? ('anual' as const) : ('mensal' as const),
+      status: row.status,
+      valor_kz: row.valor_kz,
+      data_renovacao: row.data_renovacao,
+      created_at: row.created_at,
+    }));
+
+
+    const normalizedPagamentos = (pagamentos ?? []).map((row) => ({
+      assinatura_id: row.assinatura_id,
+      status: row.status,
+      comprovativo_url: row.comprovativo_url,
+      periodo_fim: row.periodo_fim,
+      created_at: row.created_at ?? new Date(0).toISOString(),
+    }));
+
+    const summary = buildBillingDashboardSummary(normalizedAssinaturas, normalizedPagamentos);
+
+
+    return NextResponse.json({ ok: true, summary });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/super-admin/cobrancas/page.tsx
+++ b/apps/web/src/app/super-admin/cobrancas/page.tsx
@@ -1,4 +1,5 @@
 import CobrancasListClient from "@/components/super-admin/cobrancas/CobrancasListClient";
+import BillingSummarySnapshot from "@/components/super-admin/cobrancas/BillingSummarySnapshot";
 import AuditPageView from "@/components/audit/AuditPageView";
 import { DashboardHeader } from "@/components/dashboard/DashboardHeader";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -40,6 +41,9 @@ export default async function Page() {
             </div>
             <h3 className="text-slate-900 font-bold mb-1">Módulo de Auditoria Consolidada</h3>
             <p className="text-slate-500 text-sm max-w-xs mx-auto italic">O histórico detalhado de receitas globais e projeções de fluxo está agendado para a Fase 2 da implementação.</p>
+            <div className="mt-6">
+              <BillingSummarySnapshot />
+            </div>
           </div>
         </TabsContent>
       </Tabs>

--- a/apps/web/src/components/super-admin/cobrancas/BillingSummarySnapshot.tsx
+++ b/apps/web/src/components/super-admin/cobrancas/BillingSummarySnapshot.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type DashboardSummary = {
+  mrr: number;
+  arr: number;
+  pendentes_comprovativo: number;
+  vencidas_gt_7d: number;
+};
+
+export default function BillingSummarySnapshot() {
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch("/api/super-admin/billing/dashboard/summary", { cache: "no-store" });
+      const json = await res.json();
+      if (res.ok && json?.ok) setSummary(json.summary as DashboardSummary);
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-left">
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <p className="text-[10px] uppercase font-bold tracking-widest text-slate-400">MRR</p>
+        <p className="font-bold text-slate-900">Kz {(summary?.mrr ?? 0).toLocaleString()}</p>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <p className="text-[10px] uppercase font-bold tracking-widest text-slate-400">ARR</p>
+        <p className="font-bold text-slate-900">Kz {(summary?.arr ?? 0).toLocaleString()}</p>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <p className="text-[10px] uppercase font-bold tracking-widest text-slate-400">Pendentes comprovativo</p>
+        <p className="font-bold text-amber-700">{summary?.pendentes_comprovativo ?? 0}</p>
+      </div>
+      <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+        <p className="text-[10px] uppercase font-bold tracking-widest text-slate-400">Vencidas {'>'}7d</p>
+        <p className="font-bold text-rose-700">{summary?.vencidas_gt_7d ?? 0}</p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
+++ b/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
@@ -21,7 +21,7 @@ type AssinaturaPendente = {
   escola_id: string;
   escola_nome: string;
   plano: PlanTier;
-  ciclo: 'mensal' | 'anual';
+  ciclo: "mensal" | "anual";
   valor_kz: number;
   data_renovacao: string;
   metodo_pagamento: string;
@@ -32,12 +32,21 @@ type AssinaturaPendente = {
   created_at: string;
 };
 
+type DashboardSummary = {
+  mrr: number;
+  arr: number;
+  pendentes_comprovativo: number;
+  vencidas_gt_7d: number;
+  vencidas_assinatura_ids: string[];
+  mrr_variacao_percentual: number;
+};
+
 // ─── Helpers visuais ──────────────────────────────────────────────────────────
 
 const PLAN_META: Record<PlanTier, { pill: string; dot: string }> = {
-  essencial:    { pill: "bg-slate-100 border border-slate-200 text-slate-600",  dot: "bg-slate-400"   },
+  essencial: { pill: "bg-slate-100 border border-slate-200 text-slate-600", dot: "bg-slate-400" },
   profissional: { pill: "bg-[#E3B23C]/10 border border-[#E3B23C]/20 text-[#B48924]", dot: "bg-[#E3B23C]" },
-  premium:      { pill: "bg-[#1F6B3B]/10 border border-[#1F6B3B]/20 text-[#1F6B3B]", dot: "bg-[#1F6B3B]" },
+  premium: { pill: "bg-[#1F6B3B]/10 border border-[#1F6B3B]/20 text-[#1F6B3B]", dot: "bg-[#1F6B3B]" },
 };
 
 function PlanBadge({ plano }: { plano: PlanTier }) {
@@ -51,14 +60,18 @@ function PlanBadge({ plano }: { plano: PlanTier }) {
 }
 
 function StatusBadge({ status }: { status: string }) {
-  const isActiva = status === 'activa';
-  const isPendente = status === 'pendente';
-  
+  const isActiva = status === "activa";
+  const isPendente = status === "pendente";
+
   return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide
-      ${isActiva ? 'bg-emerald-100 text-emerald-700 border border-emerald-200' : 
-        isPendente ? 'bg-amber-100 text-amber-700 border border-amber-200' : 
-        'bg-slate-100 text-slate-600 border border-slate-200'}`}>
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide
+      ${isActiva
+        ? "bg-emerald-100 text-emerald-700 border border-emerald-200"
+        : isPendente
+          ? "bg-amber-100 text-amber-700 border border-amber-200"
+          : "bg-slate-100 text-slate-600 border border-slate-200"}`}
+    >
       {status}
     </span>
   );
@@ -86,19 +99,32 @@ export default function CobrancasListClient() {
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [summary, setSummary] = useState<DashboardSummary | null>(null);
 
   const supabase = createClient();
+
+  const loadSummary = async () => {
+    try {
+      const res = await fetch("/api/super-admin/billing/dashboard/summary", { cache: "no-store" });
+      const json = await res.json();
+      if (!res.ok || !json?.ok) throw new Error(json?.error || "Falha ao carregar KPIs de billing");
+      setSummary(json.summary as DashboardSummary);
+    } catch (err: any) {
+      toast.error(`Falha ao carregar KPIs: ${err.message}`);
+    }
+  };
 
   const handleSync = async () => {
     try {
       setSyncing(true);
-      const res = await fetch('/api/super-admin/billing/sync-assinaturas', { method: 'POST' });
+      const res = await fetch("/api/super-admin/billing/sync-assinaturas", { method: "POST" });
       const json = await res.json();
-      if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao sincronizar');
-      toast.success(json.message || 'Sincronização concluída');
+      if (!res.ok || !json?.ok) throw new Error(json?.error || "Falha ao sincronizar");
+      toast.success(json.message || "Sincronização concluída");
       loadData();
+      loadSummary();
     } catch (err: any) {
-      toast.error('Erro ao sincronizar: ' + err.message);
+      toast.error(`Erro ao sincronizar: ${err.message}`);
     } finally {
       setSyncing(false);
     }
@@ -110,7 +136,7 @@ export default function CobrancasListClient() {
       setErro(null);
 
       const { data, error } = await supabase
-        .from('assinaturas')
+        .from("assinaturas")
         .select(`
           *,
           escolas:escola_id (nome),
@@ -122,21 +148,21 @@ export default function CobrancasListClient() {
             created_at
           )
         `)
-        .order('created_at', { ascending: false });
+        .order("created_at", { ascending: false });
 
       if (error) throw error;
 
-      const normalized: AssinaturaPendente[] = (data || []).map(row => {
-        const ultimoPg = row.pagamentos?.sort((a: any, b: any) => 
-          new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+      const normalized: AssinaturaPendente[] = (data || []).map((row) => {
+        const ultimoPg = row.pagamentos?.sort(
+          (a: any, b: any) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
         )[0];
 
         return {
           id: row.id,
           escola_id: row.escola_id,
-          escola_nome: (row.escolas as any)?.nome || 'Escola Desconhecida',
+          escola_nome: (row.escolas as any)?.nome || "Escola Desconhecida",
           plano: row.plano as PlanTier,
-          ciclo: row.ciclo as any,
+          ciclo: row.ciclo as "mensal" | "anual",
           valor_kz: row.valor_kz,
           data_renovacao: row.data_renovacao,
           metodo_pagamento: row.metodo_pagamento,
@@ -144,14 +170,14 @@ export default function CobrancasListClient() {
           pagamento_id: ultimoPg?.id,
           comprovativo_url: ultimoPg?.comprovativo_url || undefined,
           referencia_ext: ultimoPg?.referencia_ext,
-          created_at: row.created_at
+          created_at: row.created_at,
         } as AssinaturaPendente;
       });
 
       setItems(normalized);
     } catch (err: any) {
-      setErro(err.message || 'Erro ao carregar cobranças');
-      toast.error('Falha ao carregar dados de faturação');
+      setErro(err.message || "Erro ao carregar cobranças");
+      toast.error("Falha ao carregar dados de faturação");
     } finally {
       setLoading(false);
     }
@@ -159,45 +185,52 @@ export default function CobrancasListClient() {
 
   useEffect(() => {
     loadData();
+    loadSummary();
   }, []);
 
+  const refreshAll = () => {
+    loadData();
+    loadSummary();
+  };
+
   const handleConfirmar = async (item: AssinaturaPendente) => {
-    if (!confirm('Deseja confirmar o pagamento desta subscrição?')) return;
-    
+    if (!confirm("Deseja confirmar o pagamento desta subscrição?")) return;
+
     try {
       setConfirmingId(item.id);
-      
+
       const novaDataRenovacao = new Date(item.data_renovacao);
-      if (item.ciclo === 'mensal') novaDataRenovacao.setMonth(novaDataRenovacao.getMonth() + 1);
+      if (item.ciclo === "mensal") novaDataRenovacao.setMonth(novaDataRenovacao.getMonth() + 1);
       else novaDataRenovacao.setFullYear(novaDataRenovacao.getFullYear() + 1);
 
       const { error: assError } = await supabase
-        .from('assinaturas')
+        .from("assinaturas")
         .update({
-          status: 'activa',
-          data_renovacao: novaDataRenovacao.toISOString()
+          status: "activa",
+          data_renovacao: novaDataRenovacao.toISOString(),
         })
-        .eq('id', item.id);
+        .eq("id", item.id);
 
       if (assError) throw assError;
 
       if (item.pagamento_id) {
         const { error: pgError } = await supabase
-          .from('pagamentos_saas')
+          .from("pagamentos_saas")
           .update({
-            status: 'confirmado',
+            status: "confirmado",
             confirmado_por: (await supabase.auth.getUser()).data.user?.id,
-            confirmado_em: new Date().toISOString()
+            confirmado_em: new Date().toISOString(),
           })
-          .eq('id', item.pagamento_id);
-        
+          .eq("id", item.pagamento_id);
+
         if (pgError) throw pgError;
       }
 
       toast.success(`Subscrição de ${item.escola_nome} activada!`);
       loadData();
+      loadSummary();
     } catch (err: any) {
-      toast.error('Erro ao confirmar: ' + err.message);
+      toast.error(`Erro ao confirmar: ${err.message}`);
     } finally {
       setConfirmingId(null);
     }
@@ -205,34 +238,43 @@ export default function CobrancasListClient() {
 
   const cols = ["Escola", "Plano / Ciclo", "Valor", "Status", "Pagamento", "Renovação", "Acções"];
 
+  const mrrDelta = summary?.mrr_variacao_percentual ?? 0;
+  const mrrDeltaPositive = mrrDelta >= 0;
+  const overdueIds = new Set(summary?.vencidas_assinatura_ids ?? []);
+
   return (
     <div className="text-slate-900">
-      
       {/* ── Dashboard Stats ── */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
         <div className="bg-white border border-slate-200 p-4 rounded-2xl shadow-sm">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">MRR Estático</p>
-          <p className="text-2xl font-bold text-slate-900">
-            Kz {items.filter(i => i.status === 'activa' && i.ciclo === 'mensal').reduce((acc, i) => acc + i.valor_kz, 0).toLocaleString()}
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">MRR</p>
+          <p className="text-2xl font-bold text-slate-900">Kz {(summary?.mrr ?? 0).toLocaleString()}</p>
+          <p className={`mt-1 text-[11px] font-semibold ${mrrDeltaPositive ? "text-emerald-600" : "text-rose-600"}`}>
+            {mrrDeltaPositive ? "▲" : "▼"} {Math.abs(mrrDelta).toFixed(1)}% vs mês anterior
           </p>
         </div>
+
         <div className="bg-white border border-slate-200 p-4 rounded-2xl shadow-sm">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">Pendentes</p>
-          <p className="text-2xl font-bold text-amber-600">
-            {items.filter(i => i.status === 'pendente').length}
-          </p>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">ARR</p>
+          <p className="text-2xl font-bold text-emerald-600">Kz {(summary?.arr ?? 0).toLocaleString()}</p>
+          <p className="mt-1 text-[10px] text-slate-500">MRR anualizado + contratos anuais activos</p>
         </div>
+
         <div className="bg-white border border-slate-200 p-4 rounded-2xl shadow-sm">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">Escolas Activas</p>
-          <p className="text-2xl font-bold text-emerald-600">
-            {items.filter(i => i.status === 'activa').length}
-          </p>
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">Pendentes comprovativo</p>
+          <p className="text-2xl font-bold text-amber-600">{summary?.pendentes_comprovativo ?? 0}</p>
         </div>
-        <div className="bg-white border border-slate-200 p-4 rounded-2xl shadow-sm">
-          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">Total Kz (Global)</p>
-          <p className="text-2xl font-bold text-slate-500">
-            Kz {items.reduce((acc, i) => acc + i.valor_kz, 0).toLocaleString()}
+
+        <div
+          className={`bg-white border p-4 rounded-2xl shadow-sm ${summary && summary.vencidas_gt_7d > 0 ? "border-rose-300 bg-rose-50/40" : "border-slate-200"}`}
+        >
+          <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-1">Vencidas {'>'} 7 dias</p>
+          <p className={`text-2xl font-bold ${summary && summary.vencidas_gt_7d > 0 ? "text-rose-600" : "text-slate-500"}`}>
+            {summary?.vencidas_gt_7d ?? 0}
           </p>
+          {!!summary && summary.vencidas_gt_7d > 0 && (
+            <p className="mt-1 text-[10px] font-semibold text-rose-600">Atenção: requer acção manual imediata</p>
+          )}
         </div>
       </div>
 
@@ -244,15 +286,15 @@ export default function CobrancasListClient() {
             <p className="text-[10px] text-slate-400">Gestão global de contratos e planos ativos</p>
           </div>
           <div className="flex gap-3">
-            <button 
-              onClick={handleSync} 
+            <button
+              onClick={handleSync}
               disabled={syncing}
               className="px-3 py-1.5 rounded-lg bg-amber-50 border border-amber-200 text-amber-700 text-[10px] font-bold uppercase hover:bg-amber-100 transition-all disabled:opacity-50"
             >
-              {syncing ? 'Sincronizando...' : 'Inicializar Assinaturas'}
+              {syncing ? "Sincronizando..." : "Inicializar Assinaturas"}
             </button>
-            <button 
-              onClick={loadData} 
+            <button
+              onClick={refreshAll}
               className="px-3 py-1.5 rounded-lg bg-white border border-slate-200 text-slate-500 text-[10px] font-bold uppercase hover:bg-slate-50 transition-all"
             >
               Actualizar
@@ -264,7 +306,7 @@ export default function CobrancasListClient() {
           <table className="w-full text-sm">
             <thead>
               <tr className="border-b border-slate-100 bg-slate-50/30">
-                {cols.map(h => (
+                {cols.map((h) => (
                   <th key={h} className="py-3 px-6 text-left text-[10px] font-bold text-slate-400 uppercase tracking-widest whitespace-nowrap">
                     {h}
                   </th>
@@ -273,7 +315,7 @@ export default function CobrancasListClient() {
             </thead>
             <tbody className="divide-y divide-slate-100">
               {loading && Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)}
-              
+
               {!loading && items.length === 0 && (
                 <tr>
                   <td colSpan={7} className="py-20 text-center">
@@ -282,80 +324,72 @@ export default function CobrancasListClient() {
                 </tr>
               )}
 
-              {!loading && items.map((item) => (
-                <tr key={item.id} className="hover:bg-slate-50 transition-colors">
-                  <td className="py-4 px-6">
-                    <p className="font-bold text-slate-900">{item.escola_nome}</p>
-                    <p className="text-[10px] text-slate-400 font-mono mt-0.5">{item.id.slice(0,8)}</p>
-                  </td>
-                  <td className="py-4 px-6">
-                    <div className="flex flex-col gap-1.5 items-start">
-                      <PlanBadge plano={item.plano} />
-                      <span className="text-[10px] text-slate-400 font-medium uppercase tracking-tighter">
-                        Ciclo: {item.ciclo}
-                      </span>
-                    </div>
-                  </td>
-                  <td className="py-4 px-6">
-                    <p className="text-slate-700 font-mono font-semibold">Kz {item.valor_kz.toLocaleString()}</p>
-                  </td>
-                  <td className="py-4 px-6">
-                    <StatusBadge status={item.status} />
-                  </td>
-                  <td className="py-4 px-6">
-                    {item.comprovativo_url ? (
-                      <button 
-                        onClick={() => window.open(item.comprovativo_url, '_blank')}
-                        className="flex items-center gap-2 text-[10px] font-bold text-amber-600 uppercase hover:text-amber-700"
-                      >
-                        📄 Ver Comprovativo
-                      </button>
-                    ) : (
-                      <span className="text-[10px] text-slate-300 uppercase italic">Sem prova</span>
-                    )}
-                    {item.referencia_ext && (
-                      <p className="text-[10px] text-slate-400 mt-1 font-mono">Ref: {item.referencia_ext}</p>
-                    )}
-                  </td>
-                  <td className="py-4 px-6">
-                    <p className="text-xs text-slate-500">
-                      {format(new Date(item.data_renovacao), "dd 'de' MMM, yyyy", { locale: pt })}
-                    </p>
-                  </td>
-                  <td className="py-4 px-6">
-                    <div className="flex gap-2">
-                      {item.status === 'pendente' && (
-                        <button
-                          disabled={confirmingId === item.id}
-                          onClick={() => handleConfirmar(item)}
-                          className="px-3 py-1.5 rounded-lg bg-[#1F6B3B] hover:bg-[#1F6B3B]/90 text-white text-[10px] font-bold uppercase transition-colors disabled:opacity-50 shadow-sm"
-                        >
-                          {confirmingId === item.id ? '...' : 'Activar'}
-                        </button>
+              {!loading &&
+                items.map((item) => (
+                  <tr key={item.id} className={`hover:bg-slate-50 transition-colors ${overdueIds.has(item.id) ? "bg-rose-50/50" : ""}`}>
+                    <td className="py-4 px-6">
+                      <p className="font-bold text-slate-900">{item.escola_nome}</p>
+                      <p className="text-[10px] text-slate-400 font-mono mt-0.5">{item.id.slice(0, 8)}</p>
+                    </td>
+                    <td className="py-4 px-6">
+                      <div className="flex flex-col gap-1.5 items-start">
+                        <PlanBadge plano={item.plano} />
+                        <span className="text-[10px] text-slate-400 font-medium uppercase tracking-tighter">Ciclo: {item.ciclo}</span>
+                      </div>
+                    </td>
+                    <td className="py-4 px-6">
+                      <p className="text-slate-700 font-mono font-semibold">Kz {item.valor_kz.toLocaleString()}</p>
+                    </td>
+                    <td className="py-4 px-6">
+                      <StatusBadge status={item.status} />
+                      {overdueIds.has(item.id) && (
+                        <p className="text-[10px] mt-1 font-bold uppercase tracking-wide text-rose-600">Vencida {'>'} 7d</p>
                       )}
-                      <button 
-                        onClick={() => setSelectedId(item.id)}
-                        className="px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:bg-slate-50 text-slate-600 text-[10px] font-bold uppercase transition-colors"
-                      >
-                        Detalhes
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
+                    </td>
+                    <td className="py-4 px-6">
+                      {item.comprovativo_url ? (
+                        <button
+                          onClick={() => window.open(item.comprovativo_url, "_blank")}
+                          className="flex items-center gap-2 text-[10px] font-bold text-amber-600 uppercase hover:text-amber-700"
+                        >
+                          📄 Ver Comprovativo
+                        </button>
+                      ) : (
+                        <span className="text-[10px] text-slate-300 uppercase italic">Sem prova</span>
+                      )}
+                      {item.referencia_ext && <p className="text-[10px] text-slate-400 mt-1 font-mono">Ref: {item.referencia_ext}</p>}
+                    </td>
+                    <td className="py-4 px-6">
+                      <p className="text-xs text-slate-500">{format(new Date(item.data_renovacao), "dd 'de' MMM, yyyy", { locale: pt })}</p>
+                    </td>
+                    <td className="py-4 px-6">
+                      <div className="flex gap-2">
+                        {item.status === "pendente" && (
+                          <button
+                            disabled={confirmingId === item.id}
+                            onClick={() => handleConfirmar(item)}
+                            className="px-3 py-1.5 rounded-lg bg-[#1F6B3B] hover:bg-[#1F6B3B]/90 text-white text-[10px] font-bold uppercase transition-colors disabled:opacity-50 shadow-sm"
+                          >
+                            {confirmingId === item.id ? "..." : "Activar"}
+                          </button>
+                        )}
+                        <button
+                          onClick={() => setSelectedId(item.id)}
+                          className="px-3 py-1.5 rounded-lg bg-white border border-slate-200 hover:bg-slate-50 text-slate-600 text-[10px] font-bold uppercase transition-colors"
+                        >
+                          Detalhes
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
             </tbody>
           </table>
         </div>
       </div>
 
       {/* ── Slideover de Detalhes ── */}
-      {selectedId && (
-        <AssinaturaDetailsSlideover 
-          assinaturaId={selectedId} 
-          onClose={() => setSelectedId(null)} 
-          onUpdated={loadData}
-        />
-      )}
+      {selectedId && <AssinaturaDetailsSlideover assinaturaId={selectedId} onClose={() => setSelectedId(null)} onUpdated={refreshAll} />}
     </div>
   );
 }

--- a/apps/web/src/lib/super-admin/billing-dashboard-summary.ts
+++ b/apps/web/src/lib/super-admin/billing-dashboard-summary.ts
@@ -1,0 +1,155 @@
+export type BillingAssinaturaSnapshot = {
+  id: string;
+  ciclo: "mensal" | "anual";
+  status: string;
+  valor_kz: number;
+  data_renovacao: string;
+  created_at?: string | null;
+};
+
+export type BillingPagamentoSnapshot = {
+  assinatura_id: string;
+  status: "pendente" | "confirmado" | "falhado" | string;
+  comprovativo_url?: string | null;
+  periodo_fim?: string | null;
+  created_at: string;
+};
+
+export type BillingDashboardSummary = {
+  mrr: number;
+  arr: number;
+  pendentes_comprovativo: number;
+  vencidas_gt_7d: number;
+  vencidas_assinatura_ids: string[];
+  mrr_variacao_percentual: number;
+  mrr_mes_anterior: number;
+  regras: {
+    tolerancia_atraso_dias: number;
+    renovacao_base: string;
+    pagamento_confirmado_status: string;
+  };
+};
+
+const STATUS_ATIVO = "activa";
+const STATUS_PAGAMENTO_CONFIRMADO = "confirmado";
+export const TOLERANCIA_ATRASO_DIAS = 7;
+
+function startOfDay(date: Date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function addDays(date: Date, days: number) {
+  const d = new Date(date);
+  d.setDate(d.getDate() + days);
+  return d;
+}
+
+function getLatestPaymentBefore(
+  paymentsByAssinatura: Map<string, BillingPagamentoSnapshot[]>,
+  assinaturaId: string,
+  referenceDate: Date,
+) {
+  const all = paymentsByAssinatura.get(assinaturaId) ?? [];
+  const refTs = referenceDate.getTime();
+  for (const pg of all) {
+    if (new Date(pg.created_at).getTime() <= refTs) return pg;
+  }
+  return null;
+}
+
+function isCoveredByConfirmedPayment(payment: BillingPagamentoSnapshot | null, referenceDate: Date) {
+  if (!payment || payment.status !== STATUS_PAGAMENTO_CONFIRMADO) return false;
+  if (!payment.periodo_fim) return true;
+  return new Date(payment.periodo_fim).getTime() >= startOfDay(referenceDate).getTime();
+}
+
+function isOverdue(
+  assinatura: BillingAssinaturaSnapshot,
+  latestPayment: BillingPagamentoSnapshot | null,
+  referenceDate: Date,
+) {
+  const renewalDate = new Date(assinatura.data_renovacao);
+  const renewalDeadline = addDays(renewalDate, TOLERANCIA_ATRASO_DIAS);
+  if (renewalDeadline.getTime() >= referenceDate.getTime()) return false;
+  return !isCoveredByConfirmedPayment(latestPayment, referenceDate);
+}
+
+function computeMrrAt(
+  assinaturas: BillingAssinaturaSnapshot[],
+  paymentsByAssinatura: Map<string, BillingPagamentoSnapshot[]>,
+  referenceDate: Date,
+) {
+  return assinaturas.reduce((acc, assinatura) => {
+    if (assinatura.status !== STATUS_ATIVO || assinatura.ciclo !== "mensal") return acc;
+
+    const latestPayment = getLatestPaymentBefore(paymentsByAssinatura, assinatura.id, referenceDate);
+    if (isOverdue(assinatura, latestPayment, referenceDate)) return acc;
+
+    return acc + Number(assinatura.valor_kz ?? 0);
+  }, 0);
+}
+
+export function buildBillingDashboardSummary(
+  assinaturas: BillingAssinaturaSnapshot[],
+  pagamentos: BillingPagamentoSnapshot[],
+  referenceDate = new Date(),
+): BillingDashboardSummary {
+  const orderedPayments = [...pagamentos].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+
+  const paymentsByAssinatura = orderedPayments.reduce((map, payment) => {
+    const bucket = map.get(payment.assinatura_id) ?? [];
+    bucket.push(payment);
+    map.set(payment.assinatura_id, bucket);
+    return map;
+  }, new Map<string, BillingPagamentoSnapshot[]>());
+
+  const currentMrr = computeMrrAt(assinaturas, paymentsByAssinatura, referenceDate);
+  const previousMonthReference = new Date(referenceDate);
+  previousMonthReference.setMonth(previousMonthReference.getMonth() - 1);
+  const previousMrr = computeMrrAt(assinaturas, paymentsByAssinatura, previousMonthReference);
+
+  const vencidasAssinaturaIds: string[] = [];
+  let arr = 0;
+
+  for (const assinatura of assinaturas) {
+    if (assinatura.status !== STATUS_ATIVO) continue;
+
+    const latestPayment = getLatestPaymentBefore(paymentsByAssinatura, assinatura.id, referenceDate);
+    if (isOverdue(assinatura, latestPayment, referenceDate)) {
+      vencidasAssinaturaIds.push(assinatura.id);
+      continue;
+    }
+
+    if (assinatura.ciclo === "anual") {
+      arr += Number(assinatura.valor_kz ?? 0);
+    }
+  }
+
+  arr += currentMrr * 12;
+
+  const pendentesComprovativo = orderedPayments.filter(
+    (payment) => payment.status === "pendente" && !!payment.comprovativo_url,
+  ).length;
+
+  const mrrVariacaoPercentual =
+    previousMrr <= 0 ? (currentMrr > 0 ? 100 : 0) : ((currentMrr - previousMrr) / previousMrr) * 100;
+
+  return {
+    mrr: currentMrr,
+    arr,
+    pendentes_comprovativo: pendentesComprovativo,
+    vencidas_gt_7d: vencidasAssinaturaIds.length,
+    vencidas_assinatura_ids: vencidasAssinaturaIds,
+    mrr_variacao_percentual: mrrVariacaoPercentual,
+    mrr_mes_anterior: previousMrr,
+    regras: {
+      tolerancia_atraso_dias: TOLERANCIA_ATRASO_DIAS,
+      renovacao_base: "data_renovacao",
+      pagamento_confirmado_status: STATUS_PAGAMENTO_CONFIRMADO,
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Centralize billing KPI calculations on the backend so dashboard widgets and the histórico tab share a single source of truth and avoid divergence. 
- Provide an aggregated KPI endpoint for MRR/ARR and operational flags to simplify frontend logic and enforce consistent business rules. 
- Make overdue detection and payment-tolerance rules explicit in one place to reduce subtle mismatch between UI and table data. 

### Description
- Added a new endpoint `GET /api/super-admin/billing/dashboard/summary` (server route) that returns `mrr`, `arr`, `pendentes_comprovativo`, `vencidas_gt_7d` plus helper fields and rules metadata, and requires super-admin access. 
- Introduced `buildBillingDashboardSummary` in `apps/web/src/lib/super-admin/billing-dashboard-summary.ts` to centralize calculation rules (renewal base = `data_renovacao`, tolerance = 7 days, confirmed status = `confirmado`, MRR/ARR logic and previous month comparison). 
- Updated `CobrancasListClient.tsx` to consume the new endpoint via `loadSummary`, remove local KPI calculations, refresh list+KPIs together, and render MRR month-over-month variation and overdue visual cues in cards and table rows. 
- Added `BillingSummarySnapshot` component and included it in the Histórico tab so that the historical view reads the same aggregated summary as the dashboard. 

### Testing
- Typecheck passed with `pnpm --filter web exec tsc --noEmit`. 
- Linting executed with `pnpm --filter web exec eslint` on touched files and completed without errors (existing warnings in `CobrancasListClient.tsx` remain). 
- Local dev run succeeded (`pnpm --filter web dev`) and a Playwright screenshot was captured to validate the UI changes (visual verification artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a411f235808328a1be042bbfbdcb06)