### PR TITLE
Portal Aluno: nova UI, guardas de autorização, APIs e upload de comprovativos

### DIFF
--- a/agents/output/RELATORIO_PORTAL_ALUNO.md
+++ b/agents/output/RELATORIO_PORTAL_ALUNO.md
@@ -1,0 +1,49 @@
+# Relatório — Portal Aluno
+
+Data: 2026-03-02
+Escopo: revisão do estado atual do portal aluno após os últimos ajustes de layout, APIs e guardas de autorização.
+
+## 1) Estado atual
+
+- O portal aluno já está integrado com dados reais em endpoints `/api/aluno/*` para home, académico e financeiro.
+- A seleção de `studentId` está protegida por validação de vínculo via `auth.uid()` + vínculos de aluno/encarregado.
+- Fluxo de comprovativo financeiro está ativo (upload + transição para `em_verificacao`).
+
+## 2) Riscos/pendências identificadas
+
+1. **Coordenadas bancárias hardcoded no drawer**
+   - Banco/IBAN/referência exibidos com valores fixos na UI.
+   - Impacto: risco operacional e inconsistência entre escolas.
+
+2. **Académico com campos MAC/NPP/PT sem origem dedicada**
+   - UI exibe os 3 campos com base no mesmo valor trimestral no componente atual.
+   - Impacto: semântica académica incompleta para boletim detalhado.
+
+3. **RLS ainda orientada a tenant (escola) em partes sensíveis**
+   - Há hardening por escola, mas o reforço por vínculo real aluno/encarregado ainda deve ser completado no banco.
+   - Impacto: segurança depende mais da camada de aplicação do que da política de dados.
+
+4. **Teste anti-IDOR parcial**
+   - Existe teste de helper de autorização, mas falta suíte de integração/API cobrindo tentativas cruzadas endpoint a endpoint.
+
+## 3) Backlog recomendado (prioridade)
+
+### P0
+- Externalizar coordenadas bancárias por escola (fonte de configuração real).
+- Criar políticas RLS por vínculo real para: mensalidades, notas, frequências e documentos.
+- Adicionar testes de integração anti-IDOR para:
+  - `/api/aluno/financeiro`
+  - `/api/aluno/boletim`
+  - `/api/aluno/boletim/pdf`
+  - `/api/aluno/financeiro/comprovativo`
+
+### P1
+- Evoluir payload académico para suportar MAC/NPP/PT e MT com origem separada e rastreável.
+- Melhorar telemetria/auditoria para registrar tentativas de `studentId` não autorizado.
+
+### P2
+- Refinos de UX (mensagens de estado, skeletons e acessibilidade do drawer).
+
+## 4) Conclusão
+
+O portal está funcional com dados reais e proteção de seleção de aluno na camada de aplicação, mas ainda requer fechamento de segurança no banco (RLS por vínculo) e testes de integração anti-IDOR para atingir maturidade de produção.

--- a/agents/outputs/RELATORIO_LIBERACAO_PORTAL_ALUNO.md
+++ b/agents/outputs/RELATORIO_LIBERACAO_PORTAL_ALUNO.md
@@ -1,0 +1,31 @@
+# Relatório — Liberação de acesso (Portal do Aluno/Encarregado)
+
+Data: 2026-03-02T15:28:02Z
+
+## Objetivo
+Validar se escolas com portal do aluno concedido conseguem liberar acesso dos alunos e se a liberação é efetivada no backend.
+
+## Verificações realizadas
+
+1. **Gate de portal concedido na API de liberação**
+   - Endpoint: `POST /api/secretaria/alunos/liberar-acesso`
+   - Validação adicionada: consulta `escolas.aluno_portal_enabled` e bloqueio com `409` quando desativado.
+
+2. **Autorização por escola e usuário**
+   - A rota exige usuário autenticado.
+   - Resolve `escolaId` via `resolveEscolaIdForUser(...)`.
+   - Valida permissão com `authorizeEscolaAction(...)`.
+
+3. **Liberação real no backend**
+   - A rota chama `rpc('request_liberar_acesso', ...)`.
+   - A função SQL `request_liberar_acesso` chama `liberar_acesso_alunos_v2`.
+   - `liberar_acesso_alunos_v2` atualiza `alunos.acesso_liberado = true`, define `codigo_ativacao`, `data_ativacao` e enfileira notificação (`outbox_notificacoes`).
+   - `request_liberar_acesso` também enfileira evento de provisionamento (`outbox_event`).
+
+## Resultado
+- **Escola com portal concedido (`aluno_portal_enabled = true`)**: consegue executar a liberação, desde que tenha permissão de ação na escola.
+- **Escola sem portal concedido (`aluno_portal_enabled = false`)**: recebe bloqueio explícito (`409`) antes da RPC.
+- **Efetivação da liberação**: ocorre no banco (marca acesso liberado e gera código), com processamento assíncrono adicional via filas.
+
+## Observação operacional
+O status retornado pela API permanece como `queued`, indicando que parte do fluxo (notificação/provisionamento) é assíncrona, embora a marcação principal de liberação no aluno já seja persistida no banco.

--- a/apps/web/src/app/(portal-aluno)/academico/page.tsx
+++ b/apps/web/src/app/(portal-aluno)/academico/page.tsx
@@ -1,0 +1,11 @@
+import AuditPageView from "@/components/audit/AuditPageView";
+import { AcademicoAccordion } from "@/components/aluno/academico/AcademicoAccordion";
+
+export default function AcademicoPage() {
+  return (
+    <div className="space-y-4 bg-slate-50">
+      <AuditPageView portal="aluno" acao="PAGE_VIEW" entity="academico" />
+      <AcademicoAccordion />
+    </div>
+  );
+}

--- a/apps/web/src/app/(portal-aluno)/aluno/financeiro/page.tsx
+++ b/apps/web/src/app/(portal-aluno)/aluno/financeiro/page.tsx
@@ -1,14 +1,11 @@
 import AuditPageView from "@/components/audit/AuditPageView";
-import { FinanceiroResumo } from "@/components/aluno/financeiro/FinanceiroResumo";
-import { MensalidadesTable } from "@/components/aluno/financeiro/MensalidadesTable";
+import { FinanceiroPortalPage } from "@/components/aluno/financeiro-portal/FinanceiroPortalPage";
 
 export default function Page() {
   return (
-    <div className="space-y-6">
-      <AuditPageView portal="aluno" acao="PAGE_VIEW" entity="financeiro" />
-      <FinanceiroResumo />
-      <MensalidadesTable />
+    <div className="space-y-4 bg-slate-50">
+      <AuditPageView portal="aluno" acao="PAGE_VIEW" entity="financeiro_portal" />
+      <FinanceiroPortalPage />
     </div>
   );
 }
-

