### PR TITLE
Follow-up for #69: allow 500-row aggregate caps in turma documentos endpoint

### DIFF
--- a/apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts
@@ -65,6 +65,7 @@ export async function GET() {
           .in("turma_id", turmaIds),
         {
           defaultLimit: 500,
+          maxLimit: 500,
           order: [{ column: 'turma_id', ascending: true }],
           tieBreakerColumn: 'turma_id',
         }
@@ -78,6 +79,7 @@ export async function GET() {
           .in("status", ["ativo", "ativa", "active"]),
         {
           defaultLimit: 500,
+          maxLimit: 500,
           order: [{ column: 'turma_id', ascending: true }],
         }
       )


### PR DESCRIPTION
### Motivation

- Fix a P1 undercount where aggregate queries in the turma documentos endpoint were still capped at 50 rows because `defaultLimit` is clamped to `maxLimit` by `normalizeListRange`.
- Ensure `pendencias` and `alunos` aggregates compute over the intended 500-row window for schools where `vw_professor_pendencias` or `matriculas` return more than 50 rows.

### Description

- Updated `apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts` to add `maxLimit: 500` to the `vw_professor_pendencias` aggregate query defaults so `defaultLimit: 500` is not clamped to 50.
- Added `maxLimit: 500` to the `matriculas` aggregate query defaults in the same file to allow `alunos` counts to use the intended 500-row cap.
- This change preserves the use of `applyKf2ListInvariants` and the existing ordering/tie-breaker settings while restoring the larger aggregate window.

### Testing

- Ran `pnpm --filter web exec eslint src/app/api/secretaria/documentos-oficiais/turmas/route.ts` and the modified file passed linting.
- Ran `pnpm -w --filter web exec tsc --noEmit` which exited non-zero due to pre-existing unrelated TypeScript syntax errors in `apps/web/src/app/api/aluno/boletim/route.ts`; those errors are not introduced by this change.
- Verified the updated lines in `apps/web/src/app/api/secretaria/documentos-oficiais/turmas/route.ts` so the aggregate queries now include `maxLimit: 500` and will not be clamped by the default `maxLimit` of 50.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a80415818c8328b3477cb103f12142)