### PR TITLE
fix(agent): reduce KF2 search audit false positives on query patterns

### DIFF
--- a/agents/scan/kf2-search-audit.ts
+++ b/agents/scan/kf2-search-audit.ts
@@ -16,12 +16,49 @@ type Finding = {
 
 const findings: Finding[] = [];
 
+const QUERY_END_MARKER = /(?:;|\n\s*return\s+|\n\s*const\s+|\n\s*let\s+|\n\s*if\s*\(|\n\s*}\s*catch)/;
+
 function hasAllowScan(content: string) {
   return content.includes("@kf2 allow-scan");
 }
 
 function hasKf2Invariants(content: string) {
   return content.includes("applyKf2ListInvariants");
+}
+
+function extractQuerySegments(content: string) {
+  const segments: string[] = [];
+  const queryRegex = /\.(from|rpc)\(/g;
+
+  for (const match of content.matchAll(queryRegex)) {
+    const start = match.index ?? -1;
+    if (start < 0) continue;
+
+    const rest = content.slice(start);
+    const endMatch = rest.match(QUERY_END_MARKER);
+    const end = endMatch?.index ?? rest.length;
+
+    segments.push(rest.slice(0, end));
+  }
+
+  return segments;
+}
+
+function isSingleRowQuery(segment: string) {
+  return (
+    segment.includes(".single(") ||
+    segment.includes(".maybeSingle(") ||
+    segment.includes("head: true") ||
+    /\.limit\(\s*1\s*\)/.test(segment)
+  );
+}
+
+function hasRange(segment: string) {
+  return /\.range\(\s*\d+\s*,\s*\d+\s*\)/.test(segment);
+}
+
+function hasDeterministicOrder(segment: string) {
+  return segment.includes(".order(");
 }
 
 function checkFile(file: string, content: string) {
@@ -44,40 +81,71 @@ function checkFile(file: string, content: string) {
     return;
   }
 
-  if (content.includes(".select('*')") || content.includes('.select("*")')) {
-    findings.push({
-      file,
-      error: "Uso de select('*') em pesquisa",
-    });
+  const querySegments = extractQuerySegments(content);
+  if (querySegments.length === 0) {
+    return;
   }
 
-  const limitRegex = /\.limit\((\d+)\)/g;
-  const limits = [...content.matchAll(limitRegex)];
-  const usesKf2Invariants = hasKf2Invariants(content);
-
-  if (!usesKf2Invariants) {
-    if (limits.length === 0) {
+  for (const segment of querySegments) {
+    if (segment.includes(".select('*')") || segment.includes('.select("*")')) {
       findings.push({
         file,
-        error: "Pesquisa sem LIMIT explícito",
+        error: "Uso de select('*') em pesquisa",
       });
-    } else {
-      for (const [, value] of limits) {
-        if (Number(value) > MAX_LIMIT) {
-          findings.push({
-            file,
-            error: `LIMIT maior que ${MAX_LIMIT}`,
-          });
+    }
+
+    const limitRegex = /\.limit\((\d+)\)/g;
+    const limits = [...segment.matchAll(limitRegex)];
+    const usesKf2Invariants = hasKf2Invariants(content);
+    const singleRowQuery = isSingleRowQuery(segment);
+    const aggregateQuery =
+      segment.includes("count(") ||
+      segment.includes("COUNT(") ||
+      segment.includes("sum(") ||
+      segment.includes("SUM(") ||
+      segment.includes("group(");
+
+    if (!usesKf2Invariants && !singleRowQuery) {
+      if (limits.length === 0 && !hasRange(segment)) {
+        findings.push({
+          file,
+          error: "Pesquisa sem LIMIT explícito",
+        });
+      } else {
+        for (const [, value] of limits) {
+          if (Number(value) > MAX_LIMIT) {
+            findings.push({
+              file,
+              error: `LIMIT maior que ${MAX_LIMIT}`,
+            });
+          }
+        }
+
+        const rangeMatch = segment.match(/\.range\(\s*(\d+)\s*,\s*(\d+)\s*\)/);
+        if (rangeMatch) {
+          const from = Number(rangeMatch[1]);
+          const to = Number(rangeMatch[2]);
+          if (to - from + 1 > MAX_LIMIT) {
+            findings.push({
+              file,
+              error: `LIMIT maior que ${MAX_LIMIT}`,
+            });
+          }
         }
       }
     }
-  }
 
-  if (!usesKf2Invariants && !content.includes(".order(")) {
-    findings.push({
-      file,
-      error: "Pesquisa sem ORDER BY determinístico",
-    });
+    if (
+      !usesKf2Invariants &&
+      !singleRowQuery &&
+      !aggregateQuery &&
+      !hasDeterministicOrder(segment)
+    ) {
+      findings.push({
+        file,
+        error: "Pesquisa sem ORDER BY determinístico",
+      });
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- The KF2 search auditor produced many false positives because checks were applied at file level across mixed query types. 
- The intent is to narrow validation to each query chain so single-row and aggregate queries are not incorrectly flagged for list invariants.

### Description
- Updated `agents/scan/kf2-search-audit.ts` to extract and analyze each query chain by detecting `.from()` / `.rpc()` segments using a `QUERY_END_MARKER` regex. 
- Added helpers `extractQuerySegments`, `isSingleRowQuery`, `hasRange`, and `hasDeterministicOrder` to classify query shapes and pagination styles. 
- Applied validations per-segment: detect `select('*')`, require explicit `limit` or valid `.range()` for list queries, enforce `MAX_LIMIT` for `.limit()` and `.range()` windows, and require deterministic `.order()` only for list queries (skipping single-row and aggregate queries). 
- Kept `MAX_LIMIT` behavior and `applyKf2ListInvariants` opt-out, but moved logic from file-wide heuristics to per-query-segment checks in `agents/scan/kf2-search-audit.ts`.

### Testing
- Ran the scanner with `pnpm agent:kf2`; the command completed but returned exit code 1 because many API routes still have real violations (so the overall audit remains failing). 
- The updated scanner shows improved precision (fewer false positives) while still reporting legitimate missing `LIMIT`/`ORDER`/`select('*')` issues across the codebase.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4608f757483288d9e5ba91fd7f573)