### PR TITLE
Fix(portal-aluno): exact guardian email match & keep /aluno redirect inside guarded layout

### DIFF
--- a/apps/web/src/app/(portal-aluno)/aluno/page.tsx
+++ b/apps/web/src/app/(portal-aluno)/aluno/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
 export default function Page() {
-  redirect("/home");
+  redirect("/aluno/home");
 }

--- a/apps/web/src/lib/portalAlunoAuth.ts
+++ b/apps/web/src/lib/portalAlunoAuth.ts
@@ -20,11 +20,13 @@ export async function resolveAuthorizedStudentIds(params: {
 
   let linkedIds: string[] = [];
   if (userEmail) {
+    const normalizedEmail = userEmail.trim();
+
     const { data: encarregado } = await supabase
       .from("encarregados")
       .select("id")
       .eq("escola_id", escolaId)
-      .ilike("email", userEmail)
+      .eq("email", normalizedEmail)
       .limit(1)
       .maybeSingle();
 


### PR DESCRIPTION
### Motivation

- Prevent an IDOR by ensuring guardian email lookups do not use wildcard matching which can return the wrong `encarregado` and expose other students' data. 
- Ensure the `/aluno` entry path stays inside the `(portal-aluno)` guarded layout so role/plan/status gates and shared UI (StudentSwitcher/BottomNav) are always applied.

### Description

- Tighten guardian lookup in `resolveAuthorizedStudentIds` by normalizing the email with `trim()` and replacing `.ilike("email", userEmail)` with an exact `.eq("email", normalizedEmail)` to avoid `_`/`%` wildcard matches (`apps/web/src/lib/portalAlunoAuth.ts`).
- Keep the portal landing inside the guarded segment by changing the redirect target from `/home` to `/aluno/home` in `apps/web/src/app/(portal-aluno)/aluno/page.tsx`.
- Changes committed on the feature branch and a follow-up PR was created summarizing these fixes.

### Testing

- Ran ESLint for the modified files with `pnpm exec eslint ...` in the `apps/web` package and the lint run completed successfully. 
- Ran TypeScript checks with `pnpm exec tsc --noEmit` in `apps/web` and type checking passed. 
- Attempted to run the Playwright spec `tests/aluno-idor-authorization.spec.ts` but the Playwright CLI is not available in this environment so the end-to-end test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8041432b08328b0a8413ef5750d77)