### PR TITLE
Make sync-assinaturas create pending subscriptions, require explicit valor_kz, and add admin report

### DIFF
--- a/apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts
+++ b/apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts
@@ -9,6 +9,31 @@ import { PLAN_NAMES, type PlanTier } from '@/config/plans';
  * API para Gestão Individual de Assinaturas (Cockpit Super Admin)
  */
 
+
+function getExpectedValorKz(plano: PlanTier, ciclo: 'mensal' | 'anual'): number | null {
+  const tabela: Record<PlanTier, Record<'mensal' | 'anual', number | null>> = {
+    essencial: { mensal: 60000, anual: 720000 },
+    profissional: { mensal: 120000, anual: 1440000 },
+    premium: { mensal: null, anual: null },
+  };
+
+  return tabela[plano]?.[ciclo] ?? null;
+}
+
+function isValorKzValido({ plano, ciclo, valorKz }: { plano: PlanTier; ciclo: 'mensal' | 'anual'; valorKz: unknown }) {
+  if (typeof valorKz !== 'number' || !Number.isFinite(valorKz) || valorKz <= 0) {
+    return false;
+  }
+
+  const esperado = getExpectedValorKz(plano, ciclo);
+
+  if (plano === 'premium') {
+    return esperado === null;
+  }
+
+  return valorKz === esperado;
+}
+
 export async function PATCH(req: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params;
   
@@ -21,6 +46,22 @@ export async function PATCH(req: NextRequest, context: { params: Promise<{ id: s
 
     const body = await req.json();
     const { action, ...updates } = body;
+
+    if ('plano' in updates || 'ciclo' in updates || 'valor_kz' in updates) {
+      const plano = (updates.plano ?? body.plano) as PlanTier | undefined;
+      const ciclo = (updates.ciclo ?? body.ciclo) as 'mensal' | 'anual' | undefined;
+      const valorKz = updates.valor_kz;
+
+      if (!plano || !ciclo || !isValorKzValido({ plano, ciclo, valorKz: valorKz as unknown })) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: 'Não é permitido salvar assinatura sem valor_kz válido para o plano/ciclo seleccionado.',
+          },
+          { status: 400 },
+        );
+      }
+    }
 
     // 1. Acção Especial: Reenviar Instruções por Email
     if (action === 'resend_instructions') {

--- a/apps/web/src/app/api/super-admin/billing/sync-assinaturas/route.ts
+++ b/apps/web/src/app/api/super-admin/billing/sync-assinaturas/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { supabaseServer } from '@/lib/supabaseServer';
 import { isSuperAdminRole } from '@/lib/auth/requireSuperAdminAccess';
-import { parsePlanTier } from '@/config/plans';
+import { parsePlanTier, type PlanTier } from '@/config/plans';
 
-export async function POST(req: NextRequest) {
+export async function POST(_req: NextRequest) {
   try {
     const s = await supabaseServer();
     const { data: sess } = await s.auth.getUser();
@@ -40,39 +40,99 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ ok: true, message: 'Todas as escolas já possuem assinaturas configuradas.' });
     }
 
-    // 4. Mapeamento de preços por plano
-    const precos: Record<string, number> = {
-      essencial: 60000,
-      profissional: 120000,
-      premium: 0 // Negociado / Placeholder
+    // 4. Mapeamento de preços por plano/ciclo
+    const precosPorPlanoCiclo: Record<PlanTier, Record<'mensal' | 'anual', number | null>> = {
+      essencial: {
+        mensal: 60000,
+        anual: 720000,
+      },
+      profissional: {
+        mensal: 120000,
+        anual: 1440000,
+      },
+      premium: {
+        mensal: null,
+        anual: null,
+      },
     };
 
-    // 5. Preparar inserts
+    // 5. Preparar inserts e relatório
     const dataRenovacao = new Date();
     dataRenovacao.setDate(dataRenovacao.getDate() + 30); // 30 dias a partir de hoje
 
-    const inserts = escolasParaSync.map(e => ({
-      escola_id: e.id,
-      plano: parsePlanTier(e.plano_atual),
-      ciclo: 'mensal',
-      status: 'activa',
-      metodo_pagamento: 'transferencia',
-      valor_kz: precos[parsePlanTier(e.plano_atual)] || 60000,
-      data_renovacao: dataRenovacao.toISOString(),
-      data_inicio: new Date().toISOString()
-    }));
+    const agoraIso = new Date().toISOString();
+    const inserts: Array<Record<string, unknown>> = [];
+    const escolasCriadasViaSync: Array<Record<string, unknown>> = [];
+    const escolasPendentesParametrizacao: Array<Record<string, unknown>> = [];
+
+    for (const escola of escolasParaSync) {
+      const plano = parsePlanTier(escola.plano_atual);
+      const ciclo: 'mensal' | 'anual' = 'mensal';
+      const valorDefinido = precosPorPlanoCiclo[plano]?.[ciclo] ?? null;
+
+      if (plano === 'premium' && valorDefinido === null) {
+        escolasPendentesParametrizacao.push({
+          escola_id: escola.id,
+          escola_nome: escola.nome,
+          plano,
+          ciclo,
+          motivo: 'Plano premium exige valor_kz explícito (sem fallback automático).',
+        });
+      }
+
+      if (typeof valorDefinido !== 'number' || Number.isNaN(valorDefinido) || valorDefinido <= 0) {
+        escolasPendentesParametrizacao.push({
+          escola_id: escola.id,
+          escola_nome: escola.nome,
+          plano,
+          ciclo,
+          motivo: 'Não foi criada assinatura: valor_kz inválido para o plano/ciclo.',
+        });
+        continue;
+      }
+
+      inserts.push({
+        escola_id: escola.id,
+        plano,
+        ciclo,
+        status: 'pendente',
+        metodo_pagamento: 'transferencia',
+        valor_kz: valorDefinido,
+        data_renovacao: dataRenovacao.toISOString(),
+        data_inicio: agoraIso,
+        origem_registo: 'sync_bootstrap',
+        motivo_origem: 'sync_bootstrap',
+      });
+
+      escolasCriadasViaSync.push({
+        escola_id: escola.id,
+        escola_nome: escola.nome,
+        plano,
+        ciclo,
+        valor_kz: valorDefinido,
+      });
+    }
 
     // 6. Inserir em lote
-    const { error: insertError } = await s
-      .from('assinaturas')
-      .insert(inserts);
+    if (inserts.length > 0) {
+      const { error: insertError } = await s
+        .from('assinaturas')
+        .insert(inserts);
 
-    if (insertError) throw insertError;
+      if (insertError) throw insertError;
+    }
 
-    return NextResponse.json({ 
-      ok: true, 
-      message: `${escolasParaSync.length} assinaturas inicializadas com sucesso.`,
-      count: escolasParaSync.length
+    return NextResponse.json({
+      ok: true,
+      message: `${inserts.length} assinaturas inicializadas em status pendente.`,
+      count: inserts.length,
+      report_super_admin: {
+        total_escolas_sync: escolasParaSync.length,
+        assinaturas_criadas: escolasCriadasViaSync.length,
+        escolas_criadas: escolasCriadasViaSync,
+        pendentes_parametrizacao: escolasPendentesParametrizacao.length,
+        escolas_pendentes_parametrizacao: escolasPendentesParametrizacao,
+      },
     });
 
   } catch (err: any) {

--- a/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
+++ b/apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx
@@ -6,13 +6,14 @@
  * Tokens KLASSE: #1F6B3B (green), #E3B23C (gold).
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createClient } from "@/lib/supabaseClient";
 import { toast } from "sonner";
 import { format } from "date-fns";
 import { pt } from "date-fns/locale";
 import { PLAN_NAMES, type PlanTier } from "@/config/plans";
 import AssinaturaDetailsSlideover from "./AssinaturaDetailsSlideover";
+import { AlertTriangle } from "lucide-react";
 
 // ─── Tipos ────────────────────────────────────────────────────────────────────
 
@@ -26,6 +27,8 @@ type AssinaturaPendente = {
   data_renovacao: string;
   metodo_pagamento: string;
   status: string;
+  origem_registo?: string | null;
+  motivo_origem?: string | null;
   pagamento_id?: string;
   comprovativo_url?: string;
   referencia_ext?: string;
@@ -86,6 +89,7 @@ export default function CobrancasListClient() {
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [syncing, setSyncing] = useState(false);
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [syncReport, setSyncReport] = useState<{ total_escolas_sync: number; assinaturas_criadas: number; escolas_criadas: Array<{ escola_id: string; escola_nome: string; plano: PlanTier; ciclo: "mensal" | "anual"; valor_kz: number; }>; pendentes_parametrizacao: number; escolas_pendentes_parametrizacao: Array<{ escola_id: string; escola_nome: string; plano: PlanTier; ciclo: "mensal" | "anual"; motivo: string; }>; } | null>(null);
 
   const supabase = createClient();
 
@@ -95,6 +99,7 @@ export default function CobrancasListClient() {
       const res = await fetch('/api/super-admin/billing/sync-assinaturas', { method: 'POST' });
       const json = await res.json();
       if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao sincronizar');
+      setSyncReport(json.report_super_admin ?? null);
       toast.success(json.message || 'Sincronização concluída');
       loadData();
     } catch (err: any) {
@@ -141,6 +146,8 @@ export default function CobrancasListClient() {
           data_renovacao: row.data_renovacao,
           metodo_pagamento: row.metodo_pagamento,
           status: row.status,
+          origem_registo: row.origem_registo,
+          motivo_origem: row.motivo_origem,
           pagamento_id: ultimoPg?.id,
           comprovativo_url: ultimoPg?.comprovativo_url || undefined,
           referencia_ext: ultimoPg?.referencia_ext,
@@ -205,9 +212,59 @@ export default function CobrancasListClient() {
 
   const cols = ["Escola", "Plano / Ciclo", "Valor", "Status", "Pagamento", "Renovação", "Acções"];
 
+  const pendentesParametrizacao = useMemo(
+    () => items.filter((item) => item.status === "pendente" && item.valor_kz <= 0),
+    [items],
+  );
+
   return (
     <div className="text-slate-900">
       
+      {syncReport && (
+        <div className="mb-4 rounded-2xl border border-amber-200 bg-amber-50 p-4">
+          <p className="text-[11px] font-bold uppercase tracking-widest text-amber-700">Relatório de bootstrap para revisão Super Admin</p>
+          <p className="mt-1 text-xs text-amber-800">
+            {syncReport.total_escolas_sync} escola(s) no sync; {syncReport.assinaturas_criadas} assinatura(s) criada(s); {syncReport.pendentes_parametrizacao} pendente(s) de parametrização.
+          </p>
+          {syncReport.escolas_criadas.length > 0 && (
+            <div className="mt-2">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-amber-700">Escolas com assinatura criada</p>
+              <ul className="mt-1 space-y-1 text-xs text-amber-900">
+                {syncReport.escolas_criadas.map((escola) => (
+                  <li key={escola.escola_id}>
+                    • {escola.escola_nome} ({PLAN_NAMES[escola.plano]} / {escola.ciclo}) — Kz {escola.valor_kz.toLocaleString()}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {syncReport.escolas_pendentes_parametrizacao.length > 0 && (
+            <div className="mt-2">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-red-700">Escolas pendentes de parametrização</p>
+              <ul className="mt-1 space-y-1 text-xs text-red-800">
+                {syncReport.escolas_pendentes_parametrizacao.map((escola) => (
+                  <li key={escola.escola_id}>
+                    • {escola.escola_nome} ({PLAN_NAMES[escola.plano]} / {escola.ciclo}) — {escola.motivo}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {pendentesParametrizacao.length > 0 && (
+        <div className="mb-4 rounded-2xl border border-red-200 bg-red-50 p-4 flex items-start gap-3">
+          <AlertTriangle className="h-4 w-4 mt-0.5 text-red-600" />
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-widest text-red-700">Assinaturas pendentes de parametrização</p>
+            <p className="mt-1 text-xs text-red-800">
+              {pendentesParametrizacao.length} assinatura(s) com valor_kz inválido ou pendência de configuração inicial. Rever e parametrizar antes da activação.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* ── Dashboard Stats ── */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
         <div className="bg-white border border-slate-200 p-4 rounded-2xl shadow-sm">
@@ -298,6 +355,9 @@ export default function CobrancasListClient() {
                   </td>
                   <td className="py-4 px-6">
                     <p className="text-slate-700 font-mono font-semibold">Kz {item.valor_kz.toLocaleString()}</p>
+                    {item.status === 'pendente' && item.valor_kz <= 0 && (
+                      <p className="mt-1 text-[10px] font-bold uppercase tracking-wide text-red-600">Parametrização obrigatória</p>
+                    )}
                   </td>
                   <td className="py-4 px-6">
                     <StatusBadge status={item.status} />

--- a/supabase/migrations/20260327000000_assinaturas_sync_bootstrap_metadata.sql
+++ b/supabase/migrations/20260327000000_assinaturas_sync_bootstrap_metadata.sql
@@ -1,0 +1,8 @@
+-- Metadata para rastrear origem da criação automática de assinaturas
+ALTER TABLE public.assinaturas
+  ADD COLUMN IF NOT EXISTS origem_registo TEXT,
+  ADD COLUMN IF NOT EXISTS motivo_origem TEXT;
+
+COMMENT ON COLUMN public.assinaturas.origem_registo IS 'Origem operacional do registo (ex.: sync_bootstrap, manual, import).';
+COMMENT ON COLUMN public.assinaturas.motivo_origem IS 'Motivo da criação automática para revisão do Super Admin.';
+


### PR DESCRIPTION
### Motivation
- Ensure automatically-created subscriptions are not activated implicitly and carry provenance for later review by Super Admin. 
- Avoid unsafe fallbacks for `premium` plans by requiring an explicit `valor_kz` per plan/cycle. 
- Surface outstanding parametrization work in the Super Admin UI so operators can review and complete missing billing data.

### Description
- Change `POST /api/super-admin/billing/sync-assinaturas` to create subscriptions with `status: 'pendente'`, record `origem_registo`/`motivo_origem` set to `sync_bootstrap`, and remove automatic price fallback for `premium`, returning a structured `report_super_admin` with created vs pending items (file: `apps/web/src/app/api/super-admin/billing/sync-assinaturas/route.ts`).
- Add a DB migration to add metadata columns `origem_registo` and `motivo_origem` on `public.assinaturas` for provenance and review (file: `supabase/migrations/20260327000000_assinaturas_sync_bootstrap_metadata.sql`).
- Add server-side validation on subscription updates to prevent saving without a valid `valor_kz` for the selected `plano`/`ciclo`, and enforce explicit positive `valor_kz` requirements for `premium` (file: `apps/web/src/app/api/super-admin/billing/assinaturas/[id]/route.ts`).
- Update Super Admin billing UI to show the `report_super_admin` returned by the sync, highlight subscriptions pending parametrization, and mark rows where `valor_kz` is invalid (file: `apps/web/src/components/super-admin/cobrancas/CobrancasListClient.tsx`).

### Testing
- Ran ESLint on the modified files (`sync-assinaturas/route.ts`, `assinaturas/[id]/route.ts`, `CobrancasListClient.tsx`) with `npx eslint` and received no errors; only preexisting/warning-level issues remain in the list component. (result: warnings only)
- Adjusted `POST` handler param name to `_req` to silence an unused-arg lint warning; other lint issues are non-blocking warnings. (result: lint clean for errors)
- Attempted a Playwright screenshot of the `/super-admin/cobrancas` page to validate the UI change, but the local dev server was not available (`ERR_EMPTY_RESPONSE`), so end-to-end screenshot validation was not completed. (result: failed due to unavailable server)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a412616efc83289b043f69ab2d9336)