### PR TITLE
Improve KF2 search audit: segment-level parsing, precise LIMIT/ORDER checks, and dedupe

### DIFF
--- a/agents/scan/kf2-search-audit.ts
+++ b/agents/scan/kf2-search-audit.ts
@@ -15,6 +15,16 @@ type Finding = {
 };
 
 const findings: Finding[] = [];
+const findingKeys = new Set<string>();
+
+function pushFinding(file: string, error: string) {
+  const key = `${file}::${error}`;
+  if (findingKeys.has(key)) return;
+  findingKeys.add(key);
+  findings.push({ file, error });
+}
+
+const QUERY_END_MARKER = /(?:;|\n\s*return\s+|\n\s*const\s+|\n\s*let\s+|\n\s*if\s*\(|\n\s*}\s*catch)/;
 
 function hasAllowScan(content: string) {
   return content.includes("@kf2 allow-scan");
@@ -22,6 +32,76 @@ function hasAllowScan(content: string) {
 
 function hasKf2Invariants(content: string) {
   return content.includes("applyKf2ListInvariants");
+}
+
+
+function extractQuerySegments(content: string) {
+  const segments: string[] = [];
+  const queryRegex = /\.(from|rpc)\(/g;
+
+  for (const match of content.matchAll(queryRegex)) {
+    const start = match.index ?? -1;
+    if (start < 0) continue;
+
+    const rest = content.slice(start);
+    const endMatch = rest.match(QUERY_END_MARKER);
+    const end = endMatch?.index ?? rest.length;
+
+    segments.push(rest.slice(0, end));
+  }
+
+  return segments;
+}
+
+function isSingleRowQuery(segment: string) {
+  return (
+    segment.includes(".single(") ||
+    segment.includes(".maybeSingle(") ||
+    segment.includes("head: true") ||
+    /\.limit\(\s*1\s*\)/.test(segment)
+  );
+}
+
+function hasExplicitLimit(segment: string) {
+  return /\.limit\(\s*[^)]+\)/.test(segment);
+}
+
+function extractNumericLimits(segment: string) {
+  const matches = [...segment.matchAll(/\.limit\(\s*(\d+)\s*\)/g)];
+  return matches.map(([, value]) => Number(value));
+}
+
+function hasRange(segment: string) {
+  return /\.range\(\s*[^,]+\s*,\s*[^)]+\)/.test(segment);
+}
+
+function hasDeterministicOrder(segment: string) {
+  const orders = [...segment.matchAll(/\.order\(\s*['"`]([^'"`]+)['"`]/g)].map((m) => m[1]);
+  if (orders.length === 0) return false;
+
+  if (orders.some((field) => field === "id" || field === "created_at" || field === "updated_at")) {
+    return true;
+  }
+
+  return false;
+}
+
+
+function isReadQuerySegment(segment: string) {
+  if (segment.startsWith('.rpc(')) {
+    return true;
+  }
+
+  return segment.includes('.select(');
+}
+
+function isWriteQuerySegment(segment: string) {
+  return (
+    segment.includes(".insert(") ||
+    segment.includes(".update(") ||
+    segment.includes(".upsert(") ||
+    segment.includes(".delete(")
+  );
 }
 
 function checkFile(file: string, content: string) {
@@ -44,40 +124,60 @@ function checkFile(file: string, content: string) {
     return;
   }
 
-  if (content.includes(".select('*')") || content.includes('.select("*")')) {
-    findings.push({
-      file,
-      error: "Uso de select('*') em pesquisa",
-    });
+  const querySegments = extractQuerySegments(content);
+  if (querySegments.length === 0) {
+    return;
   }
 
-  const limitRegex = /\.limit\((\d+)\)/g;
-  const limits = [...content.matchAll(limitRegex)];
-  const usesKf2Invariants = hasKf2Invariants(content);
+  for (const segment of querySegments) {
+    if (!isReadQuerySegment(segment) || isWriteQuerySegment(segment)) {
+      continue;
+    }
 
-  if (!usesKf2Invariants) {
-    if (limits.length === 0) {
-      findings.push({
-        file,
-        error: "Pesquisa sem LIMIT explícito",
-      });
-    } else {
-      for (const [, value] of limits) {
-        if (Number(value) > MAX_LIMIT) {
-          findings.push({
-            file,
-            error: `LIMIT maior que ${MAX_LIMIT}`,
-          });
+    if (segment.includes(".select('*')") || segment.includes('.select("*")')) {
+      pushFinding(file, "Uso de select('*') em pesquisa");
+    }
+
+    const limits = extractNumericLimits(segment);
+    const usesKf2Invariants = hasKf2Invariants(content);
+    const singleRowQuery = isSingleRowQuery(segment);
+    const aggregateQuery =
+      segment.includes("count(") ||
+      segment.includes("COUNT(") ||
+      segment.includes("sum(") ||
+      segment.includes("SUM(") ||
+      segment.includes("group(");
+
+    if (!usesKf2Invariants && !singleRowQuery && !segment.startsWith(".rpc(")) {
+      if (!hasExplicitLimit(segment) && !hasRange(segment)) {
+        pushFinding(file, "Pesquisa sem LIMIT explícito");
+      } else {
+        for (const value of limits) {
+          if (value > MAX_LIMIT) {
+            pushFinding(file, `LIMIT maior que ${MAX_LIMIT}`);
+          }
+        }
+
+        const rangeMatch = segment.match(/\.range\(\s*(\d+)\s*,\s*(\d+)\s*\)/);
+        if (rangeMatch) {
+          const from = Number(rangeMatch[1]);
+          const to = Number(rangeMatch[2]);
+          if (to - from + 1 > MAX_LIMIT) {
+            pushFinding(file, `LIMIT maior que ${MAX_LIMIT}`);
+          }
         }
       }
     }
-  }
 
-  if (!usesKf2Invariants && !content.includes(".order(")) {
-    findings.push({
-      file,
-      error: "Pesquisa sem ORDER BY determinístico",
-    });
+    if (
+      !usesKf2Invariants &&
+      !singleRowQuery &&
+      !aggregateQuery &&
+      !segment.startsWith(".rpc(") &&
+      !hasDeterministicOrder(segment)
+    ) {
+      pushFinding(file, "Pesquisa sem ORDER BY determinístico");
+    }
   }
 }
 


### PR DESCRIPTION
### Motivation
- Increase precision of the search audit by analyzing individual query segments instead of scanning the whole file text, to reduce false positives.
- Respect single-row, aggregate and RPC queries, and support explicit `.range()` checks and deterministic `order` detection to avoid flagging valid queries.
- Prevent duplicate findings when the same issue is detected multiple times in a file.

### Description
- Implemented segment extraction around `.from(` and `.rpc(` calls using a `QUERY_END_MARKER` and added per-segment analysis via `extractQuerySegments` and helpers like `isSingleRowQuery`, `hasExplicitLimit`, `extractNumericLimits`, `hasRange`, and `hasDeterministicOrder`.
- Adjusted logic to skip write queries, treat `.rpc(` as read, and exempt single-row/aggregate/RPC queries from limit/order checks while still validating `.limit()` and `.range()` sizes against `MAX_LIMIT` (50).
- Added deduplication of findings with `findingKeys` and `pushFinding` to avoid repeating the same error for a file.
- Retained existing `@kf2 allow-scan` and API GET handler exemptions and improved detection of `select('*')` usages per segment.

### Testing
- Executed the updated audit script with `node agents/scan/kf2-search-audit.ts` against the repository to verify it runs and reports findings without crashing, and the process exits with non-zero when issues are present.
- Verified that queries using `.single()`, `.maybeSingle()`, RPCs, aggregates, explicit `.limit()` and `.range()` are handled according to the new rules on sample files.
- No unit tests were added in this change; existing CI should pick up the script execution as part of repository checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4608f757483288d9e5ba91fd7f573)