### PR TITLE
Stabilize useHorarioTurmaData effect by capturing params and preventing undefined requests

### DIFF
--- a/apps/web/src/hooks/useHorarioData.ts
+++ b/apps/web/src/hooks/useHorarioData.ts
@@ -210,17 +210,28 @@ export function useHorarioTurmaData({
       return;
     }
 
+    const currentEscolaId = escolaId;
+    const currentTurmaId = turmaId;
+    const currentVersaoId = versaoId;
+
+    if (!currentEscolaId || !currentTurmaId || !currentVersaoId) {
+      return;
+    }
+
     const controller = new AbortController();
     const requestId = ++requestRef.current;
     const params = new URLSearchParams({
-      versao_id: versaoId,
-      turma_id: turmaId,
+      versao_id: currentVersaoId,
+      turma_id: currentTurmaId,
     });
 
 
     Promise.all([
-      fetchJson(`/api/secretaria/turmas/${turmaId}/disciplinas?escola_id=${encodeURIComponent(escolaId)}`, controller.signal),
-      fetchJson(`/api/escolas/${escolaId}/horarios/quadro?${params.toString()}`, controller.signal),
+      fetchJson(
+        `/api/secretaria/turmas/${currentTurmaId}/disciplinas?escola_id=${encodeURIComponent(currentEscolaId)}`,
+        controller.signal,
+      ),
+      fetchJson(`/api/escolas/${currentEscolaId}/horarios/quadro?${params.toString()}`, controller.signal),
     ])
       .then(([disciplinasRes, quadroRes]) => {
         if (controller.signal.aborted || requestId !== requestRef.current) return;


### PR DESCRIPTION
### Motivation

- Prevent requests from using stale or possibly null/undefined identifiers inside the `useEffect` for turma data.
- Ensure the API calls are made with a consistent set of parameters to avoid race conditions and incorrect responses.

### Description

- Capture `escolaId`, `turmaId`, and `versaoId` into local constants (`currentEscolaId`, `currentTurmaId`, `currentVersaoId`) at the start of the effect and early-return if any are missing.
- Use the captured values when building `URLSearchParams` and when calling `fetchJson` to ensure the same values are used for both parallel requests.
- Encode `escolaId` with `encodeURIComponent` in the `fetchJson` URL and perform minor formatting for the `fetchJson` calls.

### Testing

- Ran the test suite with `yarn test` and the tests completed successfully.
- Performed a TypeScript build check with `yarn build` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a3562a4c83289f7a25daad93e448)