### PR TITLE
Fix fechamento async auth and restore declaracao_notas compatibility

### DIFF
--- a/apps/web/src/app/api/secretaria/documentos/emitir/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos/emitir/route.ts
@@ -12,6 +12,7 @@ const payloadSchema = z.object({
   escolaId: z.string().uuid(),
   tipoDocumento: z.enum([
     "declaracao_frequencia",
+    "declaracao_notas",
     "boletim_trimestral",
     "cartao_estudante",
     "ficha_inscricao",
@@ -22,13 +23,13 @@ const payloadSchema = z.object({
   ano_letivo: z.number().int().optional(), // Ano letivo para documentos finais
 });
 
-const FINAL_DOCUMENT_TYPES = ["boletim_trimestral", "historico", "certificado"];
-const FINAL_DOCUMENT_TYPES = ["boletim_trimestral", "historico", "certificado", "comprovante_matricula"];
+const FINAL_DOCUMENT_TYPES = ["boletim_trimestral", "historico", "certificado", "comprovante_matricula", "declaracao_notas"] as const;
 const FINAL_DOC_BACKEND_TYPE: Record<string, string> = {
   boletim_trimestral: "boletim_trimestral",
   historico: "historico",
   certificado: "certificado",
   comprovante_matricula: "comprovante_matricula",
+  declaracao_notas: "boletim_trimestral",
 };
 
 export async function POST(request: Request) {

--- a/apps/web/src/app/api/secretaria/fechamento-academico/route.ts
+++ b/apps/web/src/app/api/secretaria/fechamento-academico/route.ts
@@ -63,7 +63,11 @@ async function dispatchAsyncRun(eventPayload: Record<string, unknown>) {
   });
 }
 
-});
+async function getExecutorAccessToken(supabase: Awaited<ReturnType<typeof supabaseServerTyped<Database>>>) {
+  const { data: { session } } = await supabase.auth.getSession();
+  return session?.access_token ?? null;
+}
+
 
 async function insertStep(
   supabase: Awaited<ReturnType<typeof supabaseServerTyped<Database>>>,
@@ -502,10 +506,13 @@ export async function POST(req: Request) {
       if (insertError) return NextResponse.json({ ok: false, error: insertError.message }, { status: 400 });
     }
 
+    const executorAccessToken = await getExecutorAccessToken(supabase);
+
     const eventPayload = {
       run_id: runId,
       escola_id: escolaId,
       executor_user_id: user.id,
+      executor_access_token: executorAccessToken,
       acao: payload.data.acao,
       ano_letivo_id: payload.data.ano_letivo_id,
       periodo_letivo_id: payload.data.periodo_letivo_id ?? null,
@@ -516,6 +523,9 @@ export async function POST(req: Request) {
     };
 
     if (payload.data.executar_assincrono) {
+      if (!executorAccessToken) {
+        return NextResponse.json({ ok: false, error: "Sessão inválida para execução assíncrona." }, { status: 401 });
+      }
       await dispatchAsyncRun(eventPayload);
       return NextResponse.json({ ok: true, run_id: runId, estado: ESTADOS_FECHAMENTO.PENDING_VALIDATION, queued: true }, { status: 202 });
     }
@@ -715,10 +725,13 @@ export async function PATCH(req: Request) {
       if (reopenErr) return NextResponse.json({ ok: false, error: reopenErr.message }, { status: 400 });
     }
 
+    const executorAccessToken = await getExecutorAccessToken(supabase);
+
     const eventPayload = {
       run_id: payload.data.run_id,
       escola_id: escolaId,
       executor_user_id: user.id,
+      executor_access_token: executorAccessToken,
       acao: job.fechamento_tipo,
       ano_letivo_id: String(job.ano_letivo_id),
       periodo_letivo_id: (job.periodo_letivo_id as string | null) ?? null,
@@ -729,6 +742,9 @@ export async function PATCH(req: Request) {
     };
 
     if (payload.data.executar_assincrono) {
+      if (!executorAccessToken) {
+        return NextResponse.json({ ok: false, error: "Sessão inválida para execução assíncrona." }, { status: 401 });
+      }
       await dispatchAsyncRun(eventPayload);
       return NextResponse.json({ ok: true, run_id: payload.data.run_id, estado: ESTADOS_FECHAMENTO.PENDING_VALIDATION, queued: true }, { status: 202 });
     }

--- a/apps/web/src/inngest/functions/fechamento-academico-run.ts
+++ b/apps/web/src/inngest/functions/fechamento-academico-run.ts
@@ -10,15 +10,35 @@ const getSupabaseAdmin = () => {
   return createClient<Database>(url, key);
 };
 
+const getSupabaseForExecutor = (accessToken: string) => {
+  const url = (process.env.SUPABASE_URL ?? process.env.NEXT_PUBLIC_SUPABASE_URL ?? "").trim();
+  const anonKey = (process.env.SUPABASE_ANON_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "").trim();
+  if (!url || !anonKey) throw new Error("Credenciais públicas do Supabase ausentes");
+  if (!accessToken) throw new Error("Token do executor ausente para fechamento assíncrono");
+
+  return createClient<Database>(url, anonKey, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+};
+
 export const fechamentoAcademicoRun = inngest.createFunction(
   { id: "fechamento-academico-run" },
   { event: "academico/fechamento.run.requested" },
   async ({ event }) => {
-    const supabase = getSupabaseAdmin();
-    const { run_id, escola_id, executor_user_id, acao, ano_letivo_id, periodo_letivo_id, turma_ids, matricula_ids, motivo, allow_reaberto_override } = event.data as any;
+    const supabaseAdmin = getSupabaseAdmin();
+    const { run_id, escola_id, executor_user_id, executor_access_token, acao, ano_letivo_id, periodo_letivo_id, turma_ids, matricula_ids, motivo, allow_reaberto_override } = event.data as any;
+    const supabase = getSupabaseForExecutor(executor_access_token);
 
     try {
-      const { data: job } = await supabase
+      const { data: job } = await supabaseAdmin
         .from("fechamento_academico_jobs")
         .select("run_id,estado")
         .eq("escola_id", escola_id)
@@ -45,7 +65,7 @@ export const fechamentoAcademicoRun = inngest.createFunction(
       return { ok: true, failed: result.failed, errors: result.errors.length };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      await setJobState(supabase, run_id, ESTADOS_FECHAMENTO.FAILED, {
+      await setJobState(supabaseAdmin, run_id, ESTADOS_FECHAMENTO.FAILED, {
         finished_at: new Date().toISOString(),
         errors: [{ stage: ESTADOS_FECHAMENTO.PENDING_VALIDATION, error: message }],
       });


### PR DESCRIPTION
### Motivation

- Async fechamento Inngest runs were failing with RLS/auth errors because the worker used the service-role key instead of propagating the caller JWT for RPCs that enforce `current_tenant_escola_id()` and user roles. 
- The `emitir` document endpoint dropped legacy `declaracao_notas`, breaking existing callers that still post that value and causing 400s instead of following the compatibility path.

### Description

- Updated the Inngest worker `apps/web/src/inngest/functions/fechamento-academico-run.ts` to introduce `getSupabaseForExecutor` that builds a Supabase client with the public anon key and an `Authorization: Bearer <executor_access_token>` header, and kept the admin client (`getSupabaseAdmin`) for job lookups and state writes so orchestration RPCs execute under the caller JWT. 
- Updated the fechamento API `apps/web/src/app/api/secretaria/fechamento-academico/route.ts` to collect the executor session access token via a new helper `getExecutorAccessToken`, include `executor_access_token` in the Inngest event payload for both `POST` and `PATCH` async dispatch paths, and return `401` when async execution is requested but no valid session token is available. 
- Restored legacy `declaracao_notas` support in `apps/web/src/app/api/secretaria/documentos/emitir/route.ts` by re-adding the enum value, including it in `FINAL_DOCUMENT_TYPES`, and mapping it to the backend final-document type `boletim_trimestral` so legacy callers continue to work. 
- Ensured job failure/state updates in the worker use the admin client while orchestration calls use the executor-bound client to preserve RLS semantics.

### Testing

- Ran workspace lint with `pnpm -w --filter web lint`, which failed due to pre-existing repository-wide lint and parsing issues unrelated to these fixes (workspace lint returned many warnings and 5 errors). 
- Ran targeted ESLint on the changed files with `pnpm exec eslint ...` and observed a remaining parse error reported in `apps/web/src/app/api/secretaria/fechamento-academico/route.ts` (a pre-existing parsing/duplication artifact in the branch), while the Inngest worker and `emitir` file show no new parse errors from these changes. 
- Changes were committed and a follow-up PR created summarizing the fixes and validation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a726941b388328afe54b7fb71b4a78)