--- a/apps/web/src/app/(portal-aluno)/aluno/layout.tsx
+++ b/apps/web/src/app/(portal-aluno)/aluno/layout.tsx
@@ -1,94 +1,168 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import React, { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { createClient } from "@/lib/supabaseClient";
-import AlunoShell from "@/components/aluno/AlunoShell";
 import { parsePlanTier, type PlanTier } from "@/config/plans";
-import { Tables } from "~types/supabase";
+import { StudentSwitcher } from "@/components/aluno/StudentSwitcher";
+import { BottomNav } from "@/components/aluno/BottomNav";
 
-type Vínculo = Tables<"escola_users"> | null;
-type Perfil = { id: string; nome: string | null } | null;
+type Educando = { id: string; nome: string; escola_id: string | null };
+
+function shortSchoolName(nome: string | null): string {
+  if (!nome) return "Portal Aluno";
+  const parts = nome.trim().split(/\s+/).filter(Boolean);
+  if (parts.length <= 2) return nome;
+  return parts.slice(0, 2).join(" ");
+}
 
 export default function AlunoLayout({ children }: { children: React.ReactNode }) {
   const [ready, setReady] = useState(false);
-  const [perfil, setPerfil] = useState<Perfil>(null);
-  const [vinculo, setVinculo] = useState<Vínculo>(null);
+  const [escolaNome, setEscolaNome] = useState<string | null>(null);
+  const [educandos, setEducandos] = useState<Educando[]>([]);
+
   const router = useRouter();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     let active = true;
     const s = createClient();
+
     (async () => {
       const { data: userRes } = await s.auth.getUser();
       const user = userRes?.user;
-      if (!user) { router.replace("/login"); return; }
+      if (!user) {
+        router.replace("/login");
+        return;
+      }
 
-      // Perfil básico
-      const { data: prof } = await s
-        .from("profiles")
-        .select("user_id, nome")
-        .eq("user_id", user.id)
-        .maybeSingle();
-
-      // Vínculo do aluno
       const { data: vinc } = await s
         .from("escola_users")
-        .select("*")
+        .select("escola_id, papel, role")
         .eq("user_id", user.id)
         .limit(10);
 
-      const vincAluno = (vinc || []).find((v: Tables<'escola_users'>) => {
+      const vincPortal = (vinc || []).find((v) => {
         const papel = v.papel ?? v.role ?? null;
-        return papel === "aluno";
+        return papel === "aluno" || papel === "encarregado";
       });
 
-      if (!vincAluno) { router.replace("/"); return; }
-
-      const escolaId = vincAluno?.escola_id;
-
-      // Gate por plano/feature e STATUS
-      let ok = true;
-      if (escolaId) {
-        const { data: esc } = await s
-          .from("escolas")
-          .select("plano_atual, aluno_portal_enabled, status")
-          .eq("id", escolaId)
-          .maybeSingle();
-
-        if (esc?.status === 'suspensa') {
-          router.replace('/escola/suspensa');
-          return;
-        }
-
-        const planoRaw = esc?.plano_atual ?? null;
-        const plano: PlanTier = parsePlanTier(planoRaw);
-        const enabled = Boolean(esc?.aluno_portal_enabled);
-        ok = Boolean(plano && (plano === 'profissional' || plano === 'premium') && enabled);
-      }
-
-      if (!active) return;
-      const papel = vincAluno?.papel ?? vincAluno?.role ?? null;
-
-      const perfilData = prof ? { id: prof.user_id, nome: prof.nome } : null;
-
-      setPerfil(perfilData);
-      setVinculo(vincAluno ?? null);
-      if (!ok && pathname !== '/aluno/desabilitado') {
-        router.replace('/aluno/desabilitado');
+      if (!vincPortal?.escola_id) {
+        router.replace("/");
         return;
       }
+
+      const escolaId = vincPortal.escola_id;
+
+      const { data: esc } = await s
+        .from("escolas")
+        .select("nome, plano_atual, aluno_portal_enabled, status")
+        .eq("id", escolaId)
+        .maybeSingle();
+
+      if (esc?.status === "suspensa") {
+        router.replace("/escola/suspensa");
+        return;
+      }
+
+      const plano: PlanTier = parsePlanTier(esc?.plano_atual ?? null);
+      const enabled = Boolean(esc?.aluno_portal_enabled);
+      const acessoPortal = Boolean(plano && (plano === "profissional" || plano === "premium") && enabled);
+
+      const alunosDiretosPromise = s
+        .from("alunos")
+        .select("id, nome, escola_id")
+        .eq("profile_id", user.id)
+        .eq("escola_id", escolaId)
+        .limit(20);
+
+      const encarregadoPromise = user.email
+        ? s
+            .from("encarregados")
+            .select("id")
+            .eq("escola_id", escolaId)
+            .ilike("email", user.email)
+            .limit(1)
+            .maybeSingle()
+        : Promise.resolve({ data: null as { id: string } | null });
+
+      const [{ data: alunosDiretos }, { data: encarregado }] = await Promise.all([alunosDiretosPromise, encarregadoPromise]);
+
+      let alunosVinculados: Educando[] = [];
+      if (encarregado?.id) {
+        const { data: alunoLinks } = await s
+          .from("aluno_encarregados")
+          .select("aluno:alunos!aluno_encarregados_aluno_id_fkey(id, nome, escola_id)")
+          .eq("escola_id", escolaId)
+          .eq("encarregado_id", encarregado.id)
+          .limit(20);
+
+        alunosVinculados = (alunoLinks || [])
+          .map((row) => row.aluno)
+          .flat()
+          .filter(Boolean) as Educando[];
+      }
+
+      const merged = [...(alunosDiretos || []), ...alunosVinculados].reduce<Educando[]>((acc, row) => {
+        if (!acc.some((a) => a.id === row.id)) acc.push({ id: row.id, nome: row.nome ?? "Educando", escola_id: row.escola_id });
+        return acc;
+      }, []);
+
+      if (!active) return;
+
+      setEscolaNome(esc?.nome ?? null);
+      setEducandos(merged);
+
+      if (!acessoPortal && pathname !== "/aluno/desabilitado") {
+        router.replace("/aluno/desabilitado");
+        return;
+      }
+
       setReady(true);
     })();
+
     return () => {
       active = false;
     };
   }, [pathname, router]);
 
+  const alunoSelecionado = useMemo(() => searchParams?.get("aluno") ?? educandos[0]?.id ?? null, [searchParams, educandos]);
+
   if (!ready) {
     return <div className="p-6">🔒 Verificando acesso do aluno…</div>;
   }
 
-  return <AlunoShell perfil={perfil} vinculo={vinculo}>{children}</AlunoShell>;
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900 pb-[calc(84px+env(safe-area-inset-bottom))]">
+      <header className="sticky top-0 z-20 border-b border-slate-200 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-3 px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#1F6B3B] text-sm font-semibold text-white">KL</div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-500">Portal aluno</p>
+              <p className="text-sm font-semibold text-slate-900">{shortSchoolName(escolaNome)}</p>
+            </div>
+          </div>
+
+          <StudentSwitcher educandos={educandos} selectedId={alunoSelecionado} />
+        </div>
+      </header>
+
+      <main className="mx-auto w-full max-w-5xl px-4 py-4">
+        <div className="rounded-xl bg-white p-4 shadow-sm md:p-6">{children}</div>
+
+        <div className="mt-4 flex flex-wrap gap-2 text-xs">
+          <span className="rounded-full px-3 py-1 font-medium text-white" style={{ backgroundColor: "#1F6B3B" }}>
+            CTA principal
+          </span>
+          <span className="rounded-full px-3 py-1 font-medium text-slate-900" style={{ backgroundColor: "#E3B23C" }}>
+            Alerta
+          </span>
+        </div>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
 }

--- a/apps/web/src/app/(portal-aluno)/aluno/page.tsx
+++ b/apps/web/src/app/(portal-aluno)/aluno/page.tsx
@@ -1,6 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Page() {
-  redirect("/aluno/dashboard");
+  redirect("/home");
 }
-

--- a/apps/web/src/app/(portal-aluno)/home/page.tsx
+++ b/apps/web/src/app/(portal-aluno)/home/page.tsx
@@ -1,0 +1,11 @@
+import AuditPageView from "@/components/audit/AuditPageView";
+import { HomePageClient } from "@/components/aluno/home/HomePageClient";
+
+export default function HomePage() {
+  return (
+    <div className="space-y-4 bg-slate-50">
+      <AuditPageView portal="aluno" acao="PAGE_VIEW" entity="home" />
+      <HomePageClient />
+    </div>
+  );
+}

--- a/apps/web/src/app/api/aluno/boletim/pdf/route.ts
+++ b/apps/web/src/app/api/aluno/boletim/pdf/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { createInstitutionalPdf } from "@/lib/pdf/documentTemplate";
+import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type BoletimRow = { disciplina_id: string | null; disciplina_nome: string | null; trimestre: number | null; nota_final: number | null };
+
+export async function GET(request: Request) {
+  try {
+    const { supabase, ctx } = await getAlunoContext();
+    if (!ctx?.escolaId || !ctx.userId) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
+
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({ supabase, userId: ctx.userId, escolaId: ctx.escolaId, userEmail: userRes?.user?.email });
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: false, error: "Aluno não autorizado" }, { status: 403 });
+
+    const [{ data: escola }, { data: aluno }, { data: matricula }] = await Promise.all([
+      supabase.from("escolas").select("nome, nif, endereco, logo_url").eq("id", ctx.escolaId).maybeSingle(),
+      supabase.from("alunos").select("nome").eq("id", alunoId).eq("escola_id", ctx.escolaId).maybeSingle(),
+      supabase.from("matriculas").select("id").eq("aluno_id", alunoId).eq("escola_id", ctx.escolaId).order("created_at", { ascending: false }).limit(1).maybeSingle(),
+    ]);
+
+    if (!matricula?.id) return NextResponse.json({ ok: false, error: "Sem matrícula" }, { status: 404 });
+
+    const { data: boletimRows, error } = await supabase
+      .from("vw_boletim_por_matricula")
+      .select("disciplina_id, disciplina_nome, trimestre, nota_final")
+      .eq("matricula_id", matricula.id)
+      .limit(50);
+    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+
+    const byDisciplina = new Map<string, { nome: string; t1: number | null; t2: number | null; t3: number | null; final: number | null }>();
+    (boletimRows as BoletimRow[] | null)?.forEach((row) => {
+      const id = row.disciplina_id ?? "";
+      if (!id) return;
+      const existing = byDisciplina.get(id) ?? { nome: row.disciplina_nome ?? "Disciplina", t1: null, t2: null, t3: null, final: null };
+      if (row.trimestre === 1) existing.t1 = row.nota_final ?? null;
+      if (row.trimestre === 2) existing.t2 = row.nota_final ?? null;
+      if (row.trimestre === 3) existing.t3 = row.nota_final ?? null;
+      existing.final = existing.final ?? row.nota_final ?? null;
+      byDisciplina.set(id, existing);
+    });
+
+    const linhas = Array.from(byDisciplina.values());
+    const pdfBytes = await createInstitutionalPdf({
+      title: `Boletim do Aluno — ${aluno?.nome ?? "Aluno"}`,
+      school: { name: escola?.nome ?? "Escola", nif: escola?.nif ?? null, address: escola?.endereco ?? null, logoUrl: escola?.logo_url ?? null },
+      content: async ({ page, margin, contentStartY, font, boldFont }) => {
+        let y = contentStartY;
+        page.drawText("Disciplina", { x: margin, y, size: 10, font: boldFont });
+        page.drawText("T1", { x: margin + 210, y, size: 10, font: boldFont });
+        page.drawText("T2", { x: margin + 250, y, size: 10, font: boldFont });
+        page.drawText("T3", { x: margin + 290, y, size: 10, font: boldFont });
+        page.drawText("Final", { x: margin + 330, y, size: 10, font: boldFont });
+        y -= 14;
+        for (const row of linhas) {
+          if (y < 70) break;
+          page.drawText(row.nome.slice(0, 34), { x: margin, y, size: 9, font });
+          page.drawText(row.t1 == null ? "—" : row.t1.toFixed(1), { x: margin + 210, y, size: 9, font });
+          page.drawText(row.t2 == null ? "—" : row.t2.toFixed(1), { x: margin + 250, y, size: 9, font });
+          page.drawText(row.t3 == null ? "—" : row.t3.toFixed(1), { x: margin + 290, y, size: 9, font });
+          page.drawText(row.final == null ? "—" : row.final.toFixed(1), { x: margin + 330, y, size: 9, font: boldFont });
+          y -= 13;
+        }
+      },
+    });
+
+    return new NextResponse(pdfBytes as BodyInit, { status: 200, headers: { "Content-Type": "application/pdf", "Content-Disposition": `attachment; filename="boletim_${(aluno?.nome ?? "aluno").replace(/\s+/g, "_")}.pdf"` } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/aluno/boletim/route.ts
+++ b/apps/web/src/app/api/aluno/boletim/route.ts
@@ -1,72 +1,38 @@
 import { NextResponse } from "next/server";
 import { getAlunoContext } from "@/lib/alunoContext";
 import { applyKf2ListInvariants } from "@/lib/kf2";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-type BoletimRow = {
-  disciplina_id: string | null;
-  disciplina_nome: string | null;
-  trimestre: number | null;
-  nota_final: number | null;
-  status: string | null;
-  missing_count: number | null;
-};
+type BoletimRow = { disciplina_id: string | null; disciplina_nome: string | null; trimestre: number | null; nota_final: number | null; status: string | null; missing_count: number | null };
 
-type FrequenciaRow = {
-  periodo_letivo_id: string | null;
-  faltas: number | null;
-  aulas_previstas: number | null;
-  frequencia_min_percent: number | null;
-};
+type FrequenciaRow = { faltas: number | null; aulas_previstas: number | null; frequencia_min_percent: number | null };
 
-type PeriodoRow = {
-  id: string;
-  numero: number | null;
-  data_inicio: string | null;
-  data_fim: string | null;
-};
-
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const { supabase, ctx } = await getAlunoContext();
-    if (!ctx?.matriculaId || !ctx.escolaId || !ctx.alunoId) {
-      return NextResponse.json({ ok: true, disciplinas: [], nome_aluno: null, trimestre_atual: null });
-    }
+    if (!ctx?.escolaId || !ctx.userId) return NextResponse.json({ ok: true, disciplinas: [], nome_aluno: null, trimestre_atual: null });
 
-    const { data: aluno } = await supabase
-      .from("alunos")
-      .select("nome")
-      .eq("id", ctx.alunoId)
-      .maybeSingle();
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({ supabase, userId: ctx.userId, escolaId: ctx.escolaId, userEmail: userRes?.user?.email });
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: true, disciplinas: [], nome_aluno: null, trimestre_atual: null });
+
+    const { data: aluno } = await supabase.from("alunos").select("nome").eq("id", alunoId).eq("escola_id", ctx.escolaId).maybeSingle();
 
     const { data: matricula } = await supabase
       .from("matriculas")
-      .select("ano_letivo")
-      .eq("id", ctx.matriculaId)
+      .select("id, ano_letivo")
+      .eq("aluno_id", alunoId)
+      .eq("escola_id", ctx.escolaId)
+      .order("created_at", { ascending: false })
+      .limit(1)
       .maybeSingle();
 
-    const anoLetivo = matricula?.ano_letivo ?? null;
-    if (!anoLetivo) {
-      return NextResponse.json({ ok: true, disciplinas: [], nome_aluno: aluno?.nome ?? null, trimestre_atual: null });
-    }
-
-    let anoLetivoQuery = supabase
-      .from("anos_letivos")
-      .select("id")
-      .eq("escola_id", ctx.escolaId)
-      .eq("ano", anoLetivo)
-
-    anoLetivoQuery = applyKf2ListInvariants(anoLetivoQuery, {
-      defaultLimit: 1,
-      order: [{ column: 'created_at', ascending: false }],
-    })
-
-    const { data: anoLetivoRow } = await anoLetivoQuery.maybeSingle();
-
-    const anoLetivoId = anoLetivoRow?.id ?? null;
-    if (!anoLetivoId) {
+    if (!matricula?.id || !matricula.ano_letivo) {
       return NextResponse.json({ ok: true, disciplinas: [], nome_aluno: aluno?.nome ?? null, trimestre_atual: null });
     }
 
@@ -74,33 +40,16 @@ export async function GET() {
       .from("periodos_letivos")
       .select("id, numero, data_inicio, data_fim")
       .eq("escola_id", ctx.escolaId)
-      .eq("ano_letivo_id", anoLetivoId)
-      .eq("tipo", "TRIMESTRE")
-
-    periodosQuery = applyKf2ListInvariants(periodosQuery, {
-      defaultLimit: 50,
-      order: [{ column: 'numero', ascending: true }],
-    })
-
+      .eq("tipo", "TRIMESTRE");
+    periodosQuery = applyKf2ListInvariants(periodosQuery, { defaultLimit: 50, order: [{ column: "numero", ascending: true }] });
     const { data: periodos } = await periodosQuery;
-
-    const periodMap = new Map<string, PeriodoRow>();
-    (periodos || []).forEach((p) => {
-      if (p?.id) periodMap.set(p.id, p as PeriodoRow);
-    });
 
     let frequenciasQuery = supabase
       .from("frequencia_status_periodo")
-      .select("periodo_letivo_id, faltas, aulas_previstas, frequencia_min_percent")
+      .select("faltas, aulas_previstas, frequencia_min_percent")
       .eq("escola_id", ctx.escolaId)
-      .eq("matricula_id", ctx.matriculaId)
-
-    frequenciasQuery = applyKf2ListInvariants(frequenciasQuery, {
-      defaultLimit: 50,
-      order: [{ column: 'periodo_letivo_id', ascending: true }],
-      tieBreakerColumn: 'periodo_letivo_id',
-    })
-
+      .eq("matricula_id", matricula.id);
+    frequenciasQuery = applyKf2ListInvariants(frequenciasQuery, { defaultLimit: 50, order: [{ column: "created_at", ascending: false }] });
     const { data: frequencias } = await frequenciasQuery;
 
     let totalFaltas = 0;
@@ -109,72 +58,33 @@ export async function GET() {
       const faltas = Number(row.faltas ?? 0);
       const aulas = Number(row.aulas_previstas ?? 0);
       const minPercent = Number(row.frequencia_min_percent ?? 75);
-      const maxFaltas = Math.max(0, Math.floor(aulas * (1 - minPercent / 100)));
       totalFaltas += faltas;
-      totalMax += maxFaltas;
+      totalMax += Math.max(0, Math.floor(aulas * (1 - minPercent / 100)));
     });
 
     let boletimQuery = supabase
       .from("vw_boletim_por_matricula")
       .select("disciplina_id, disciplina_nome, trimestre, nota_final, status, missing_count")
-      .eq("matricula_id", ctx.matriculaId)
-
-    boletimQuery = applyKf2ListInvariants(boletimQuery, {
-      defaultLimit: 50,
-      order: [{ column: 'disciplina_nome', ascending: true }],
-      tieBreakerColumn: 'disciplina_id',
-    })
-
+      .eq("matricula_id", matricula.id);
+    boletimQuery = applyKf2ListInvariants(boletimQuery, { defaultLimit: 50, order: [{ column: "disciplina_nome", ascending: true }], tieBreakerColumn: "disciplina_id" });
     const { data: boletimRows, error: boletimError } = await boletimQuery;
+    if (boletimError) return NextResponse.json({ ok: false, error: boletimError.message }, { status: 500 });
 
-    if (boletimError) {
-      return NextResponse.json({ ok: false, error: boletimError.message }, { status: 500 });
-    }
-
-    const byDisciplina = new Map<string, {
-      id: string;
-      nome: string;
-      nota_t1: number | null;
-      nota_t2: number | null;
-      nota_t3: number | null;
-      nota_final: number | null;
-      status: "lancada" | "pendente" | "bloqueada";
-    }>();
-
+    const byDisciplina = new Map<string, any>();
     (boletimRows as BoletimRow[] | null)?.forEach((row) => {
-      const disciplinaId = row.disciplina_id ?? "";
-      if (!disciplinaId) return;
-      const nome = row.disciplina_nome ?? "Disciplina";
-      const status =
-        row.status === "PENDENTE_CONFIG"
-          ? "bloqueada"
-          : (row.missing_count ?? 0) > 0
-            ? "pendente"
-            : "lancada";
-      const entry = byDisciplina.get(disciplinaId) ?? {
-        id: disciplinaId,
-        nome,
-        nota_t1: null,
-        nota_t2: null,
-        nota_t3: null,
-        nota_final: null,
-        status,
-      };
-
-      const trimestre = row.trimestre ?? null;
-      if (trimestre === 1) entry.nota_t1 = row.nota_final ?? null;
-      if (trimestre === 2) entry.nota_t2 = row.nota_final ?? null;
-      if (trimestre === 3) entry.nota_t3 = row.nota_final ?? null;
+      const id = row.disciplina_id ?? "";
+      if (!id) return;
+      const status = row.status === "PENDENTE_CONFIG" ? "bloqueada" : (row.missing_count ?? 0) > 0 ? "pendente" : "lancada";
+      const entry = byDisciplina.get(id) ?? { id, nome: row.disciplina_nome ?? "Disciplina", nota_t1: null, nota_t2: null, nota_t3: null, nota_final: null, status };
+      if (row.trimestre === 1) entry.nota_t1 = row.nota_final ?? null;
+      if (row.trimestre === 2) entry.nota_t2 = row.nota_final ?? null;
+      if (row.trimestre === 3) entry.nota_t3 = row.nota_final ?? null;
       entry.nota_final = entry.nota_final ?? row.nota_final ?? null;
       entry.status = status;
-      byDisciplina.set(disciplinaId, entry);
+      byDisciplina.set(id, entry);
     });
 
-    const disciplinas = Array.from(byDisciplina.values()).map((entry) => ({
-      ...entry,
-      faltas: totalFaltas,
-      faltas_max: totalMax,
-    }));
+    const disciplinas = Array.from(byDisciplina.values()).map((entry) => ({ ...entry, faltas: totalFaltas, faltas_max: totalMax }));
 
     const hoje = new Date();
     const trimestreAtual = (periodos || []).find((p) => {
@@ -184,12 +94,7 @@ export async function GET() {
       return inicio <= hoje && hoje <= fim;
     })?.numero ?? null;
 
-    return NextResponse.json({
-      ok: true,
-      nome_aluno: aluno?.nome ?? null,
-      trimestre_atual: trimestreAtual,
-      disciplinas,
-    });
+    return NextResponse.json({ ok: true, nome_aluno: aluno?.nome ?? null, trimestre_atual: trimestreAtual, disciplinas });
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : "Erro inesperado";
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/apps/web/src/app/api/aluno/financeiro/comprovativo/route.ts
+++ b/apps/web/src/app/api/aluno/financeiro/comprovativo/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from "next/server";
+import { createRouteClient } from "@/lib/supabase/route-client";
+import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function POST(request: Request) {
+  try {
+    const { supabase, ctx } = await getAlunoContext();
+    if (!ctx?.escolaId || !ctx.userId) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
+
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({ supabase, userId: ctx.userId, escolaId: ctx.escolaId, userEmail: userRes?.user?.email });
+
+    const formData = await request.formData();
+    const mensalidadeId = formData.get("mensalidadeId")?.toString();
+    const studentIdParam = formData.get("studentId")?.toString() ?? null;
+    const file = formData.get("file");
+    if (!mensalidadeId || !(file instanceof File)) return NextResponse.json({ ok: false, error: "Dados inválidos" }, { status: 400 });
+
+    const alunoId = resolveSelectedStudentId({ selectedId: studentIdParam, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: false, error: "Aluno não autorizado" }, { status: 403 });
+
+    const routeClient = await createRouteClient();
+    const { data: mensalidade } = await routeClient
+      .from("mensalidades")
+      .select("id")
+      .eq("id", mensalidadeId)
+      .eq("escola_id", ctx.escolaId)
+      .eq("aluno_id", alunoId)
+      .maybeSingle();
+    if (!mensalidade) return NextResponse.json({ ok: false, error: "Mensalidade não encontrada" }, { status: 404 });
+
+    const objectPath = `${ctx.escolaId}/${alunoId}/${mensalidadeId}/${Date.now()}-${file.name.replace(/\s+/g, "_")}`;
+    const bytes = Buffer.from(await file.arrayBuffer());
+
+    try {
+      const { data: bucket } = await routeClient.storage.getBucket("aluno-comprovativos");
+      if (!bucket) await routeClient.storage.createBucket("aluno-comprovativos", { public: false });
+    } catch {}
+
+    const { error: uploadError } = await routeClient.storage.from("aluno-comprovativos").upload(objectPath, bytes, { contentType: file.type || "application/octet-stream", upsert: false });
+    if (uploadError) return NextResponse.json({ ok: false, error: uploadError.message }, { status: 500 });
+
+    const { error: updateError } = await routeClient
+      .from("mensalidades")
+      .update({ status: "em_verificacao", observacao: `Comprovativo anexado: ${objectPath}`, updated_by: ctx.userId })
+      .eq("id", mensalidadeId)
+      .eq("escola_id", ctx.escolaId)
+      .eq("aluno_id", alunoId);
+    if (updateError) return NextResponse.json({ ok: false, error: updateError.message }, { status: 500 });
+
+    return NextResponse.json({ ok: true, status: "em_verificacao" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/aluno/financeiro/route.ts
+++ b/apps/web/src/app/api/aluno/financeiro/route.ts
@@ -1,6 +1,8 @@
 // @kf2 allow-scan
 import { NextResponse } from "next/server";
 import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
 type MensalidadeRow = {
   id: string;
   ano_referencia: number | null;
@@ -11,49 +13,45 @@ type MensalidadeRow = {
   data_pagamento_efetiva: string | null;
 };
 
-export async function GET() {
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: Request) {
   try {
     const { supabase, ctx } = await getAlunoContext();
-    if (!ctx) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
-    const { alunoId, escolaId, matriculaId, anoLetivo } = ctx;
+    if (!ctx || !ctx.escolaId || !ctx.userId) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
 
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({
+      supabase,
+      userId: ctx.userId,
+      escolaId: ctx.escolaId,
+      userEmail: userRes?.user?.email,
+    });
+
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
     if (!alunoId) return NextResponse.json({ ok: true, mensalidades: [] });
 
-    // Busca mensalidades por aluno, no formato do frontend do aluno
-    let query = supabase
-      .from('mensalidades')
-      .select('id, ano_referencia, ano_letivo, mes_referencia, valor_previsto, data_vencimento, status, data_pagamento_efetiva, matricula_id')
-      .eq('aluno_id', alunoId);
+    const query = supabase
+      .from("mensalidades")
+      .select("id, ano_referencia, ano_letivo, mes_referencia, valor_previsto, data_vencimento, status, data_pagamento_efetiva, matricula_id")
+      .eq("aluno_id", alunoId)
+      .eq("escola_id", ctx.escolaId);
 
-    if (escolaId) query = query.eq('escola_id', escolaId);
-    if (matriculaId) query = query.eq('matricula_id', matriculaId);
-    if (typeof anoLetivo === 'number') {
-      query = query.or(`ano_referencia.eq.${anoLetivo},ano_letivo.eq.${anoLetivo}`);
-    }
-
-    const { data, error } = await query
-      .order('ano_referencia', { ascending: true })
-      .order('mes_referencia', { ascending: true })
-      .limit(50);
+    const { data, error } = await query.order("ano_referencia", { ascending: true }).order("mes_referencia", { ascending: true }).limit(50);
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
 
     const hoje = new Date().toISOString().slice(0, 10);
     const rows = (data || []).map((m: MensalidadeRow) => {
-      const competencia = `${m.ano_referencia}-${String(m.mes_referencia).padStart(2, '0')}`;
+      const competencia = `${m.ano_referencia}-${String(m.mes_referencia).padStart(2, "0")}`;
       const vencimento = m.data_vencimento ?? "";
       const pago_em = m.data_pagamento_efetiva ?? null;
-      let status: 'pago' | 'pendente' | 'atrasado' = 'pendente';
-      if ((m.status as string) === 'pago') status = 'pago';
-      else if (vencimento && vencimento < hoje) status = 'atrasado';
-      else status = 'pendente';
-      return {
-        id: m.id,
-        competencia,
-        valor: Number(m.valor_previsto ?? 0),
-        vencimento,
-        status,
-        pago_em,
-      };
+      let status: "pago" | "pendente" | "atrasado" | "em_verificacao" = "pendente";
+      if ((m.status as string) === "pago") status = "pago";
+      else if ((m.status as string) === "em_verificacao") status = "em_verificacao";
+      else if (vencimento && vencimento < hoje) status = "atrasado";
+      return { id: m.id, competencia, valor: Number(m.valor_previsto ?? 0), vencimento, status, pago_em };
     });
 
     return NextResponse.json({ ok: true, mensalidades: rows });

--- a/apps/web/src/app/api/aluno/home/finance-alert/route.ts
+++ b/apps/web/src/app/api/aluno/home/finance-alert/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+function monthLabel(ano: number | null, mes: number | null) {
+  if (!ano || !mes) return null;
+  return `${String(mes).padStart(2, "0")}/${ano}`;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { supabase, ctx } = await getAlunoContext();
+    if (!ctx?.escolaId || !ctx.userId) {
+      return NextResponse.json({ ok: true, alert: null });
+    }
+
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({
+      supabase,
+      userId: ctx.userId,
+      escolaId: ctx.escolaId,
+      userEmail: userRes?.user?.email,
+    });
+
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: true, alert: null });
+
+    const hoje = new Date().toISOString().slice(0, 10);
+    const { data } = await supabase
+      .from("mensalidades")
+      .select("id, valor_previsto, data_vencimento, ano_referencia, mes_referencia, status")
+      .eq("aluno_id", alunoId)
+      .eq("escola_id", ctx.escolaId)
+      .lt("data_vencimento", hoje)
+      .order("data_vencimento", { ascending: true })
+      .limit(1);
+
+    const row = data?.[0];
+    if (!row || row.status === "pago") return NextResponse.json({ ok: true, alert: null });
+
+    return NextResponse.json({ ok: true, alert: { id: row.id, valor: Number(row.valor_previsto ?? 0), mes: monthLabel(row.ano_referencia ?? null, row.mes_referencia ?? null) } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/aluno/home/recent-grades/route.ts
+++ b/apps/web/src/app/api/aluno/home/recent-grades/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+type NotaComAvaliacao = {
+  valor: number;
+  created_at: string;
+  avaliacao: { nome: string; tipo: string; created_at: string } | null;
+};
+
+export async function GET(request: Request) {
+  try {
+    const { supabase, ctx } = await getAlunoContext();
+    if (!ctx?.escolaId || !ctx.userId) return NextResponse.json({ ok: true, items: [] });
+
+    const { data: userRes } = await supabase.auth.getUser();
+    const authorizedIds = await resolveAuthorizedStudentIds({
+      supabase,
+      userId: ctx.userId,
+      escolaId: ctx.escolaId,
+      userEmail: userRes?.user?.email,
+    });
+
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: true, items: [] });
+
+    const { data: matricula } = await supabase
+      .from("matriculas")
+      .select("id")
+      .eq("aluno_id", alunoId)
+      .eq("escola_id", ctx.escolaId)
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (!matricula?.id) return NextResponse.json({ ok: true, items: [] });
+
+    const { data } = await supabase
+      .from("notas")
+      .select("valor, created_at, avaliacao:avaliacoes(nome, tipo, created_at)")
+      .eq("matricula_id", matricula.id)
+      .eq("escola_id", ctx.escolaId)
+      .order("created_at", { ascending: false })
+      .limit(3);
+
+    const rows = (data ?? []) as unknown as NotaComAvaliacao[];
+    const items = rows.map((row) => ({
+      disciplina: row.avaliacao?.nome ?? "Avaliação",
+      tipo: row.avaliacao?.tipo ?? "Avaliação",
+      nota: row.valor ?? null,
+      data: row.created_at ?? row.avaliacao?.created_at ?? null,
+    }));
+
+    return NextResponse.json({ ok: true, items });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/aluno/home/status/route.ts
+++ b/apps/web/src/app/api/aluno/home/status/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { getAlunoContext } from "@/lib/alunoContext";
+import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/portalAlunoAuth";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+export async function GET(request: Request) {
+  try {
+    const { supabase, ctx } = await getAlunoContext();
+    if (!ctx?.userId || !ctx.escolaId) {
+      return NextResponse.json({ ok: true, status: null });
+    }
+
+    const { data: userRes } = await supabase.auth.getUser();
+    const authUser = userRes?.user;
+    const authorizedIds = await resolveAuthorizedStudentIds({
+      supabase,
+      userId: ctx.userId,
+      escolaId: ctx.escolaId,
+      userEmail: authUser?.email,
+    });
+
+    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
+    if (!alunoId) return NextResponse.json({ ok: true, status: null });
+
+    const [{ data: aluno }, { data: matricula }] = await Promise.all([
+      supabase.from("alunos").select("id, nome").eq("id", alunoId).eq("escola_id", ctx.escolaId).maybeSingle(),
+      supabase
+        .from("matriculas")
+        .select("id, status, turma_id")
+        .eq("aluno_id", alunoId)
+        .eq("escola_id", ctx.escolaId)
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+    ]);
+
+    let turmaNome: string | null = null;
+    let classeNome: string | null = null;
+
+    if (matricula?.turma_id) {
+      const { data: turma } = await supabase
+        .from("turmas")
+        .select("nome, classe_id")
+        .eq("id", matricula.turma_id)
+        .eq("escola_id", ctx.escolaId)
+        .maybeSingle();
+      turmaNome = turma?.nome ?? null;
+
+      if (turma?.classe_id) {
+        const { data: classe } = await supabase
+          .from("classes")
+          .select("nome")
+          .eq("id", turma.classe_id)
+          .eq("escola_id", ctx.escolaId)
+          .maybeSingle();
+        classeNome = classe?.nome ?? null;
+      }
+    }
+
+    const estadoAcademico = ["ativo", "ativa", "active"].includes(matricula?.status ?? "")
+      ? "Em curso"
+      : matricula?.status
+        ? "Com pendências"
+        : "Sem matrícula ativa";
+
+    return NextResponse.json({ ok: true, status: { nome: aluno?.nome ?? "Aluno", turma: turmaNome, classe: classeNome, estadoAcademico } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/api/secretaria/alunos/liberar-acesso/route.ts
+++ b/apps/web/src/app/api/secretaria/alunos/liberar-acesso/route.ts
@@ -23,6 +23,19 @@ export async function POST(req: Request) {
     const escolaId = await resolveEscolaIdForUser(s as any, user.id, escolaIdRequest);
     if (!escolaId) return NextResponse.json({ ok: false, error: "Escola não encontrada" }, { status: 400 });
 
+    const { data: escolaCfg, error: escolaCfgErr } = await s
+      .from("escolas")
+      .select("aluno_portal_enabled")
+      .eq("id", escolaId)
+      .maybeSingle();
+    if (escolaCfgErr) return NextResponse.json({ ok: false, error: escolaCfgErr.message }, { status: 400 });
+    if (!escolaCfg?.aluno_portal_enabled) {
+      return NextResponse.json(
+        { ok: false, error: "Portal do aluno não concedido para esta escola" },
+        { status: 409 }
+      );
+    }
+
     const authz = await authorizeEscolaAction(s as any, escolaId, user.id, []);
     if (!authz.allowed) return NextResponse.json({ ok: false, error: authz.reason || "Sem permissão" }, { status: 403 });
 

--- a/apps/web/src/components/aluno/BottomNav.tsx
+++ b/apps/web/src/components/aluno/BottomNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { GraduationCap, Home, Wallet } from "lucide-react";
+
+const items = [
+  { href: "/home", label: "Home", icon: Home },
+  { href: "/academico", label: "Académico", icon: GraduationCap },
+  { href: "/aluno/financeiro", label: "Financeiro", icon: Wallet },
+];
+
+export function BottomNav() {
+  const pathname = usePathname() ?? "";
+
+  return (
+    <nav
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-slate-200 bg-white/95 backdrop-blur"
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+      aria-label="Navegação do portal do aluno"
+    >
+      <div className="mx-auto grid w-full max-w-5xl grid-cols-3 px-2 py-2">
+        {items.map(({ href, label, icon: Icon }) => {
+          const active = pathname === href || pathname.startsWith(`${href}/`);
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={`flex min-h-11 flex-col items-center justify-center rounded-xl text-xs font-medium transition ${
+                active ? "bg-emerald-50 text-emerald-700" : "text-slate-500 hover:bg-slate-100"
+              }`}
+              aria-current={active ? "page" : undefined}
+            >
+              <Icon className="mb-1 h-4 w-4" />
+              {label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/aluno/StudentSwitcher.tsx
+++ b/apps/web/src/components/aluno/StudentSwitcher.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+type Educando = { id: string; nome: string; escola_id: string | null };
+
+export function StudentSwitcher({ educandos, selectedId }: { educandos: Educando[]; selectedId: string | null }) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const searchValue = search?.toString() ?? "";
+
+  const onChange = (id: string) => {
+    const params = new URLSearchParams(searchValue);
+    params.set("aluno", id);
+    router.replace(`${pathname}?${params.toString()}`);
+  };
+
+  if (educandos.length <= 1) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-600 shadow-sm">
+        {educandos[0]?.nome ?? "Sem educandos"}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <label className="sr-only" htmlFor="student-switcher">Selecionar educando</label>
+      <select
+        id="student-switcher"
+        className="min-h-11 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 shadow-sm outline-none ring-emerald-500 focus:ring-2"
+        value={selectedId ?? educandos[0]?.id}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {educandos.map((aluno) => (
+          <option key={aluno.id} value={aluno.id}>{aluno.nome}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/academico/AcademicoAccordion.tsx
+++ b/apps/web/src/components/aluno/academico/AcademicoAccordion.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/Button";
+
+type Disciplina = {
+  id: string;
+  nome: string;
+  nota_t1?: number | null;
+  nota_t2?: number | null;
+  nota_t3?: number | null;
+  nota_final?: number | null;
+};
+
+type BoletimResponse = {
+  ok: boolean;
+  nome_aluno?: string | null;
+  disciplinas: Disciplina[];
+};
+
+function fmtNota(v?: number | null) {
+  return typeof v === "number" ? v.toFixed(1) : "—";
+}
+
+function finalStatus(nota?: number | null) {
+  if (typeof nota !== "number") return { label: "Pendente", cls: "bg-slate-100 text-slate-700" };
+  return nota >= 10
+    ? { label: "Aprovado", cls: "bg-emerald-100 text-emerald-700" }
+    : { label: "Reprovado", cls: "bg-red-100 text-red-700" };
+}
+
+export function AcademicoAccordion() {
+  const searchParams = useSearchParams();
+  const studentId = useMemo(() => searchParams?.get("aluno") ?? null, [searchParams]);
+  const [loading, setLoading] = useState(true);
+  const [disciplinas, setDisciplinas] = useState<Disciplina[]>([]);
+
+  useEffect(() => {
+    const ctrl = new AbortController();
+    fetch(`/api/aluno/boletim${studentId ? `?studentId=${studentId}` : ""}`, { cache: "no-store", signal: ctrl.signal })
+      .then((r) => r.json() as Promise<BoletimResponse>)
+      .then((json) => setDisciplinas(json.disciplinas ?? []))
+      .finally(() => setLoading(false));
+    return () => ctrl.abort();
+  }, [studentId]);
+
+  return (
+    <div className="space-y-4">
+      {loading ? (
+        <div className="h-40 animate-pulse rounded-xl bg-slate-100" />
+      ) : (
+        <section className="rounded-xl bg-white p-4 shadow-sm">
+          <h2 className="text-sm font-semibold text-slate-900">Desempenho por disciplina</h2>
+          <div className="mt-3 space-y-2">
+            {disciplinas.map((disc) => {
+              const status = finalStatus(disc.nota_final);
+              return (
+                <details key={disc.id} className="rounded-xl border border-slate-200 p-3">
+                  <summary className="cursor-pointer list-none text-sm font-medium text-slate-900">{disc.nome}</summary>
+                  <div className="mt-3 grid grid-cols-1 gap-2 text-sm md:grid-cols-3">
+                    <div className="rounded-lg border border-slate-100 p-2">
+                      <p className="text-xs text-slate-500">1º Trimestre</p>
+                      <p>MAC: {fmtNota(disc.nota_t1)}</p>
+                      <p>NPP: {fmtNota(disc.nota_t1)}</p>
+                      <p>PT: {fmtNota(disc.nota_t1)}</p>
+                      <p className="mt-1 font-medium">MT: {fmtNota(disc.nota_t1)}</p>
+                    </div>
+                    <div className="rounded-lg border border-slate-100 p-2">
+                      <p className="text-xs text-slate-500">2º Trimestre</p>
+                      <p>MAC: {fmtNota(disc.nota_t2)}</p>
+                      <p>NPP: {fmtNota(disc.nota_t2)}</p>
+                      <p>PT: {fmtNota(disc.nota_t2)}</p>
+                      <p className="mt-1 font-medium">MT: {fmtNota(disc.nota_t2)}</p>
+                    </div>
+                    <div className="rounded-lg border border-slate-100 p-2">
+                      <p className="text-xs text-slate-500">3º Trimestre</p>
+                      <p>MAC: {fmtNota(disc.nota_t3)}</p>
+                      <p>NPP: {fmtNota(disc.nota_t3)}</p>
+                      <p>PT: {fmtNota(disc.nota_t3)}</p>
+                      <p className="mt-1 font-medium">MT: {fmtNota(disc.nota_t3)}</p>
+                    </div>
+                  </div>
+                  <div className="mt-3 flex items-center justify-between">
+                    <p className="text-sm font-semibold text-slate-900">Final: {fmtNota(disc.nota_final)}</p>
+                    <span className={`rounded-full px-2 py-1 text-xs font-medium ${status.cls}`}>{status.label}</span>
+                  </div>
+                </details>
+              );
+            })}
+            {disciplinas.length === 0 && <p className="text-sm text-slate-500">Sem disciplinas no boletim.</p>}
+          </div>
+        </section>
+      )}
+
+      <div className="flex justify-end">
+        <Button asChild variant="outline" tone="gold" className="min-h-11">
+          <a href={`/api/aluno/boletim/pdf${studentId ? `?studentId=${studentId}` : ""}`} target="_blank" rel="noreferrer">Descarregar Boletim (PDF)</a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/financeiro-portal/FinanceiroPortalPage.tsx
+++ b/apps/web/src/components/aluno/financeiro-portal/FinanceiroPortalPage.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { Check, Wallet } from "lucide-react";
+import { Button } from "@/components/ui/Button";
+import { PaymentDrawer } from "./PaymentDrawer";
+import { usePortalSWR } from "@/components/aluno/usePortalSWR";
+
+type Item = { id: string; competencia: string; valor: number; status: "pago" | "pendente" | "atrasado" | "em_verificacao" };
+type ApiResponse = { ok: boolean; mensalidades: Array<Omit<Item, "status"> & { status: string }> };
+
+const money = new Intl.NumberFormat("pt-AO", { style: "currency", currency: "AOA", maximumFractionDigits: 0 });
+
+function normalizeStatus(value: string): Item["status"] {
+  if (value === "pago") return "pago";
+  if (value === "em_verificacao") return "em_verificacao";
+  if (value === "atrasado") return "atrasado";
+  return "pendente";
+}
+
+export function FinanceiroPortalPage() {
+  const searchParams = useSearchParams();
+  const studentId = useMemo(() => searchParams?.get("aluno") ?? null, [searchParams]);
+  const [loading, setLoading] = useState(true);
+  const [rows, setRows] = useState<Item[]>([]);
+  const [selected, setSelected] = useState<Item | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const query = studentId ? `?studentId=${studentId}` : "";
+  const req = usePortalSWR({
+    key: `financeiro-${studentId ?? "default"}`,
+    url: `/api/aluno/financeiro${query}`,
+    intervalMs: 30000,
+    parse: (payload) => (((payload as ApiResponse).mensalidades ?? []).map((m) => ({ ...m, status: normalizeStatus(m.status) }))),
+    onData: (data) => {
+      setRows(data);
+      setLoading(false);
+    },
+  });
+
+  const sorted = useMemo(() => [...rows].sort((a, b) => b.competencia.localeCompare(a.competencia)), [rows]);
+
+  const refresh = async () => {
+    setRefreshing(true);
+    await req.refresh();
+    setRefreshing(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <button onClick={refresh} className="min-h-11 rounded-xl border border-slate-200 bg-white px-3 text-xs text-slate-600">
+        {refreshing ? "A atualizar..." : "Puxar para atualizar"}
+      </button>
+
+      <section className="rounded-xl bg-white p-4 shadow-sm">
+        <h2 className="text-sm font-semibold text-slate-900">Mensalidades</h2>
+        {loading ? (
+          <div className="mt-3 h-36 animate-pulse rounded-xl bg-slate-100" />
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {sorted.map((item) => (
+              <li key={item.id} className="flex items-center justify-between rounded-xl border border-slate-100 p-3">
+                <div>
+                  <p className="text-sm font-medium text-slate-900">{item.competencia}</p>
+                  <p className="text-xs text-slate-500">{money.format(item.valor)}</p>
+                </div>
+                {item.status === "pago" ? (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700"><Check className="h-4 w-4" /> Pago</span>
+                ) : item.status === "em_verificacao" ? (
+                  <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-medium text-amber-700">Em Verificação</span>
+                ) : (
+                  <Button tone="gold" className="min-h-11" size="sm" onClick={() => setSelected(item)}><Wallet className="h-4 w-4" /> Pagar</Button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <PaymentDrawer
+        open={Boolean(selected)}
+        mensalidade={selected}
+        onClose={() => setSelected(null)}
+        onUploaded={(id) => setRows((prev) => prev.map((r) => (r.id === id ? { ...r, status: "em_verificacao" } : r)))}
+        studentId={studentId}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/financeiro-portal/PaymentDrawer.tsx
+++ b/apps/web/src/components/aluno/financeiro-portal/PaymentDrawer.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/Button";
+
+type Mensalidade = { id: string; competencia: string; valor: number };
+const money = new Intl.NumberFormat("pt-AO", { style: "currency", currency: "AOA", maximumFractionDigits: 0 });
+const MAX_BYTES = 5 * 1024 * 1024;
+const ALLOWED = ["application/pdf", "image/jpeg", "image/png", "image/webp"];
+
+async function compressImage(file: File): Promise<File> {
+  if (!file.type.startsWith("image/")) return file;
+  const bitmap = await createImageBitmap(file);
+  const maxW = 1600;
+  const ratio = Math.min(1, maxW / bitmap.width);
+  const w = Math.round(bitmap.width * ratio);
+  const h = Math.round(bitmap.height * ratio);
+  const canvas = document.createElement("canvas");
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return file;
+  ctx.drawImage(bitmap, 0, 0, w, h);
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/jpeg", 0.78));
+  if (!blob) return file;
+  return new File([blob], file.name.replace(/\.[^.]+$/, ".jpg"), { type: "image/jpeg" });
+}
+
+function uploadWithProgress(url: string, formData: FormData, onProgress: (pct: number) => void) {
+  return new Promise<{ ok?: boolean; error?: string }>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", url);
+    xhr.upload.onprogress = (event) => {
+      if (!event.lengthComputable) return;
+      onProgress(Math.round((event.loaded / event.total) * 100));
+    };
+    xhr.onload = () => {
+      try {
+        const json = JSON.parse(xhr.responseText || "{}");
+        if (xhr.status >= 200 && xhr.status < 300) resolve(json);
+        else reject(new Error(json?.error ?? "Falha no upload"));
+      } catch {
+        reject(new Error("Resposta inválida do servidor"));
+      }
+    };
+    xhr.onerror = () => reject(new Error("Falha de rede ao enviar comprovativo"));
+    xhr.send(formData);
+  });
+}
+
+export function PaymentDrawer({ open, mensalidade, onClose, onUploaded, studentId }: { open: boolean; mensalidade: Mensalidade | null; onClose: () => void; onUploaded: (mensalidadeId: string) => void; studentId?: string | null; }) {
+  const [sending, setSending] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const [friendlyError, setFriendlyError] = useState<string | null>(null);
+  if (!open || !mensalidade) return null;
+
+  const submitFile = async (original: File) => {
+    setFriendlyError(null);
+    if (!ALLOWED.includes(original.type)) {
+      setFriendlyError("Tipo inválido. Envie PDF, JPG, PNG ou WEBP.");
+      return;
+    }
+
+    const file = await compressImage(original);
+    if (file.size > MAX_BYTES) {
+      setFriendlyError("Arquivo muito grande. Limite de 5MB após compressão.");
+      return;
+    }
+
+    const fd = new FormData();
+    fd.append("mensalidadeId", mensalidade.id);
+    fd.append("file", file);
+    if (studentId) fd.append("studentId", studentId);
+
+    setSending(true);
+    setProgress(0);
+    try {
+      const json = await uploadWithProgress("/api/aluno/financeiro/comprovativo", fd, setProgress);
+      if (!json?.ok) throw new Error(json?.error ?? "Falha ao anexar comprovativo");
+      onUploaded(mensalidade.id);
+      onClose();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Não foi possível anexar o comprovativo. Tente novamente.";
+      setFriendlyError(message);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-40 bg-black/40" onClick={onClose}>
+      <div className="absolute inset-x-0 bottom-0 rounded-t-2xl bg-white p-4 shadow-xl" style={{ paddingBottom: "calc(16px + env(safe-area-inset-bottom))" }} onClick={(e) => e.stopPropagation()}>
+        <p className="text-sm font-semibold text-slate-900">Pagamento — {mensalidade.competencia}</p>
+        <p className="text-xs text-slate-500">Valor: {money.format(mensalidade.valor)}</p>
+        <div className="mt-4 rounded-xl bg-slate-50 p-3 text-sm text-slate-700">
+          <p className="font-medium text-slate-900">Coordenadas bancárias</p>
+          <p>Banco: BFA</p>
+          <p>IBAN: AO06 0000 0000 0000 0000 0000 0</p>
+          <p>Referência: MENS-{mensalidade.id.slice(0, 8).toUpperCase()}</p>
+        </div>
+        <label className="mt-4 block">
+          <span className="mb-2 block text-xs text-slate-500">Comprovativo (PDF/Imagem)</span>
+          <input type="file" className="block w-full text-sm" accept=".pdf,image/jpeg,image/png,image/webp" onChange={(e) => { const f = e.target.files?.[0]; if (f) void submitFile(f); }} disabled={sending} />
+        </label>
+        {sending && <p className="mt-2 text-xs text-slate-500">Upload: {progress}%</p>}
+        {friendlyError && <p className="mt-2 text-xs text-red-600">{friendlyError}</p>}
+        <Button tone="green" className="mt-4 min-h-11 w-full" disabled={sending}>{sending ? "A anexar..." : "Anexar Comprovativo"}</Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/home/FinanceAlertBanner.tsx
+++ b/apps/web/src/components/aluno/home/FinanceAlertBanner.tsx
@@ -1,0 +1,27 @@
+import { Button } from "@/components/ui/Button";
+
+type Props = {
+  loading: boolean;
+  alert: { id: string; valor: number; mes: string | null } | null;
+};
+
+const kwanza = new Intl.NumberFormat("pt-AO", { style: "currency", currency: "AOA", maximumFractionDigits: 0 });
+
+export function FinanceAlertBanner({ loading, alert }: Props) {
+  if (loading) return <div className="h-16 animate-pulse rounded-xl bg-amber-100" />;
+  if (!alert) return null;
+
+  return (
+    <section className="rounded-xl border border-amber-200 bg-amber-50 p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className="text-sm font-semibold text-slate-900">Mensalidade em atraso</p>
+          <p className="text-xs text-slate-600">
+            {kwanza.format(alert.valor)} {alert.mes ? `• ${alert.mes}` : ""}
+          </p>
+        </div>
+        <Button tone="green" className="min-h-11" size="sm">Pagar Agora</Button>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/aluno/home/HomePageClient.tsx
+++ b/apps/web/src/components/aluno/home/HomePageClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { FinanceAlertBanner } from "./FinanceAlertBanner";
+import { RecentGradesCard } from "./RecentGradesCard";
+import { StudentStatusCard } from "./StudentStatusCard";
+import { usePortalSWR } from "@/components/aluno/usePortalSWR";
+
+type StatusResponse = { nome: string; classe: string | null; turma: string | null; estadoAcademico: string } | null;
+type FinanceResponse = { id: string; valor: number; mes: string | null } | null;
+type GradeItem = { disciplina: string; tipo: string; nota: number | null; data: string | null };
+
+export function HomePageClient() {
+  const searchParams = useSearchParams();
+  const studentId = useMemo(() => searchParams?.get("aluno") ?? null, [searchParams]);
+
+  const [status, setStatus] = useState<StatusResponse>(null);
+  const [alert, setAlert] = useState<FinanceResponse>(null);
+  const [grades, setGrades] = useState<GradeItem[]>([]);
+  const [loadingStatus, setLoadingStatus] = useState(true);
+  const [loadingAlert, setLoadingAlert] = useState(true);
+  const [loadingGrades, setLoadingGrades] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const query = studentId ? `?studentId=${studentId}` : "";
+
+  const statusReq = usePortalSWR({
+    key: `home-status-${studentId ?? "default"}`,
+    url: `/api/aluno/home/status${query}`,
+    intervalMs: 60000,
+    parse: (payload) => (payload as { status?: StatusResponse }).status ?? null,
+    onData: (data) => {
+      setStatus(data);
+      setLoadingStatus(false);
+    },
+  });
+
+  const alertReq = usePortalSWR({
+    key: `home-alert-${studentId ?? "default"}`,
+    url: `/api/aluno/home/finance-alert${query}`,
+    intervalMs: 45000,
+    parse: (payload) => (payload as { alert?: FinanceResponse }).alert ?? null,
+    onData: (data) => {
+      setAlert(data);
+      setLoadingAlert(false);
+    },
+  });
+
+  const gradesReq = usePortalSWR({
+    key: `home-grades-${studentId ?? "default"}`,
+    url: `/api/aluno/home/recent-grades${query}`,
+    intervalMs: 90000,
+    parse: (payload) => ((payload as { items?: GradeItem[] }).items ?? []).slice(0, 3),
+    onData: (data) => {
+      setGrades(data);
+      setLoadingGrades(false);
+    },
+  });
+
+  const pullToRefresh = async () => {
+    setRefreshing(true);
+    await Promise.all([statusReq.refresh(), alertReq.refresh(), gradesReq.refresh()]);
+    setRefreshing(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <button onClick={pullToRefresh} className="min-h-11 rounded-xl border border-slate-200 bg-white px-3 text-xs text-slate-600">
+        {refreshing ? "A atualizar..." : "Puxar para atualizar"}
+      </button>
+
+      <FinanceAlertBanner loading={loadingAlert} alert={alert} />
+      <StudentStatusCard loading={loadingStatus} nome={status?.nome} classe={status?.classe} turma={status?.turma} estadoAcademico={status?.estadoAcademico} />
+      <RecentGradesCard loading={loadingGrades} items={grades} />
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/home/RecentGradesCard.tsx
+++ b/apps/web/src/components/aluno/home/RecentGradesCard.tsx
@@ -1,0 +1,45 @@
+type GradeItem = {
+  disciplina: string;
+  tipo: string;
+  nota: number | null;
+  data: string | null;
+};
+
+type Props = {
+  loading: boolean;
+  items: GradeItem[];
+};
+
+function shortDate(value: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleDateString("pt-PT", { day: "2-digit", month: "short" });
+}
+
+export function RecentGradesCard({ loading, items }: Props) {
+  if (loading) return <div className="h-48 animate-pulse rounded-xl bg-slate-100" />;
+
+  return (
+    <section className="rounded-xl bg-white p-4 shadow-sm">
+      <p className="text-sm font-semibold text-slate-900">Últimas avaliações</p>
+      <ul className="mt-3 space-y-3">
+        {items.length === 0 ? (
+          <li className="text-sm text-slate-500">Sem avaliações recentes.</li>
+        ) : (
+          items.map((item, idx) => (
+            <li key={`${item.disciplina}-${idx}`} className="flex items-center justify-between rounded-lg border border-slate-100 px-3 py-2">
+              <div>
+                <p className="text-sm font-medium text-slate-900">{item.disciplina}</p>
+                <p className="text-xs text-slate-500">{item.tipo}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-semibold text-slate-900">{item.nota ?? "—"}</p>
+                <p className="text-xs text-slate-500">{shortDate(item.data)}</p>
+              </div>
+            </li>
+          ))
+        )}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/aluno/home/StudentStatusCard.tsx
+++ b/apps/web/src/components/aluno/home/StudentStatusCard.tsx
@@ -1,0 +1,26 @@
+type Props = {
+  loading: boolean;
+  nome?: string;
+  classe?: string | null;
+  turma?: string | null;
+  estadoAcademico?: string;
+};
+
+export function StudentStatusCard({ loading, nome, classe, turma, estadoAcademico }: Props) {
+  if (loading) {
+    return <div className="h-28 animate-pulse rounded-xl bg-slate-100" />;
+  }
+
+  return (
+    <section className="rounded-xl bg-white p-4 shadow-sm">
+      <p className="text-xs uppercase tracking-wide text-slate-500">Estado do aluno</p>
+      <h2 className="mt-1 text-lg font-semibold text-slate-900">{nome ?? "Aluno"}</h2>
+      <p className="mt-2 text-sm text-slate-600">
+        {classe ?? "Classe —"} {turma ? `• ${turma}` : ""}
+      </p>
+      <span className="mt-3 inline-flex rounded-full bg-emerald-50 px-3 py-1 text-xs font-medium text-emerald-700">
+        {estadoAcademico ?? "Sem estado"}
+      </span>
+    </section>
+  );
+}

--- a/apps/web/src/components/aluno/usePortalSWR.ts
+++ b/apps/web/src/components/aluno/usePortalSWR.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+
+const inFlight = new Map<string, Promise<unknown>>();
+const lastAt = new Map<string, number>();
+
+type Options<T> = {
+  key: string;
+  url: string;
+  intervalMs?: number;
+  minGapMs?: number;
+  parse: (payload: unknown) => T;
+  onData: (data: T) => void;
+  onError?: (message: string) => void;
+};
+
+export function usePortalSWR<T>({ key, url, intervalMs = 45000, minGapMs = 1200, parse, onData, onError }: Options<T>) {
+  const abortRef = useRef<AbortController | null>(null);
+
+  const fetchNow = useCallback(
+    async (force = false) => {
+      const now = Date.now();
+      const prev = lastAt.get(key) ?? 0;
+      if (!force && now - prev < minGapMs) return;
+      lastAt.set(key, now);
+
+      abortRef.current?.abort();
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const run = inFlight.get(key) ??
+        fetch(url, { cache: "no-store", signal: controller.signal })
+          .then((r) => r.json())
+          .finally(() => inFlight.delete(key));
+
+      inFlight.set(key, run);
+
+      try {
+        const payload = await run;
+        onData(parse(payload));
+      } catch (e) {
+        if (controller.signal.aborted) return;
+        const message = e instanceof Error ? e.message : "Falha ao atualizar";
+        onError?.(message);
+      }
+    },
+    [key, minGapMs, onData, onError, parse, url],
+  );
+
+  useEffect(() => {
+    void fetchNow(true);
+    const onFocus = () => void fetchNow();
+    window.addEventListener("focus", onFocus);
+    const timer = window.setInterval(() => void fetchNow(), intervalMs);
+    return () => {
+      abortRef.current?.abort();
+      window.removeEventListener("focus", onFocus);
+      window.clearInterval(timer);
+    };
+  }, [fetchNow, intervalMs]);
+
+  return {
+    refresh: () => fetchNow(true),
+  };
+}

--- a/apps/web/src/lib/portalAlunoAuth.ts
+++ b/apps/web/src/lib/portalAlunoAuth.ts
@@ -1,0 +1,55 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~types/supabase";
+
+export async function resolveAuthorizedStudentIds(params: {
+  supabase: SupabaseClient<Database>;
+  userId: string;
+  escolaId: string;
+  userEmail?: string | null;
+}) {
+  const { supabase, userId, escolaId, userEmail } = params;
+
+  const { data: directRows } = await supabase
+    .from("alunos")
+    .select("id")
+    .eq("profile_id", userId)
+    .eq("escola_id", escolaId)
+    .limit(50);
+
+  const directIds = (directRows ?? []).map((r) => r.id);
+
+  let linkedIds: string[] = [];
+  if (userEmail) {
+    const { data: encarregado } = await supabase
+      .from("encarregados")
+      .select("id")
+      .eq("escola_id", escolaId)
+      .ilike("email", userEmail)
+      .limit(1)
+      .maybeSingle();
+
+    if (encarregado?.id) {
+      const { data: links } = await supabase
+        .from("aluno_encarregados")
+        .select("aluno_id")
+        .eq("escola_id", escolaId)
+        .eq("encarregado_id", encarregado.id)
+        .limit(100);
+      linkedIds = (links ?? []).map((l) => l.aluno_id);
+    }
+  }
+
+  const unique = Array.from(new Set([...directIds, ...linkedIds]));
+  return unique;
+}
+
+export function resolveSelectedStudentId(params: {
+  selectedId: string | null;
+  authorizedIds: string[];
+  fallbackId: string | null;
+}) {
+  const { selectedId, authorizedIds, fallbackId } = params;
+  if (selectedId && authorizedIds.includes(selectedId)) return selectedId;
+  if (fallbackId && authorizedIds.includes(fallbackId)) return fallbackId;
+  return authorizedIds[0] ?? null;
+}

--- a/apps/web/tests/aluno-idor-authorization.spec.ts
+++ b/apps/web/tests/aluno-idor-authorization.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { resolveSelectedStudentId } from '../src/lib/portalAlunoAuth';
+
+test.describe('Aluno portal authorization (IDOR guard)', () => {
+  test('rejects selected student outside authorized set', async () => {
+    const authorized = ['stu-a', 'stu-b'];
+    const chosen = resolveSelectedStudentId({
+      selectedId: 'stu-x',
+      authorizedIds: authorized,
+      fallbackId: 'stu-a',
+    });
+
+    expect(chosen).toBe('stu-a');
+  });
+
+  test('accepts selected student inside authorized set', async () => {
+    const authorized = ['stu-a', 'stu-b'];
+    const chosen = resolveSelectedStudentId({
+      selectedId: 'stu-b',
+      authorizedIds: authorized,
+      fallbackId: 'stu-a',
+    });
+
+    expect(chosen).toBe('stu-b');
+  });
+
+  test('returns null when no authorized students exist', async () => {
+    const chosen = resolveSelectedStudentId({
+      selectedId: 'stu-x',
+      authorizedIds: [],
+      fallbackId: null,
+    });
+
+    expect(chosen).toBeNull();
+  });
+});


### PR DESCRIPTION
### Motivation

- Unificar e evoluir a experiência do Portal do Aluno com novas páginas (Home, Académico, Financeiro) e navegação móvel, garantindo que a seleção de `studentId` esteja protegida por autorização aplicacional e reduzindo risco de IDORs. 
- Suportar fluxo de pagamento com upload de comprovativos e marcação de mensalidades em verificação, além de permitir geração de PDF do boletim para download. 
- Adicionar ferramentas e relatórios operacionais que identifiquem pendências de segurança (RLS por vínculo) e configurar gates no backend para operações de liberação de acesso. 

### Description

- Layout e navegação: adiciona novo `AlunoLayout` com cabeçalho, `StudentSwitcher`, `BottomNav` e lógica para resolver/selecionar educandos; altera redireção de `/aluno` para `/home`. 
- Componentes cliente: adiciona `HomePageClient`, `FinanceiroPortalPage`, `AcademicoAccordion`, `PaymentDrawer`, banners e cartões de home, e o hook `usePortalSWR` para polling/refresh de dados. 
- APIs e backend routes: implementa/ajusta endpoints para o portal (`/api/aluno/boletim`, `/api/aluno/boletim/pdf`, `/api/aluno/financeiro`, `/api/aluno/financeiro/comprovativo`, `/api/aluno/home/*`) com resolução de autorização por estudante; adiciona upload para o bucket `aluno-comprovativos` e atualiza `mensalidades` para `status = 'em_verificacao'`. 
- Autorização/guardas: adiciona `lib/portalAlunoAuth.ts` com `resolveAuthorizedStudentIds` e `resolveSelectedStudentId` para prevenir IDORs; reforça gate em `POST /api/secretaria/alunos/liberar-acesso` consultando `escolas.aluno_portal_enabled` e retornando `409` quando não concedido. 
- Infra/ops e relatórios: inclui relatórios em `agents/output` descrevendo estado atual do portal e do fluxo de liberação de acesso. 
- Testes: adiciona spec `apps/web/tests/aluno-idor-authorization.spec.ts` para validar a função de seleção/autorização de estudante. 

### Testing

- Adicionada suíte de teste Playwright em `apps/web/tests/aluno-idor-authorization.spec.ts` que valida `resolveSelectedStudentId` contra 3 cenários automáticos; os 3 testes passaram com sucesso. 
- Nenhum outro teste automatizado foi alterado neste PR; endpoints e UI novos foram exercitados por chamadas internas ao buscar dados via `usePortalSWR` (manual/integração durante desenvolvimento).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a58fe8d8208328a03dd6c9430be44a)