### PR TITLE
Fix: avoid KF2 50-row truncation in turmas and professor pendências aggregations

### DIFF
--- a/apps/web/src/app/api/escolas/[id]/professores/[profileId]/pendencias/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/professores/[profileId]/pendencias/route.ts
@@ -48,9 +48,10 @@ export async function GET(req: Request, context: { params: Promise<{ id: string;
       .eq("profile_id", profileId)
 
     pendenciasQuery = applyKf2ListInvariants(pendenciasQuery, {
-      defaultLimit: 50,
+      defaultLimit: 1000,
       order: [{ column: 'turma_nome', ascending: true }],
       tieBreakerColumn: 'turma_disciplina_id',
+      maxLimit: 5000,
     })
 
     const { data: rows, error } = await pendenciasQuery

--- a/apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts
@@ -69,28 +69,23 @@ export async function GET() {
           tieBreakerColumn: 'turma_id',
         }
       )
-      const alunosQuery = applyKf2ListInvariants(
-        supabase
+      const alunosCountPromises = turmaIds.map(async (turmaId: string) => {
+        const { count, error } = await supabase
           .from("matriculas")
-          .select("turma_id")
+          .select("id", { count: "exact", head: true })
           .eq("escola_id", escolaId)
-          .in("turma_id", turmaIds)
-          .in("status", ["ativo", "ativa", "active"]),
-        {
-          defaultLimit: 50,
-          order: [{ column: 'turma_id', ascending: true }],
-        }
-      )
+          .eq("turma_id", turmaId)
+          .in("status", ["ativo", "ativa", "active"])
 
-      const [pendenciasRes, alunosRes] = await Promise.all([pendenciasQuery, alunosQuery])
+        if (error) throw error
+        return { turmaId, total: count ?? 0 }
+      })
+
+      const [pendenciasRes, alunosCounts] = await Promise.all([pendenciasQuery, Promise.all(alunosCountPromises)])
 
       if (pendenciasRes.error) {
         return NextResponse.json({ ok: false, error: pendenciasRes.error.message }, { status: 500 })
       }
-      if (alunosRes.error) {
-        return NextResponse.json({ ok: false, error: alunosRes.error.message }, { status: 500 })
-      }
-
       for (const row of pendenciasRes.data || []) {
         const total = row.total_alunos ?? 0
         const pendente = row.pendentes ?? 0
@@ -99,8 +94,8 @@ export async function GET() {
         pendenciasMap.set(row.turma_id, (pendenciasMap.get(row.turma_id) ?? 0) + 1)
       }
 
-      for (const row of (alunosRes.data || []) as Array<{ turma_id: string }>) {
-        alunosMap.set(row.turma_id, (alunosMap.get(row.turma_id) ?? 0) + 1)
+      for (const row of alunosCounts) {
+        alunosMap.set(row.turmaId, row.total)
       }
     }
 


### PR DESCRIPTION
### Motivation

- Two endpoints were producing undercounted derived totals because `applyKf2ListInvariants(..., { defaultLimit: 50 })` truncated the source rows before aggregation, which can hide real workload for large schools or professors. 
- Ensure aggregation and summary logic operate on full counts (or appropriately large limits) so operational summaries and counts are correct.

### Description

- Replaced the limited matriculas sampling in `apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts` with per-turma exact counts using `select("id", { count: "exact", head: true })` and populate `alunosMap` from those totals so `alunos` reflects full counts.  
- Increased the pendências list defaults in `apps/web/src/app/api/escolas/[id]/professores/[profileId]/pendencias/route.ts` to `defaultLimit: 1000` and added `maxLimit: 5000` to avoid silent truncation while retaining deterministic ordering and the existing tie-breaker.  
- Changes are localized to the two route handlers and preserve KF2 ordering/tie-breaker behavior via `applyKf2ListInvariants` options.

### Testing

- Ran `eslint` against the two modified files (`apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts` and `apps/web/src/app/api/escolas/[id]/professores/[profileId]/pendencias/route.ts`) and the linter passed for those files.  
- Attempted workspace type-check with the repository commands (`pnpm typecheck`) but the pretypecheck `db:types` step failed due to a registry/auth fetch error (`ERR_PNPM_FETCH_403`) in this environment, preventing a full typecheck run.  
- Ran `tsc --noEmit` for the `apps/web` package and observed pre-existing TypeScript syntax errors in unrelated files which blocked a clean `tsc` pass in this environment; the failures are unrelated to the two modified routes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a71ecf4d9483289e6963b3a493c9b3)