### PR TITLE
Fix secretaria_financeiro admin linkage in school creation flow

### DIFF
--- a/apps/web/src/app/api/escolas/create/route.ts
+++ b/apps/web/src/app/api/escolas/create/route.ts
@@ -225,7 +225,13 @@ async function ensureAdminUser(
     { onConflict: 'escola_id,user_id' }
   )
 
-  if (params.papel === 'admin' || params.papel === 'admin_escola' || params.papel === 'staff_admin' || params.papel === 'admin_financeiro') {
+  if (
+    params.papel === 'admin' ||
+    params.papel === 'admin_escola' ||
+    params.papel === 'staff_admin' ||
+    params.papel === 'admin_financeiro' ||
+    params.papel === 'secretaria_financeiro'
+  ) {
     await supabase.from('escola_administradores').upsert(
       {
         escola_id: params.escolaId,


### PR DESCRIPTION
### Motivation

- Ensure creators assigned the composite `secretaria_financeiro` role are granted admin fallback permissions by being added to `escola_administradores`, preventing a brand-new school from being blocked for user management.

### Description

- Treat `secretaria_financeiro` as an admin-like role in the school-creation flow by adding it to the admin-role condition in `ensureAdminUser` so the creator is upserted into `escola_administradores` (file: `apps/web/src/app/api/escolas/create/route.ts`, lines ~228–243). 

### Testing

- Ran TypeScript check `pnpm -C apps/web exec tsc --noEmit`, which surfaced unrelated JSX syntax errors in `src/app/super-admin/escolas/nova/page.tsx` and caused the compile to fail; the small role-condition patch itself is a trivial logic change and does not introduce new type errors in the edited file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a804112508832887842c807a57eaa0)