### PR TITLE
feat(billing): add upgrade/annual/Stripe-portal actions to Assinatura UI and API

### DIFF
--- a/apps/web/src/app/api/escola/[id]/billing/stripe-portal/route.ts
+++ b/apps/web/src/app/api/escola/[id]/billing/stripe-portal/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+import type { Database } from "~types/supabase";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function POST(_: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id: requestedEscolaId } = await params;
+    const supabase = await supabaseServerTyped<Database>();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado." }, { status: 401 });
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id, requestedEscolaId);
+    if (!escolaId || escolaId !== requestedEscolaId) {
+      return NextResponse.json({ ok: false, error: "Acesso negado a esta escola." }, { status: 403 });
+    }
+
+    const { data: assinatura, error } = await supabase
+      .from("assinaturas")
+      .select("id, escola_id, metodo_pagamento, stripe_customer_id")
+      .eq("escola_id", escolaId)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    if (!assinatura) {
+      return NextResponse.json({ ok: false, error: "Assinatura não encontrada." }, { status: 404 });
+    }
+
+    if (assinatura.metodo_pagamento !== "stripe" && assinatura.metodo_pagamento !== "cartao") {
+      return NextResponse.json(
+        { ok: false, error: "Portal Stripe disponível apenas para assinaturas com cartão/Stripe." },
+        { status: 409 }
+      );
+    }
+
+    const basePortalUrl = process.env.STRIPE_CUSTOMER_PORTAL_URL?.trim();
+    const appUrl = (process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000").trim();
+
+    if (!basePortalUrl) {
+      return NextResponse.json(
+        { ok: false, error: "Stripe portal não configurado. Defina STRIPE_CUSTOMER_PORTAL_URL." },
+        { status: 503 }
+      );
+    }
+
+    const portalUrl = assinatura.stripe_customer_id
+      ? `${basePortalUrl}?prefilled_email=&customer=${encodeURIComponent(assinatura.stripe_customer_id)}&return_url=${encodeURIComponent(`${appUrl}/escola/${escolaId}/admin/configuracoes/assinatura`)}`
+      : `${basePortalUrl}?return_url=${encodeURIComponent(`${appUrl}/escola/${escolaId}/admin/configuracoes/assinatura`)}`;
+
+    return NextResponse.json({
+      ok: true,
+      url: portalUrl,
+      message: "A redirecionar para o portal Stripe.",
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao iniciar Stripe portal.";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/escola/[id]/billing/upgrade/route.ts
+++ b/apps/web/src/app/api/escola/[id]/billing/upgrade/route.ts
@@ -1,0 +1,133 @@
+import { NextRequest, NextResponse } from "next/server";
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+import { PLAN_VALUES, type PlanTier } from "@/config/plans";
+import type { Database } from "~types/supabase";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const PLAN_INDEX: Record<PlanTier, number> = {
+  essencial: 0,
+  profissional: 1,
+  premium: 2,
+};
+
+const PRICE_TABLE: Record<PlanTier, { mensal: number; anual: number }> = {
+  essencial: { mensal: 60000, anual: 600000 },
+  profissional: { mensal: 120000, anual: 1200000 },
+  premium: { mensal: 0, anual: 0 },
+};
+
+type BillingPayload = {
+  targetPlan?: PlanTier;
+  targetCycle?: "mensal" | "anual";
+};
+
+function normalizeCycle(value: unknown): "mensal" | "anual" {
+  return value === "anual" ? "anual" : "mensal";
+}
+
+function isPlanTier(value: unknown): value is PlanTier {
+  return typeof value === "string" && PLAN_VALUES.includes(value as PlanTier);
+}
+
+export async function POST(req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id: requestedEscolaId } = await params;
+    const supabase = await supabaseServerTyped<Database>();
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado." }, { status: 401 });
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id, requestedEscolaId);
+    if (!escolaId || escolaId !== requestedEscolaId) {
+      return NextResponse.json({ ok: false, error: "Acesso negado a esta escola." }, { status: 403 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as BillingPayload;
+
+    const { data: assinatura, error: assinaturaError } = await supabase
+      .from("assinaturas")
+      .select("id, escola_id, plano, ciclo, status, data_renovacao, valor_kz, metodo_pagamento")
+      .eq("escola_id", escolaId)
+      .maybeSingle();
+
+    if (assinaturaError) throw assinaturaError;
+
+    if (!assinatura) {
+      return NextResponse.json({ ok: false, error: "Assinatura não encontrada." }, { status: 404 });
+    }
+
+    if (assinatura.status !== "activa") {
+      return NextResponse.json(
+        { ok: false, error: "Upgrade permitido apenas durante ciclo activo." },
+        { status: 409 }
+      );
+    }
+
+    const now = new Date();
+    const renewalDate = new Date(assinatura.data_renovacao);
+    const cycleIsActive = now < renewalDate;
+
+    if (!cycleIsActive) {
+      return NextResponse.json(
+        { ok: false, error: "Ciclo inactivo. Aguarde renovação para alterar o plano." },
+        { status: 409 }
+      );
+    }
+
+    const nextPlan: PlanTier = isPlanTier(body.targetPlan) ? body.targetPlan : assinatura.plano;
+    const currentCycle = normalizeCycle(assinatura.ciclo);
+    const nextCycle: "mensal" | "anual" = body.targetCycle === "anual" ? "anual" : currentCycle;
+
+    const currentPlanIndex = PLAN_INDEX[assinatura.plano as PlanTier];
+    const targetPlanIndex = PLAN_INDEX[nextPlan];
+
+    if (targetPlanIndex < currentPlanIndex) {
+      return NextResponse.json(
+        { ok: false, error: "Downgrade no meio do ciclo não é permitido." },
+        { status: 409 }
+      );
+    }
+
+    const updatedValue = PRICE_TABLE[nextPlan][nextCycle];
+
+    const { error: updateError } = await supabase
+      .from("assinaturas")
+      .update({
+        plano: nextPlan,
+        ciclo: nextCycle,
+        valor_kz: updatedValue,
+      })
+      .eq("id", assinatura.id)
+      .eq("escola_id", escolaId);
+
+    if (updateError) throw updateError;
+
+    const actionLabel = targetPlanIndex > currentPlanIndex ? "upgrade" : "mudança de ciclo";
+
+    return NextResponse.json({
+      ok: true,
+      action: actionLabel,
+      message:
+        assinatura.metodo_pagamento === "stripe" || assinatura.metodo_pagamento === "cartao"
+          ? "Alteração registada. O fluxo Stripe será priorizado para cobrança automática."
+          : "Alteração registada. Continue com upload de comprovativo para pagamentos por transferência.",
+      data: {
+        assinaturaId: assinatura.id,
+        targetPlan: nextPlan,
+        targetCycle: nextCycle,
+        valor_kz: updatedValue,
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao iniciar upgrade.";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/escola/configuracoes/AssinaturaKlasseClient.tsx
+++ b/apps/web/src/components/escola/configuracoes/AssinaturaKlasseClient.tsx
@@ -5,6 +5,7 @@ import { createClient } from "@/lib/supabaseClient";
 import { toast } from "sonner";
 import { format } from "date-fns";
 import { pt } from "date-fns/locale";
+import { differenceInCalendarDays } from "date-fns";
 import { PLAN_NAMES, type PlanTier } from "@/config/plans";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
@@ -38,6 +39,7 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
   const [pagamentos, setPagamentos] = useState<Pagamento[]>([]);
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState(false);
+  const [actionLoading, setActionLoading] = useState<null | "upgrade" | "annual" | "portal">(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const supabase = createClient();
@@ -92,6 +94,41 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
   useEffect(() => {
     if (escolaId) loadData();
   }, [escolaId]);
+
+  const handleBillingAction = async (
+    action: "upgrade" | "annual" | "portal",
+    payload?: Record<string, unknown>
+  ) => {
+    try {
+      setActionLoading(action);
+      const endpoint = action === "portal"
+        ? `/api/escola/${escolaId}/billing/stripe-portal`
+        : `/api/escola/${escolaId}/billing/upgrade`;
+
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload ?? {}),
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error ?? "Não foi possível processar a acção.");
+      }
+
+      if (result?.url) {
+        window.location.href = result.url as string;
+        return;
+      }
+
+      toast.success(result?.message ?? "Acção iniciada com sucesso.");
+      await loadData();
+    } catch (err: any) {
+      toast.error(err?.message ?? "Falha ao executar a acção de billing.");
+    } finally {
+      setActionLoading(null);
+    }
+  };
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();
@@ -173,6 +210,13 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
 
   const isPendente = assinatura.status === 'pendente';
   const hasPagamentoPendente = pagamentos.some(p => p.status === 'pendente');
+  const renovacaoDate = new Date(assinatura.data_renovacao);
+  const diasRestantes = Math.max(0, differenceInCalendarDays(renovacaoDate, new Date()));
+  const isStripe = assinatura.metodo_pagamento === 'stripe' || assinatura.metodo_pagamento === 'cartao';
+  const planOrder: PlanTier[] = ["essencial", "profissional", "premium"];
+  const currentPlanIndex = planOrder.indexOf(assinatura.plano);
+  const canUpgradePlan = currentPlanIndex >= 0 && currentPlanIndex < planOrder.length - 1;
+  const nextPlan = canUpgradePlan ? planOrder[currentPlanIndex + 1] : null;
 
   return (
     <div className="space-y-6">
@@ -205,6 +249,12 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
                 </span>
               </div>
               <div className="flex justify-between items-center py-2 border-b border-slate-100">
+                <span className="text-sm text-slate-500">Próxima Cobrança</span>
+                <span className="text-sm font-bold text-slate-900">
+                  {diasRestantes} dia(s) · Kz {assinatura.valor_kz.toLocaleString()}
+                </span>
+              </div>
+              <div className="flex justify-between items-center py-2 border-b border-slate-100">
                 <span className="text-sm text-slate-500">Valor da Mensalidade</span>
                 <span className="text-sm font-bold text-slate-900">Kz {assinatura.valor_kz.toLocaleString()}</span>
               </div>
@@ -233,6 +283,47 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
                   </div>
                 </div>
               </div>
+            )}
+          </div>
+
+          <div className="mt-8 pt-6 border-t border-slate-100">
+            <div className="flex flex-wrap gap-3">
+              <Button
+                onClick={() => handleBillingAction("upgrade", { targetPlan: nextPlan })}
+                disabled={!canUpgradePlan || actionLoading !== null}
+                loading={actionLoading === "upgrade"}
+              >
+                Fazer upgrade
+              </Button>
+              <Button
+                tone="slate"
+                onClick={() => handleBillingAction("annual", { targetCycle: "anual" })}
+                disabled={assinatura.ciclo === "anual" || actionLoading !== null}
+                loading={actionLoading === "annual"}
+              >
+                Mudar para anual
+              </Button>
+              <Button
+                tone="green"
+                onClick={() => handleBillingAction("portal")}
+                disabled={!isStripe || actionLoading !== null}
+                loading={actionLoading === "portal"}
+              >
+                Gerir cartão (Stripe)
+              </Button>
+              <Button
+                tone="gray"
+                onClick={() => {
+                  document.getElementById("billing-history")?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }}
+              >
+                Ver histórico completo
+              </Button>
+            </div>
+            {isStripe && (
+              <p className="mt-3 text-xs text-emerald-700 bg-emerald-50 border border-emerald-100 rounded-lg p-3">
+                Pagamentos via Stripe são tratados automaticamente. Use os botões de upgrade e gestão de cartão para acelerar mudanças no seu plano.
+              </p>
             )}
           </div>
 
@@ -274,7 +365,7 @@ export default function AssinaturaKlasseClient({ escolaId }: AssinaturaKlasseCli
       </Card>
 
       {/* ── Histórico de Pagamentos ── */}
-      <Card className="border-slate-200">
+      <Card className="border-slate-200" id="billing-history">
         <CardHeader>
           <CardTitle className="text-lg">Histórico de Pagamentos Klasse</CardTitle>
           <CardDescription>Consulte os seus pagamentos anteriores e o estado das facturas.</CardDescription>


### PR DESCRIPTION
### Motivation
- Expor no UI ações de billing (upgrade, mudar para anual, gerir cartão Stripe, ver histórico) para que escolas possam gerir planos sem intervenção do suporte. 
- Fornecer endpoints backend para iniciar fluxos de upgrade e acesso ao portal Stripe com validação de tenant e regras de negócio. 
- Aplicar regras comerciais: permitir upgrade somente durante ciclo activo e bloquear downgrade a meio do ciclo. 
- Mostrar próximo evento de cobrança (dias restantes + valor) dinamicamente para evitar textos estáticos enganosos.

### Description
- Atualizei `apps/web/src/components/escola/configuracoes/AssinaturaKlasseClient.tsx` para adicionar botões `Fazer upgrade`, `Mudar para anual`, `Gerir cartão (Stripe)` e `Ver histórico completo`, um handler genérico `handleBillingAction` e cálculo de `diasRestantes` usando `differenceInCalendarDays`. 
- Mostro a linha “Próxima Cobrança” com dias restantes + valor e adicionei uma âncora `id="billing-history"` para o botão de histórico. 
- Adicionei endpoint `POST /api/escola/[id]/billing/upgrade` em `apps/web/src/app/api/escola/[id]/billing/upgrade/route.ts` que resolve o tenant com `resolveEscolaIdForUser`, valida sessão, exige `assinatura.status === 'activa'` e `ciclo` activo, impede downgrade no meio do ciclo e atualiza `plano`, `ciclo` e `valor_kz`. 
- Adicionei endpoint `POST /api/escola/[id]/billing/stripe-portal` em `apps/web/src/app/api/escola/[id]/billing/stripe-portal/route.ts` que valida método de pagamento (`stripe`/`cartao`) e retorna um `url` de redirecionamento baseado em `STRIPE_CUSTOMER_PORTAL_URL` e `NEXT_PUBLIC_APP_URL` quando configurado. 

### Testing
- Executed TypeScript compile with `cd apps/web && pnpm exec tsc --noEmit` which completed successfully. 
- `pnpm --filter web typecheck` failed during the workspace pretypecheck step due to environment restrictions fetching Supabase types (`ERR_PNPM_FETCH_403`), not due to code errors. 
- Started the dev server with `cd apps/web && pnpm dev` which compiled the app; accessing the protected school page returned a runtime error because Supabase env vars are missing in the local environment. 
- Produced UI screenshots of the app root and the assinatura route via a headless browser run (artifacts available), but the protected route could not fully render without valid Supabase envs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a41244706c8328a9d95ce46ed01d2d)