### PR TITLE
Agenda SSOT: horario_versoes, temporal guardrails and next-class selection

### DIFF
--- a/apps/web/src/app/api/aluno/dashboard/route.ts
+++ b/apps/web/src/app/api/aluno/dashboard/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { getAlunoContext } from "@/lib/alunoContext";
 import { applyKf2ListInvariants } from "@/lib/kf2";
 import type { Database } from "~types/supabase";
+import { escolherProximaAula, normalizeIsoWeekday } from "@/lib/agenda/proximaAula";
 
 type DatabaseWithAvisos = Database & {
   public: Database["public"] & {
@@ -20,7 +21,20 @@ type DatabaseWithAvisos = Database & {
   };
 };
 
-type RotinaRow = { weekday: number | null; inicio: string | null; fim: string | null; sala: string | null };
+type ProximaAulaRow = {
+  slot_id: string | null;
+  weekday: number | null;
+  inicio: string | null;
+  fim: string | null;
+  sala: string | null;
+  ordem?: number | null;
+};
+type QuadroProximaAulaRow = {
+  slot_id: string | null;
+  sala_id: string | null;
+  sala?: { nome: string | null } | null;
+  slot?: { dia_semana: number | null; inicio: string | null; fim: string | null; ordem: number | null; is_intervalo: boolean | null } | null;
+};
 type NotaRow = { valor: number | null; created_at: string | null };
 type MensalidadeRow = { status: string | null };
 type StatusFinanceiro = { emDia: boolean; pendentes: number; error?: string };
@@ -32,22 +46,52 @@ export async function GET() {
     if (!ctx) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
     const { escolaId, matriculaId, turmaId, anoLetivo } = ctx;
 
-    // Próxima aula (heurística: próxima rotina da turma pelo weekday atual)
-    let proxima_aula: RotinaRow | null = null;
+    // Próxima aula (lê apenas versão publicada do quadro oficial)
+    let proxima_aula: ProximaAulaRow | null = null;
     try {
-      if (turmaId) {
+      if (turmaId && escolaId) {
         const now = new Date();
-        const weekday = now.getDay(); // 0..6
-        let rotinasQuery = supabase
-          .from('rotinas')
-          .select('weekday, inicio, fim, sala')
+        const { data: versaoPublicada } = await supabase
+          .from('horario_versoes')
+          .select('id')
+          .eq('escola_id', escolaId)
           .eq('turma_id', turmaId)
-          .gte('weekday', weekday)
-          .order('weekday', { ascending: true })
-          .limit(1);
-        if (escolaId) rotinasQuery = rotinasQuery.eq('escola_id', escolaId);
-        const { data: rs } = await rotinasQuery;
-        proxima_aula = rs?.[0] ?? null;
+          .eq('status', 'publicada')
+          .order('publicado_em', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        const { data: quadroRows } = versaoPublicada?.id
+          ? await supabase
+              .from('quadro_horarios')
+              .select('slot_id, sala_id, sala:salas(nome), slot:horario_slots!inner(dia_semana, inicio, fim, ordem, is_intervalo)')
+              .eq('escola_id', escolaId)
+              .eq('turma_id', turmaId)
+              .eq('versao_id', versaoPublicada.id)
+              .order('slot_id', { ascending: true })
+          : { data: [] as QuadroProximaAulaRow[] };
+
+        const normalizedSlots: ProximaAulaRow[] = ((quadroRows || []) as QuadroProximaAulaRow[])
+          .filter((row) => row.slot && !row.slot.is_intervalo)
+          .map((row) => ({
+            slot_id: row.slot_id,
+            weekday: row.slot?.dia_semana ? normalizeIsoWeekday(row.slot.dia_semana) : null,
+            inicio: row.slot?.inicio ?? null,
+            fim: row.slot?.fim ?? null,
+            sala: row.sala?.nome ?? null,
+            ordem: row.slot?.ordem ?? null,
+          }));
+
+        const nextSlot = escolherProximaAula(normalizedSlots, now);
+        proxima_aula = nextSlot
+          ? {
+              slot_id: nextSlot.slot_id,
+              weekday: nextSlot.weekday,
+              inicio: nextSlot.inicio,
+              fim: nextSlot.fim,
+              sala: nextSlot.sala,
+            }
+          : null;
       }
     } catch {}
 

--- a/apps/web/src/app/api/escolas/[id]/horarios/quadro/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/horarios/quadro/route.ts
@@ -8,8 +8,10 @@ import { authorizeTurmasManage } from '@/lib/escola/disciplinas'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+type HorarioVersaoRow = { id: string; status: 'draft' | 'publicada' | 'arquivada'; publicado_em: string | null }
+
 const BodySchema = z.object({
-  versao_id: z.string().uuid(),
+  versao_id: z.string().uuid().optional(),
   turma_id: z.string().uuid(),
   items: z.array(
     z.object({
@@ -19,8 +21,29 @@ const BodySchema = z.object({
       sala_id: z.string().uuid().nullable().optional(),
     })
   ),
-  mode: z.enum(["draft", "publish"]).optional(),
+  mode: z.enum(['draft', 'publish']).optional(),
 })
+
+async function resolveVersionForRead(
+  supabase: any,
+  escolaId: string,
+  turmaId: string,
+  requestedVersionId: string | null
+): Promise<string | null> {
+  if (requestedVersionId) return requestedVersionId
+
+  const { data: publishedVersion } = await supabase
+    .from('horario_versoes')
+    .select('id')
+    .eq('escola_id', escolaId)
+    .eq('turma_id', turmaId)
+    .eq('status', 'publicada')
+    .order('publicado_em', { ascending: false })
+    .limit(1)
+    .maybeSingle()
+
+  return publishedVersion?.id ?? null
+}
 
 export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
   try {
@@ -40,15 +63,20 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     const { searchParams } = new URL(req.url)
     const versaoId = searchParams.get('versao_id')
     const turmaId = searchParams.get('turma_id')
-    if (!versaoId || !turmaId) {
-      return NextResponse.json({ ok: false, error: 'versao_id e turma_id são obrigatórios' }, { status: 400 })
+    if (!turmaId) {
+      return NextResponse.json({ ok: false, error: 'turma_id é obrigatório' }, { status: 400 })
+    }
+
+    const effectiveVersionId = await resolveVersionForRead(supabase, escolaIdResolved, turmaId, versaoId)
+    if (!effectiveVersionId) {
+      return NextResponse.json({ ok: true, items: [], versao_id: null })
     }
 
     let quadroQuery = supabase
       .from('quadro_horarios')
       .select('id, turma_id, disciplina_id, professor_id, sala_id, slot_id, versao_id')
       .eq('escola_id', escolaIdResolved)
-      .eq('versao_id', versaoId)
+      .eq('versao_id', effectiveVersionId)
       .eq('turma_id', turmaId)
 
     quadroQuery = applyKf2ListInvariants(quadroQuery, {
@@ -60,7 +88,7 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
 
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
 
-    const response = NextResponse.json({ ok: true, items: data || [] })
+    const response = NextResponse.json({ ok: true, versao_id: effectiveVersionId, items: data || [] })
     response.headers.set('Server-Timing', `app;dur=${Date.now() - start}`)
     return response
   } catch (e) {
@@ -89,6 +117,21 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       return NextResponse.json({ ok: false, error: parsed.error.issues?.[0]?.message || 'Dados inválidos' }, { status: 400 })
     }
 
+    const mode = parsed.data.mode ?? 'draft'
+
+    const { data: versionIdFromDb, error: ensureVersionError } = await supabase.rpc('ensure_horario_versao', {
+      p_escola_id: escolaIdResolved,
+      p_turma_id: parsed.data.turma_id,
+      p_versao_id: parsed.data.versao_id ?? null,
+      p_status: mode === 'publish' ? 'draft' : mode,
+    })
+
+    if (ensureVersionError || !versionIdFromDb) {
+      return NextResponse.json({ ok: false, error: ensureVersionError?.message || 'Falha ao garantir versão' }, { status: 400 })
+    }
+
+    const versaoId = String(versionIdFromDb)
+
     const payload = parsed.data.items.map((item) => ({
       escola_id: escolaIdResolved,
       turma_id: parsed.data.turma_id,
@@ -96,7 +139,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       professor_id: item.professor_id ?? null,
       sala_id: item.sala_id ?? null,
       slot_id: item.slot_id,
-      versao_id: parsed.data.versao_id,
+      versao_id: versaoId,
     }))
 
     const slotIds = Array.from(new Set(payload.map((item) => item.slot_id)))
@@ -105,31 +148,54 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
 
     const conflicts: Array<{ slot_id: string; professor_id?: string | null; sala_id?: string | null }>
       = []
-    if (slotIds.length > 0 && professorIds.length > 0) {
-      const { data: profConflicts } = await supabase
-        .from('quadro_horarios')
-        .select('slot_id, professor_id')
-        .eq('escola_id', escolaIdResolved)
-        .neq('turma_id', parsed.data.turma_id)
-        .in('slot_id', slotIds)
-        .in('professor_id', professorIds as string[])
 
-      for (const row of profConflicts || []) {
-        conflicts.push({ slot_id: row.slot_id, professor_id: row.professor_id })
+    const { data: versaoAtual } = await supabase
+      .from('horario_versoes')
+      .select('id, status, publicado_em')
+      .eq('id', versaoId)
+      .eq('escola_id', escolaIdResolved)
+      .eq('turma_id', parsed.data.turma_id)
+      .maybeSingle()
+
+    const versaoAtualRow = versaoAtual as HorarioVersaoRow | null
+
+    if (versaoAtualRow?.status === 'publicada') {
+      const { data: publishedVersions } = await supabase
+        .from('horario_versoes')
+        .select('id')
+        .eq('escola_id', escolaIdResolved)
+        .eq('status', 'publicada')
+
+      const publishedVersionIds = (publishedVersions || []).map((row: { id: string }) => row.id)
+
+      if (slotIds.length > 0 && professorIds.length > 0 && publishedVersionIds.length > 0) {
+        const { data: profConflicts } = await supabase
+          .from('quadro_horarios')
+          .select('slot_id, professor_id')
+          .eq('escola_id', escolaIdResolved)
+          .in('slot_id', slotIds)
+          .in('professor_id', professorIds as string[])
+          .in('versao_id', publishedVersionIds)
+          .neq('versao_id', versaoId)
+
+        for (const row of profConflicts || []) {
+          conflicts.push({ slot_id: row.slot_id, professor_id: row.professor_id })
+        }
       }
-    }
 
-    if (slotIds.length > 0 && salaIds.length > 0) {
-      const { data: salaConflicts } = await supabase
-        .from('quadro_horarios')
-        .select('slot_id, sala_id')
-        .eq('escola_id', escolaIdResolved)
-        .neq('turma_id', parsed.data.turma_id)
-        .in('slot_id', slotIds)
-        .in('sala_id', salaIds as string[])
+      if (slotIds.length > 0 && salaIds.length > 0 && publishedVersionIds.length > 0) {
+        const { data: salaConflicts } = await supabase
+          .from('quadro_horarios')
+          .select('slot_id, sala_id')
+          .eq('escola_id', escolaIdResolved)
+          .in('slot_id', slotIds)
+          .in('sala_id', salaIds as string[])
+          .in('versao_id', publishedVersionIds)
+          .neq('versao_id', versaoId)
 
-      for (const row of salaConflicts || []) {
-        conflicts.push({ slot_id: row.slot_id, sala_id: row.sala_id })
+        for (const row of salaConflicts || []) {
+          conflicts.push({ slot_id: row.slot_id, sala_id: row.sala_id })
+        }
       }
     }
 
@@ -140,15 +206,14 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       )
     }
 
-    const mode = parsed.data.mode ?? "draft"
-    if (mode === "publish") {
+    if (mode === 'publish') {
       const { data: cargas, error: cargasError } = await supabase
-        .from("turma_disciplinas")
+        .from('turma_disciplinas')
         .select(
-          "carga_horaria_semanal, entra_no_horario, curso_matriz:curso_matriz_id(carga_horaria_semanal, entra_no_horario, disciplina_id, disciplina:disciplinas_catalogo!curso_matriz_disciplina_id_fkey(nome))"
+          'carga_horaria_semanal, entra_no_horario, curso_matriz:curso_matriz_id(carga_horaria_semanal, entra_no_horario, disciplina_id, disciplina:disciplinas_catalogo!curso_matriz_disciplina_id_fkey(nome))'
         )
-        .eq("escola_id", escolaIdResolved)
-        .eq("turma_id", parsed.data.turma_id)
+        .eq('escola_id', escolaIdResolved)
+        .eq('turma_id', parsed.data.turma_id)
 
       if (cargasError) {
         return NextResponse.json({ ok: false, error: cargasError.message }, { status: 400 })
@@ -186,7 +251,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
 
       if (missing.length > 0 || mismatch.length > 0) {
         return NextResponse.json(
-          { ok: false, error: "CARGA_HORARIA_INCOMPLETA", details: { missing, mismatch } },
+          { ok: false, error: 'CARGA_HORARIA_INCOMPLETA', details: { missing, mismatch } },
           { status: 400 }
         )
       }
@@ -197,7 +262,7 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       .delete()
       .eq('escola_id', escolaIdResolved)
       .eq('turma_id', parsed.data.turma_id)
-      .eq('versao_id', parsed.data.versao_id)
+      .eq('versao_id', versaoId)
 
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
 
@@ -208,7 +273,23 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
 
     if (insertError) return NextResponse.json({ ok: false, error: insertError.message }, { status: 400 })
 
-    const response = NextResponse.json({ ok: true, items: data || [] })
+    if (mode === 'publish') {
+      const { data: publishedVersionId, error: publishError } = await supabase.rpc('publish_horario_versao', {
+        p_escola_id: escolaIdResolved,
+        p_turma_id: parsed.data.turma_id,
+        p_versao_id: versaoId,
+      })
+
+      if (publishError) {
+        return NextResponse.json({ ok: false, error: publishError.message }, { status: 400 })
+      }
+
+      const response = NextResponse.json({ ok: true, versao_id: String(publishedVersionId || versaoId), status: 'publicada', items: data || [] })
+      response.headers.set('Server-Timing', `app;dur=${Date.now() - start}`)
+      return response
+    }
+
+    const response = NextResponse.json({ ok: true, versao_id: versaoId, status: 'draft', items: data || [] })
     response.headers.set('Server-Timing', `app;dur=${Date.now() - start}`)
     return response
   } catch (e) {
@@ -238,6 +319,18 @@ export async function DELETE(req: Request, ctx: { params: Promise<{ id: string }
       return NextResponse.json({ ok: false, error: 'versao_id e turma_id são obrigatórios' }, { status: 400 })
     }
 
+    const { data: versaoData } = await supabase
+      .from('horario_versoes')
+      .select('status')
+      .eq('id', versaoId)
+      .eq('escola_id', escolaIdResolved)
+      .eq('turma_id', turmaId)
+      .maybeSingle()
+
+    if ((versaoData as { status?: string } | null)?.status === 'publicada') {
+      return NextResponse.json({ ok: false, error: 'Não é permitido remover versão publicada' }, { status: 409 })
+    }
+
     const { error } = await supabase
       .from('quadro_horarios')
       .delete()
@@ -246,6 +339,14 @@ export async function DELETE(req: Request, ctx: { params: Promise<{ id: string }
       .eq('turma_id', turmaId)
 
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+
+    await supabase
+      .from('horario_versoes')
+      .delete()
+      .eq('id', versaoId)
+      .eq('escola_id', escolaIdResolved)
+      .eq('turma_id', turmaId)
+      .neq('status', 'publicada')
 
     return NextResponse.json({ ok: true })
   } catch (e) {

--- a/apps/web/src/app/api/escolas/[id]/horarios/slots/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/horarios/slots/route.ts
@@ -8,12 +8,14 @@ import { applyKf2ListInvariants } from '@/lib/kf2'
 export const dynamic = 'force-dynamic'
 export const revalidate = 0
 
+const TimeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d(:[0-5]\d)?$/, 'Formato de hora inválido (HH:MM ou HH:MM:SS)')
+
 const SlotSchema = z.object({
   id: z.string().uuid().optional(),
   turno_id: z.string().min(1),
   ordem: z.number().int().min(1),
-  inicio: z.string(),
-  fim: z.string(),
+  inicio: TimeSchema,
+  fim: TimeSchema,
   dia_semana: z.number().int().min(1).max(7),
   is_intervalo: z.boolean().optional(),
   nome: z.string().optional().nullable(),
@@ -22,6 +24,59 @@ const SlotSchema = z.object({
 const PayloadSchema = z.object({
   slots: z.array(SlotSchema),
 })
+
+type SlotPayload = z.infer<typeof SlotSchema>
+type ExistingSlot = {
+  id: string
+  turno_id: string | null
+  dia_semana: number | null
+  inicio: string | null
+  fim: string | null
+  is_intervalo: boolean | null
+}
+
+type Conflict = {
+  turno_id: string
+  dia_semana: number
+  inicio: string
+  fim: string
+  conflicting_with: { id?: string; inicio: string; fim: string }
+}
+
+function toSeconds(time: string): number {
+  const [hh, mm, ss = '00'] = time.split(':')
+  return Number(hh) * 3600 + Number(mm) * 60 + Number(ss)
+}
+
+function detectTemporalOverlap(slots: Array<{ id?: string; turno_id: string; dia_semana: number; inicio: string; fim: string }>): Conflict | null {
+  const byGroup = new Map<string, Array<{ id?: string; inicio: string; fim: string }>>()
+  for (const slot of slots) {
+    const key = `${slot.turno_id}::${slot.dia_semana}`
+    const arr = byGroup.get(key) || []
+    arr.push({ id: slot.id, inicio: slot.inicio, fim: slot.fim })
+    byGroup.set(key, arr)
+  }
+
+  for (const [key, group] of byGroup.entries()) {
+    const [turno_id, dia] = key.split('::')
+    const sorted = [...group].sort((a, b) => toSeconds(a.inicio) - toSeconds(b.inicio))
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const current = sorted[i]
+      const next = sorted[i + 1]
+      if (toSeconds(next.inicio) < toSeconds(current.fim)) {
+        return {
+          turno_id,
+          dia_semana: Number(dia),
+          inicio: next.inicio,
+          fim: next.fim,
+          conflicting_with: { id: current.id, inicio: current.inicio, fim: current.fim },
+        }
+      }
+    }
+  }
+
+  return null
+}
 
 export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
   try {
@@ -85,7 +140,61 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       return NextResponse.json({ ok: false, error: parsed.error.issues?.[0]?.message || 'Dados inválidos' }, { status: 400 })
     }
 
-    const payload = parsed.data.slots.map((slot) => ({
+    for (const slot of parsed.data.slots) {
+      if (toSeconds(slot.inicio) >= toSeconds(slot.fim)) {
+        return NextResponse.json(
+          { ok: false, error: 'SLOT_TIME_RANGE_INVALID', detail: { inicio: slot.inicio, fim: slot.fim, turno_id: slot.turno_id, dia_semana: slot.dia_semana } },
+          { status: 422 }
+        )
+      }
+    }
+
+    const nonIntervalPayload = parsed.data.slots
+      .filter((slot) => !(slot.is_intervalo ?? false))
+      .map((slot) => ({ id: slot.id, turno_id: slot.turno_id, dia_semana: slot.dia_semana, inicio: slot.inicio, fim: slot.fim }))
+
+    const payloadConflict = detectTemporalOverlap(nonIntervalPayload)
+    if (payloadConflict) {
+      return NextResponse.json(
+        { ok: false, error: 'SLOT_TEMPORAL_CONFLICT', detail: payloadConflict },
+        { status: 409 }
+      )
+    }
+
+    const turnoIds = Array.from(new Set(parsed.data.slots.map((slot) => slot.turno_id)))
+    const dias = Array.from(new Set(parsed.data.slots.map((slot) => slot.dia_semana)))
+    const upsertIds = parsed.data.slots.map((slot) => slot.id).filter((id): id is string => Boolean(id))
+
+    const { data: existingSlots, error: existingError } = await supabase
+      .from('horario_slots')
+      .select('id, turno_id, dia_semana, inicio, fim, is_intervalo')
+      .eq('escola_id', escolaIdResolved)
+      .in('turno_id', turnoIds)
+      .in('dia_semana', dias)
+
+    if (existingError) return NextResponse.json({ ok: false, error: existingError.message }, { status: 400 })
+
+    const existingNonInterval = ((existingSlots || []) as ExistingSlot[])
+      .filter((slot) => !(slot.is_intervalo ?? false))
+      .filter((slot) => slot.turno_id && slot.dia_semana && slot.inicio && slot.fim)
+      .filter((slot) => !upsertIds.includes(slot.id))
+      .map((slot) => ({
+        id: slot.id,
+        turno_id: String(slot.turno_id),
+        dia_semana: Number(slot.dia_semana),
+        inicio: String(slot.inicio),
+        fim: String(slot.fim),
+      }))
+
+    const mergedConflict = detectTemporalOverlap([...existingNonInterval, ...nonIntervalPayload])
+    if (mergedConflict) {
+      return NextResponse.json(
+        { ok: false, error: 'SLOT_TEMPORAL_CONFLICT', detail: mergedConflict },
+        { status: 409 }
+      )
+    }
+
+    const payload = parsed.data.slots.map((slot: SlotPayload) => ({
       id: slot.id,
       escola_id: escolaIdResolved,
       turno_id: slot.turno_id,
@@ -101,7 +210,15 @@ export async function POST(req: Request, ctx: { params: Promise<{ id: string }> 
       .upsert(payload, { onConflict: 'id' })
       .select('id, turno_id, ordem, inicio, fim, dia_semana, is_intervalo')
 
-    if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+    if (error) {
+      if (error.message?.includes('excl_horario_slots_temporal')) {
+        return NextResponse.json({ ok: false, error: 'SLOT_TEMPORAL_CONFLICT', detail: error.message }, { status: 409 })
+      }
+      if (error.message?.includes('horario_slots_inicio_fim_check')) {
+        return NextResponse.json({ ok: false, error: 'SLOT_TIME_RANGE_INVALID', detail: error.message }, { status: 422 })
+      }
+      return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+    }
 
     const response = NextResponse.json({ ok: true, items: data || [] })
     response.headers.set('Server-Timing', `app;dur=${Date.now() - start}`)

--- a/apps/web/src/app/api/jobs/escolas/[id]/seed/academico/route.ts
+++ b/apps/web/src/app/api/jobs/escolas/[id]/seed/academico/route.ts
@@ -308,8 +308,8 @@ export async function POST(req: NextRequest, context: { params: Promise<{ id: st
       alunos.push({ user_id: userId!, aluno_id: alunoId!, matricula_id: matriculaId, secao_id: sec })
     }
 
-    // 9) Frequências: last 14 days for matching rotinas weekdays
-    const { data: rotinas } = await admin.from('rotinas').select('id, weekday, secao_id, curso_oferta_id')
+    // 9) Frequências: last 14 days for matching agenda slots (compat view during migration)
+    const { data: rotinas } = await admin.from('vw_rotinas_compat').select('id, weekday, secao_id, curso_oferta_id')
       .eq('turma_id', turmaId!)
     const today = new Date()
     const dateOf = (d: Date) => d.toISOString().slice(0,10)

--- a/apps/web/src/app/api/professor/agenda/route.ts
+++ b/apps/web/src/app/api/professor/agenda/route.ts
@@ -31,12 +31,22 @@ export async function GET() {
 
     if (!prof?.id) return NextResponse.json({ ok: true, items: [] })
 
+    const { data: publishedVersions } = await supabase
+      .from('horario_versoes')
+      .select('id')
+      .eq('escola_id', escolaId)
+      .eq('status', 'publicada')
+
+    const publishedVersionIds = (publishedVersions || []).map((row: { id: string }) => row.id)
+    if (publishedVersionIds.length === 0) return NextResponse.json({ ok: true, items: [] })
+
     const { data: quadroRows, error: quadroErr } = await applyKf2ListInvariants(
       supabase
         .from('quadro_horarios')
         .select('slot_id, turma_id, disciplina_id, sala_id')
         .eq('escola_id', escolaId)
         .eq('professor_id', prof.id)
+        .in('versao_id', publishedVersionIds)
     )
 
     if (quadroErr) return NextResponse.json({ ok: false, error: quadroErr.message }, { status: 400 })

--- a/apps/web/src/app/api/secretaria/turmas/[id]/disciplinas/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/disciplinas/route.ts
@@ -134,17 +134,18 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
         notasCount = (notasRows ?? []).length
       }
 
-      // Check rotinas (horário) by turma and professor profile
-      let rotinasCount = 0
-      if (profile?.user_id) {
-        const { data: rotinasRows } = await supabase
-          .from('rotinas')
+      // Check horário oficial SSOT (quadro_horarios + horario_slots) by turma/professor/disciplina
+      let horarioOficialCount = 0
+      if (row.professor_id) {
+        const { data: quadroRows } = await supabase
+          .from('quadro_horarios')
           .select('id')
           .eq('escola_id', escolaId)
           .eq('turma_id', turmaId)
-          .eq('professor_user_id', profile.user_id)
+          .eq('professor_id', row.professor_id)
+          .eq('disciplina_id', discInfo?.id ?? row.curso_matriz_id)
           .limit(1)
-        rotinasCount = (rotinasRows ?? []).length
+        horarioOficialCount = (quadroRows ?? []).length
       }
 
       // Check presenças: tenta filtrar por disciplina_id quando houver; senão, nível de turma
@@ -194,12 +195,12 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
         horarios: null,
         planejamento: null,
         vinculos: {
-          horarios: rotinasCount > 0,
+          horarios: horarioOficialCount > 0,
           notas: notasCount > 0,
           presencas: (presencasCount ?? 0) > 0, // turma-level
           planejamento: hasPlanejamento,
         },
-        counts: { rotinas: rotinasCount, notas: notasCount, presencas: presencasCount },
+        counts: { rotinas: horarioOficialCount, notas: notasCount, presencas: presencasCount },
       })
     }
 

--- a/apps/web/src/app/api/secretaria/turmas/[id]/horario/versao/route.ts
+++ b/apps/web/src/app/api/secretaria/turmas/[id]/horario/versao/route.ts
@@ -7,6 +7,8 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 export const fetchCache = "force-no-store";
 
+type HorarioVersaoRow = { id: string; status: string; publicado_em: string | null; created_at: string | null };
+
 export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }) {
   try {
     const supabase = await supabaseServerTyped<any>();
@@ -29,16 +31,37 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
       return NextResponse.json({ ok: false, error: authz.reason || "Sem permissão" }, { status: 403 });
     }
 
-    const { data } = await supabase
-      .from("quadro_horarios")
-      .select("versao_id, created_at")
+    const { data: versoes } = await supabase
+      .from("horario_versoes")
+      .select("id, status, publicado_em, created_at")
       .eq("escola_id", escolaId)
       .eq("turma_id", turmaId)
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
+      .order("created_at", { ascending: false });
 
-    return NextResponse.json({ ok: true, versao_id: data?.versao_id ?? null });
+    const versoesRows = (versoes || []) as HorarioVersaoRow[];
+    const publicada = versoesRows.find((row) => row.status === "publicada") ?? null;
+    let draft = versoesRows.find((row) => row.status === "draft") ?? null;
+
+    if (!draft) {
+      const { data: createdDraft, error: createDraftError } = await supabase
+        .from("horario_versoes")
+        .insert({ escola_id: escolaId, turma_id: turmaId, status: "draft" })
+        .select("id, status, publicado_em, created_at")
+        .single();
+
+      if (createDraftError) {
+        return NextResponse.json({ ok: false, error: createDraftError.message }, { status: 400 });
+      }
+
+      draft = createdDraft as HorarioVersaoRow;
+    }
+
+    return NextResponse.json({
+      ok: true,
+      versao_id: draft?.id ?? null,
+      versao_publicada_id: publicada?.id ?? null,
+      versoes: versoesRows,
+    });
   } catch (err: any) {
     return NextResponse.json({ ok: false, error: err?.message || "Erro desconhecido" }, { status: 500 });
   }

--- a/apps/web/src/lib/agenda/proximaAula.ts
+++ b/apps/web/src/lib/agenda/proximaAula.ts
@@ -1,0 +1,69 @@
+export type ProximaAulaSlot = {
+  slot_id: string | null;
+  weekday: number | null;
+  inicio: string | null;
+  fim: string | null;
+  sala: string | null;
+  ordem?: number | null;
+}
+
+const SECONDS_IN_DAY = 24 * 60 * 60
+export function normalizeIsoWeekday(day: number): number {
+  if (!Number.isFinite(day)) return 1
+  const n = Math.trunc(day)
+  if (n === 0) return 7
+  if (n >= 1 && n <= 7) return n
+  const mod = ((n % 7) + 7) % 7
+  return mod === 0 ? 7 : mod
+}
+
+export function timeToSeconds(time: string | null | undefined): number {
+  if (!time) return Number.NaN
+  const [hh, mm, ss = '00'] = time.split(':')
+  return Number(hh) * 3600 + Number(mm) * 60 + Number(ss)
+}
+
+function slotWeekOffsetSeconds(slot: ProximaAulaSlot, nowIsoWeekday: number, nowSeconds: number): number {
+  const slotIsoDay = normalizeIsoWeekday(slot.weekday ?? 1)
+  const startSec = timeToSeconds(slot.inicio)
+  const endSec = timeToSeconds(slot.fim)
+
+  if (!Number.isFinite(startSec) || !Number.isFinite(endSec)) return Number.POSITIVE_INFINITY
+
+  const dayDelta = (slotIsoDay - nowIsoWeekday + 7) % 7
+
+  if (dayDelta === 0) {
+    if (nowSeconds <= endSec) {
+      return Math.max(0, startSec - nowSeconds)
+    }
+    return (7 * SECONDS_IN_DAY) - nowSeconds + startSec
+  }
+
+  return dayDelta * SECONDS_IN_DAY - nowSeconds + startSec
+}
+
+export function escolherProximaAula(
+  slots: ProximaAulaSlot[],
+  now: Date
+): ProximaAulaSlot | null {
+  const nowIsoWeekday = normalizeIsoWeekday(now.getDay())
+  const nowSeconds = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds()
+
+  const valid = slots
+    .filter((slot) => slot.slot_id && slot.weekday && slot.inicio && slot.fim)
+    .map((slot) => ({
+      slot,
+      offsetSeconds: slotWeekOffsetSeconds(slot, nowIsoWeekday, nowSeconds),
+      start: timeToSeconds(slot.inicio),
+      ordem: slot.ordem ?? Number.MAX_SAFE_INTEGER,
+    }))
+    .filter((entry) => Number.isFinite(entry.offsetSeconds))
+    .sort((a, b) => {
+      if (a.offsetSeconds !== b.offsetSeconds) return a.offsetSeconds - b.offsetSeconds
+      if (a.start !== b.start) return a.start - b.start
+      return a.ordem - b.ordem
+    })
+
+  return valid[0]?.slot ?? null
+}
+

--- a/apps/web/tests/unit/proxima-aula.spec.ts
+++ b/apps/web/tests/unit/proxima-aula.spec.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { escolherProximaAula } from '../../src/lib/agenda/proximaAula'
+
+test('segunda: escolhe slot do mesmo dia ainda em curso/futuro', () => {
+  const now = new Date('2026-03-09T08:20:00') // Monday
+  const result = escolherProximaAula(
+    [
+      { slot_id: 's1', weekday: 1, inicio: '08:00:00', fim: '08:45:00', sala: 'A1', ordem: 1 },
+      { slot_id: 's2', weekday: 1, inicio: '09:00:00', fim: '09:45:00', sala: 'A1', ordem: 2 },
+      { slot_id: 's3', weekday: 2, inicio: '08:00:00', fim: '08:45:00', sala: 'A1', ordem: 1 },
+    ],
+    now
+  )
+
+  assert.equal(result?.slot_id, 's1')
+})
+
+test('sábado à noite: fallback para próxima semana', () => {
+  const now = new Date('2026-03-14T23:10:00') // Saturday
+  const result = escolherProximaAula(
+    [
+      { slot_id: 's1', weekday: 1, inicio: '07:30:00', fim: '08:15:00', sala: 'B2', ordem: 1 },
+      { slot_id: 's2', weekday: 6, inicio: '09:00:00', fim: '09:45:00', sala: 'B2', ordem: 2 },
+    ],
+    now
+  )
+
+  assert.equal(result?.slot_id, 's1')
+})
+
+test('domingo: normalização ISO 1..7 e escolha de segunda', () => {
+  const now = new Date('2026-03-15T10:00:00') // Sunday
+  const result = escolherProximaAula(
+    [
+      { slot_id: 's1', weekday: 1, inicio: '08:00:00', fim: '08:45:00', sala: 'C3', ordem: 1 },
+      { slot_id: 's2', weekday: 7, inicio: '09:00:00', fim: '09:45:00', sala: 'C3', ordem: 2 },
+    ],
+    now
+  )
+
+  assert.equal(result?.slot_id, 's1')
+})

--- a/docs/checklists.md
+++ b/docs/checklists.md
@@ -7,3 +7,10 @@
 4) Validar envio de e-mails via `/api/jobs/outbox` e logs do worker.
 5) UI/API: `/secretaria/acesso-alunos` lista pendentes; `/api/secretaria/alunos/sem-acesso`, `/metricas-acesso`, `/liberar-acesso` (idempotente); ativação self-service `/ativar-acesso` → `/api/alunos/ativar-acesso` (código + BI).
 6) Segurança: rate limit em `/ativar-acesso`; para e-mails sintéticos, prever reset de senha via secretaria (não por “esqueci minha senha”).
+
+## Checklist de paridade de agenda (migração SSOT)
+
+1) Confirmar que **agenda professor** (`/api/professor/agenda`) e **próxima aula aluno** (`/api/aluno/dashboard`) retornam o mesmo `slot_id` para a mesma combinação de `turma_id + professor_id`.
+2) Validar que ambos os endpoints leem de `quadro_horarios + horario_slots` (sem leitura directa de `rotinas`).
+3) Se houver divergência de slot, bloquear deploy da migração e corrigir mapeamento de `disciplina_id/professor_id` no quadro oficial.
+4) Enquanto existir consumidor legado, usar apenas `vw_rotinas_compat` para leitura temporária; escrita em `rotinas` deve permanecer bloqueada.

--- a/supabase/migrations/20261216000000_schedule_ssot_and_rotinas_compat.sql
+++ b/supabase/migrations/20261216000000_schedule_ssot_and_rotinas_compat.sql
@@ -1,0 +1,49 @@
+BEGIN;
+
+-- SSOT oficial de agenda: quadro_horarios + horario_slots.
+-- rotinas passa a ser apenas compatibilidade de leitura temporária.
+
+DROP VIEW IF EXISTS public.vw_rotinas_compat;
+
+CREATE VIEW public.vw_rotinas_compat AS
+SELECT
+  q.id,
+  q.turma_id,
+  NULL::uuid AS secao_id,
+  q.disciplina_id AS curso_oferta_id,
+  p.profile_id AS professor_user_id,
+  hs.dia_semana AS weekday,
+  hs.inicio,
+  hs.fim,
+  COALESCE(s.nome, t.sala) AS sala,
+  q.escola_id
+FROM public.quadro_horarios q
+JOIN public.horario_slots hs ON hs.id = q.slot_id
+LEFT JOIN public.professores p ON p.id = q.professor_id
+LEFT JOIN public.salas s ON s.id = q.sala_id
+LEFT JOIN public.turmas t ON t.id = q.turma_id
+WHERE COALESCE(hs.is_intervalo, false) = false;
+
+COMMENT ON VIEW public.vw_rotinas_compat IS
+  'Compatibilidade temporária de leitura com o formato legado de rotinas; SSOT oficial é quadro_horarios + horario_slots.';
+
+CREATE OR REPLACE FUNCTION public.block_legacy_rotinas_write()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'Tabela rotinas em modo legado somente-leitura. Use quadro_horarios + horario_slots (SSOT oficial).';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_block_legacy_rotinas_write ON public.rotinas;
+
+CREATE TRIGGER trg_block_legacy_rotinas_write
+BEFORE INSERT OR UPDATE OR DELETE ON public.rotinas
+FOR EACH ROW
+EXECUTE FUNCTION public.block_legacy_rotinas_write();
+
+COMMENT ON FUNCTION public.block_legacy_rotinas_write IS
+  'Bloqueia escrita em rotinas após migração para SSOT de agenda.';
+
+COMMIT;

--- a/supabase/migrations/20261216010000_horario_versoes_publish_atomic.sql
+++ b/supabase/migrations/20261216010000_horario_versoes_publish_atomic.sql
@@ -1,0 +1,213 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.horario_versoes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  turma_id uuid NOT NULL REFERENCES public.turmas(id) ON DELETE CASCADE,
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'publicada', 'arquivada')),
+  publicado_em timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_horario_versoes_escola_turma_status
+  ON public.horario_versoes (escola_id, turma_id, status, created_at DESC);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_horario_versoes_publicada
+  ON public.horario_versoes (escola_id, turma_id)
+  WHERE status = 'publicada';
+
+-- Backfill one published version per turma from existing quadro_horarios rows.
+INSERT INTO public.horario_versoes (id, escola_id, turma_id, status, publicado_em, created_at, updated_at)
+SELECT
+  q.versao_id,
+  q.escola_id,
+  q.turma_id,
+  'publicada'::text,
+  now(),
+  MIN(q.created_at),
+  now()
+FROM public.quadro_horarios q
+LEFT JOIN public.horario_versoes hv ON hv.id = q.versao_id
+WHERE hv.id IS NULL
+GROUP BY q.versao_id, q.escola_id, q.turma_id;
+
+ALTER TABLE public.quadro_horarios
+  ADD CONSTRAINT fk_quadro_horarios_versao
+  FOREIGN KEY (versao_id)
+  REFERENCES public.horario_versoes(id)
+  ON DELETE CASCADE;
+
+DROP INDEX IF EXISTS public.ux_quadro_horarios_turma_slot;
+CREATE UNIQUE INDEX IF NOT EXISTS ux_quadro_horarios_turma_slot_versao
+  ON public.quadro_horarios (turma_id, slot_id, versao_id);
+
+ALTER TABLE public.quadro_horarios
+  DROP CONSTRAINT IF EXISTS quadro_horarios_professor_slot_excl;
+
+ALTER TABLE public.quadro_horarios
+  DROP CONSTRAINT IF EXISTS quadro_horarios_sala_slot_excl;
+
+CREATE OR REPLACE FUNCTION public.trg_validate_quadro_published_conflicts()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_status text;
+BEGIN
+  SELECT hv.status
+    INTO v_status
+  FROM public.horario_versoes hv
+  WHERE hv.id = NEW.versao_id;
+
+  IF v_status IS DISTINCT FROM 'publicada' THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.professor_id IS NOT NULL AND EXISTS (
+    SELECT 1
+      FROM public.quadro_horarios q
+      JOIN public.horario_versoes hv ON hv.id = q.versao_id
+     WHERE q.escola_id = NEW.escola_id
+       AND q.slot_id = NEW.slot_id
+       AND q.professor_id = NEW.professor_id
+       AND hv.status = 'publicada'
+       AND q.id <> COALESCE(NEW.id, '00000000-0000-0000-0000-000000000000'::uuid)
+  ) THEN
+    RAISE EXCEPTION 'Conflito global de professor para slot publicado';
+  END IF;
+
+  IF NEW.sala_id IS NOT NULL AND EXISTS (
+    SELECT 1
+      FROM public.quadro_horarios q
+      JOIN public.horario_versoes hv ON hv.id = q.versao_id
+     WHERE q.escola_id = NEW.escola_id
+       AND q.slot_id = NEW.slot_id
+       AND q.sala_id = NEW.sala_id
+       AND hv.status = 'publicada'
+       AND q.id <> COALESCE(NEW.id, '00000000-0000-0000-0000-000000000000'::uuid)
+  ) THEN
+    RAISE EXCEPTION 'Conflito global de sala para slot publicado';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_validate_quadro_published_conflicts ON public.quadro_horarios;
+CREATE TRIGGER trg_validate_quadro_published_conflicts
+BEFORE INSERT OR UPDATE ON public.quadro_horarios
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_validate_quadro_published_conflicts();
+
+CREATE OR REPLACE FUNCTION public.ensure_horario_versao(
+  p_escola_id uuid,
+  p_turma_id uuid,
+  p_versao_id uuid DEFAULT NULL,
+  p_status text DEFAULT 'draft'
+)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_versao_id uuid;
+BEGIN
+  IF p_versao_id IS NOT NULL THEN
+    SELECT id INTO v_versao_id
+    FROM public.horario_versoes
+    WHERE id = p_versao_id
+      AND escola_id = p_escola_id
+      AND turma_id = p_turma_id;
+
+    IF v_versao_id IS NULL THEN
+      RAISE EXCEPTION 'versao_id não pertence à escola/turma informada';
+    END IF;
+
+    RETURN v_versao_id;
+  END IF;
+
+  INSERT INTO public.horario_versoes (escola_id, turma_id, status)
+  VALUES (p_escola_id, p_turma_id, COALESCE(p_status, 'draft'))
+  RETURNING id INTO v_versao_id;
+
+  RETURN v_versao_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.publish_horario_versao(
+  p_escola_id uuid,
+  p_turma_id uuid,
+  p_versao_id uuid
+)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_exists uuid;
+  v_rows integer;
+BEGIN
+  PERFORM pg_advisory_xact_lock(hashtext(CONCAT(p_escola_id::text, ':', p_turma_id::text)));
+
+  SELECT id INTO v_exists
+  FROM public.horario_versoes
+  WHERE id = p_versao_id
+    AND escola_id = p_escola_id
+    AND turma_id = p_turma_id;
+
+  IF v_exists IS NULL THEN
+    RAISE EXCEPTION 'versão de horário não encontrada para escola/turma';
+  END IF;
+
+  SELECT COUNT(*)::int INTO v_rows
+  FROM public.quadro_horarios
+  WHERE escola_id = p_escola_id
+    AND turma_id = p_turma_id
+    AND versao_id = p_versao_id;
+
+  IF v_rows = 0 THEN
+    RAISE EXCEPTION 'não é possível publicar versão vazia';
+  END IF;
+
+  UPDATE public.horario_versoes
+     SET status = 'arquivada',
+         updated_at = now()
+   WHERE escola_id = p_escola_id
+     AND turma_id = p_turma_id
+     AND status = 'publicada'
+     AND id <> p_versao_id;
+
+  UPDATE public.horario_versoes
+     SET status = 'publicada',
+         publicado_em = now(),
+         updated_at = now()
+   WHERE id = p_versao_id
+     AND escola_id = p_escola_id
+     AND turma_id = p_turma_id;
+
+  RETURN p_versao_id;
+END;
+$$;
+
+DROP VIEW IF EXISTS public.vw_rotinas_compat;
+CREATE VIEW public.vw_rotinas_compat AS
+SELECT
+  q.id,
+  q.turma_id,
+  NULL::uuid AS secao_id,
+  q.disciplina_id AS curso_oferta_id,
+  p.profile_id AS professor_user_id,
+  hs.dia_semana AS weekday,
+  hs.inicio,
+  hs.fim,
+  COALESCE(s.nome, t.sala) AS sala,
+  q.escola_id
+FROM public.quadro_horarios q
+JOIN public.horario_slots hs ON hs.id = q.slot_id
+JOIN public.horario_versoes hv ON hv.id = q.versao_id
+LEFT JOIN public.professores p ON p.id = q.professor_id
+LEFT JOIN public.salas s ON s.id = q.sala_id
+LEFT JOIN public.turmas t ON t.id = q.turma_id
+WHERE COALESCE(hs.is_intervalo, false) = false
+  AND hv.status = 'publicada';
+
+COMMIT;

--- a/supabase/migrations/20261216020000_quadro_tenant_cohesion.sql
+++ b/supabase/migrations/20261216020000_quadro_tenant_cohesion.sql
@@ -1,0 +1,127 @@
+BEGIN;
+
+-- Composite unique indexes to support composite FKs by tenant.
+CREATE UNIQUE INDEX IF NOT EXISTS ux_turmas_id_escola ON public.turmas (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_disciplinas_catalogo_id_escola ON public.disciplinas_catalogo (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_professores_id_escola ON public.professores (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_salas_id_escola ON public.salas (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_horario_slots_id_escola ON public.horario_slots (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_horario_versoes_id_escola ON public.horario_versoes (id, escola_id);
+CREATE UNIQUE INDEX IF NOT EXISTS ux_horario_versoes_id_escola_turma ON public.horario_versoes (id, escola_id, turma_id);
+
+-- Replace simple FKs with tenant-aware composite FKs.
+ALTER TABLE public.quadro_horarios
+  DROP CONSTRAINT IF EXISTS quadro_horarios_turma_id_fkey,
+  DROP CONSTRAINT IF EXISTS quadro_horarios_disciplina_id_fkey,
+  DROP CONSTRAINT IF EXISTS quadro_horarios_professor_id_fkey,
+  DROP CONSTRAINT IF EXISTS quadro_horarios_sala_id_fkey,
+  DROP CONSTRAINT IF EXISTS quadro_horarios_slot_id_fkey,
+  DROP CONSTRAINT IF EXISTS fk_quadro_horarios_versao;
+
+ALTER TABLE public.quadro_horarios
+  ADD CONSTRAINT fk_quadro_horarios_turma_escola
+    FOREIGN KEY (turma_id, escola_id)
+    REFERENCES public.turmas (id, escola_id)
+    ON DELETE CASCADE,
+  ADD CONSTRAINT fk_quadro_horarios_disciplina_escola
+    FOREIGN KEY (disciplina_id, escola_id)
+    REFERENCES public.disciplinas_catalogo (id, escola_id),
+  ADD CONSTRAINT fk_quadro_horarios_professor_escola
+    FOREIGN KEY (professor_id, escola_id)
+    REFERENCES public.professores (id, escola_id),
+  ADD CONSTRAINT fk_quadro_horarios_sala_escola
+    FOREIGN KEY (sala_id, escola_id)
+    REFERENCES public.salas (id, escola_id),
+  ADD CONSTRAINT fk_quadro_horarios_slot_escola
+    FOREIGN KEY (slot_id, escola_id)
+    REFERENCES public.horario_slots (id, escola_id),
+  ADD CONSTRAINT fk_quadro_horarios_versao_escola_turma
+    FOREIGN KEY (versao_id, escola_id, turma_id)
+    REFERENCES public.horario_versoes (id, escola_id, turma_id)
+    ON DELETE CASCADE;
+
+CREATE OR REPLACE FUNCTION public.trg_validate_quadro_tenant_cohesion()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_ref_escola uuid;
+  v_ref_turma uuid;
+BEGIN
+  SELECT escola_id INTO v_ref_escola
+  FROM public.turmas
+  WHERE id = NEW.turma_id;
+
+  IF v_ref_escola IS NULL THEN
+    RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: turma_id % não encontrado', NEW.turma_id;
+  ELSIF v_ref_escola <> NEW.escola_id THEN
+    RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: turma_id % pertence a escola diferente', NEW.turma_id;
+  END IF;
+
+  SELECT escola_id INTO v_ref_escola
+  FROM public.disciplinas_catalogo
+  WHERE id = NEW.disciplina_id;
+
+  IF v_ref_escola IS NULL THEN
+    RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: disciplina_id % não encontrado', NEW.disciplina_id;
+  ELSIF v_ref_escola <> NEW.escola_id THEN
+    RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: disciplina_id % pertence a escola diferente', NEW.disciplina_id;
+  END IF;
+
+  SELECT escola_id INTO v_ref_escola
+  FROM public.horario_slots
+  WHERE id = NEW.slot_id;
+
+  IF v_ref_escola IS NULL THEN
+    RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: slot_id % não encontrado', NEW.slot_id;
+  ELSIF v_ref_escola <> NEW.escola_id THEN
+    RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: slot_id % pertence a escola diferente', NEW.slot_id;
+  END IF;
+
+  IF NEW.professor_id IS NOT NULL THEN
+    SELECT escola_id INTO v_ref_escola
+    FROM public.professores
+    WHERE id = NEW.professor_id;
+
+    IF v_ref_escola IS NULL THEN
+      RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: professor_id % não encontrado', NEW.professor_id;
+    ELSIF v_ref_escola <> NEW.escola_id THEN
+      RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: professor_id % pertence a escola diferente', NEW.professor_id;
+    END IF;
+  END IF;
+
+  IF NEW.sala_id IS NOT NULL THEN
+    SELECT escola_id INTO v_ref_escola
+    FROM public.salas
+    WHERE id = NEW.sala_id;
+
+    IF v_ref_escola IS NULL THEN
+      RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: sala_id % não encontrado', NEW.sala_id;
+    ELSIF v_ref_escola <> NEW.escola_id THEN
+      RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: sala_id % pertence a escola diferente', NEW.sala_id;
+    END IF;
+  END IF;
+
+  SELECT escola_id, turma_id INTO v_ref_escola, v_ref_turma
+  FROM public.horario_versoes
+  WHERE id = NEW.versao_id;
+
+  IF v_ref_escola IS NULL THEN
+    RAISE EXCEPTION 'DOMAIN_REFERENCE_NOT_FOUND: versao_id % não encontrado', NEW.versao_id;
+  ELSIF v_ref_escola <> NEW.escola_id THEN
+    RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: versao_id % pertence a escola diferente', NEW.versao_id;
+  ELSIF v_ref_turma <> NEW.turma_id THEN
+    RAISE EXCEPTION 'DOMAIN_CROSS_TENANT_REFERENCE: versao_id % não pertence à turma %', NEW.versao_id, NEW.turma_id;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_validate_quadro_tenant_cohesion ON public.quadro_horarios;
+CREATE TRIGGER trg_validate_quadro_tenant_cohesion
+BEFORE INSERT OR UPDATE ON public.quadro_horarios
+FOR EACH ROW
+EXECUTE FUNCTION public.trg_validate_quadro_tenant_cohesion();
+
+COMMIT;

--- a/supabase/migrations/20261216030000_horario_slots_temporal_guardrails.sql
+++ b/supabase/migrations/20261216030000_horario_slots_temporal_guardrails.sql
@@ -1,0 +1,108 @@
+BEGIN;
+
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+-- Saneamento 1: corrigir ranges inválidos (inicio >= fim).
+UPDATE public.horario_slots
+SET fim = LEAST((inicio + interval '45 minutes')::time, time '23:59:59')
+WHERE inicio >= fim;
+
+-- Saneamento 2: garantir ordem única por (escola,turno,dia).
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY escola_id, turno_id, dia_semana
+      ORDER BY ordem, inicio, id
+    ) AS ordem_normalizada
+  FROM public.horario_slots
+)
+UPDATE public.horario_slots hs
+SET ordem = r.ordem_normalizada
+FROM ranked r
+WHERE hs.id = r.id
+  AND hs.ordem IS DISTINCT FROM r.ordem_normalizada;
+
+-- Saneamento 3: eliminar sobreposição temporal de slots não-intervalo.
+WITH RECURSIVE ordered AS (
+  SELECT
+    id,
+    escola_id,
+    turno_id,
+    dia_semana,
+    inicio,
+    fim,
+    ROW_NUMBER() OVER (
+      PARTITION BY escola_id, turno_id, dia_semana
+      ORDER BY inicio, fim, ordem, id
+    ) AS rn
+  FROM public.horario_slots
+  WHERE COALESCE(is_intervalo, false) = false
+), rec AS (
+  SELECT
+    o.id,
+    o.escola_id,
+    o.turno_id,
+    o.dia_semana,
+    o.rn,
+    o.inicio AS new_inicio,
+    o.fim AS new_fim
+  FROM ordered o
+  WHERE o.rn = 1
+
+  UNION ALL
+
+  SELECT
+    o.id,
+    o.escola_id,
+    o.turno_id,
+    o.dia_semana,
+    o.rn,
+    GREATEST(o.inicio, rec.new_fim) AS new_inicio,
+    GREATEST(o.fim, GREATEST(o.inicio, rec.new_fim) + interval '5 minutes') AS new_fim
+  FROM ordered o
+  JOIN rec
+    ON rec.escola_id = o.escola_id
+   AND rec.turno_id = o.turno_id
+   AND rec.dia_semana = o.dia_semana
+   AND rec.rn + 1 = o.rn
+)
+UPDATE public.horario_slots hs
+SET
+  inicio = rec.new_inicio::time,
+  fim = rec.new_fim::time
+FROM rec
+WHERE hs.id = rec.id
+  AND (
+    hs.inicio IS DISTINCT FROM rec.new_inicio::time
+    OR hs.fim IS DISTINCT FROM rec.new_fim::time
+  );
+
+ALTER TABLE public.horario_slots
+  DROP CONSTRAINT IF EXISTS horario_slots_inicio_fim_check;
+
+ALTER TABLE public.horario_slots
+  ADD CONSTRAINT horario_slots_inicio_fim_check
+  CHECK (inicio < fim);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_horario_slots_grade_estavel
+  ON public.horario_slots (escola_id, turno_id, dia_semana, ordem);
+
+ALTER TABLE public.horario_slots
+  DROP CONSTRAINT IF EXISTS excl_horario_slots_temporal;
+
+ALTER TABLE public.horario_slots
+  ADD CONSTRAINT excl_horario_slots_temporal
+  EXCLUDE USING gist (
+    escola_id WITH =,
+    turno_id WITH =,
+    dia_semana WITH =,
+    int4range(
+      EXTRACT(EPOCH FROM inicio)::int,
+      EXTRACT(EPOCH FROM fim)::int,
+      '[)'
+    ) WITH &&
+  )
+  WHERE (COALESCE(is_intervalo, false) = false);
+
+COMMIT;

--- a/supabase/ops/tests/regression_horario_slots_temporal_constraints.sql
+++ b/supabase/ops/tests/regression_horario_slots_temporal_constraints.sql
@@ -1,0 +1,43 @@
+-- Regression test: horario_slots enforces inicio < fim and non-overlap per escola/turno/dia for non-intervals.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_escola uuid := gen_random_uuid();
+  v_err text;
+BEGIN
+  INSERT INTO public.escolas (id, nome, status, onboarding_finalizado)
+  VALUES (v_escola, 'Escola Slots', 'ativa', true);
+
+  INSERT INTO public.horario_slots (escola_id, turno_id, ordem, inicio, fim, dia_semana, is_intervalo)
+  VALUES (v_escola, 'M', 1, '08:00', '08:45', 1, false);
+
+  BEGIN
+    INSERT INTO public.horario_slots (escola_id, turno_id, ordem, inicio, fim, dia_semana, is_intervalo)
+    VALUES (v_escola, 'M', 2, '08:30', '09:00', 1, false);
+
+    RAISE EXCEPTION 'Teste falhou: deveria bloquear sobreposição temporal';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_err = MESSAGE_TEXT;
+    IF position('excl_horario_slots_temporal' in lower(v_err)) = 0
+       AND position('conflicting key value violates exclusion constraint' in lower(v_err)) = 0 THEN
+      RAISE EXCEPTION 'Teste falhou: erro inesperado para sobreposição temporal: %', v_err;
+    END IF;
+  END;
+
+  BEGIN
+    INSERT INTO public.horario_slots (escola_id, turno_id, ordem, inicio, fim, dia_semana, is_intervalo)
+    VALUES (v_escola, 'M', 3, '10:00', '09:50', 1, false);
+
+    RAISE EXCEPTION 'Teste falhou: deveria bloquear inicio >= fim';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_err = MESSAGE_TEXT;
+    IF position('horario_slots_inicio_fim_check' in lower(v_err)) = 0
+       AND position('violates check constraint' in lower(v_err)) = 0 THEN
+      RAISE EXCEPTION 'Teste falhou: erro inesperado para check inicio/fim: %', v_err;
+    END IF;
+  END;
+END $$;
+
+ROLLBACK;

--- a/supabase/ops/tests/regression_quadro_horarios_cross_school.sql
+++ b/supabase/ops/tests/regression_quadro_horarios_cross_school.sql
@@ -1,0 +1,78 @@
+-- Regression test: quadro_horarios rejects cross-school references with explicit domain errors.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_escola_a uuid := gen_random_uuid();
+  v_escola_b uuid := gen_random_uuid();
+  v_turma_a uuid := gen_random_uuid();
+  v_turma_b uuid := gen_random_uuid();
+  v_disc_a uuid := gen_random_uuid();
+  v_disc_b uuid := gen_random_uuid();
+  v_slot_a uuid := gen_random_uuid();
+  v_slot_b uuid := gen_random_uuid();
+  v_versao_a uuid := gen_random_uuid();
+  v_err text;
+BEGIN
+  INSERT INTO public.escolas (id, nome, status, onboarding_finalizado)
+  VALUES
+    (v_escola_a, 'Escola A', 'ativa', true),
+    (v_escola_b, 'Escola B', 'ativa', true);
+
+  INSERT INTO public.turmas (id, escola_id, nome)
+  VALUES
+    (v_turma_a, v_escola_a, 'Turma A'),
+    (v_turma_b, v_escola_b, 'Turma B');
+
+  INSERT INTO public.disciplinas_catalogo (id, escola_id, nome)
+  VALUES
+    (v_disc_a, v_escola_a, 'Disciplina A'),
+    (v_disc_b, v_escola_b, 'Disciplina B');
+
+  INSERT INTO public.horario_slots (id, escola_id, turno_id, ordem, inicio, fim, dia_semana)
+  VALUES
+    (v_slot_a, v_escola_a, 'M', 1, '08:00', '08:45', 1),
+    (v_slot_b, v_escola_b, 'M', 1, '08:00', '08:45', 1);
+
+  INSERT INTO public.horario_versoes (id, escola_id, turma_id, status)
+  VALUES (v_versao_a, v_escola_a, v_turma_a, 'draft');
+
+  BEGIN
+    INSERT INTO public.quadro_horarios (escola_id, turma_id, disciplina_id, slot_id, versao_id)
+    VALUES (v_escola_a, v_turma_a, v_disc_b, v_slot_a, v_versao_a);
+
+    RAISE EXCEPTION 'Teste falhou: inserção com disciplina de outra escola deveria falhar';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_err = MESSAGE_TEXT;
+    IF position('DOMAIN_CROSS_TENANT_REFERENCE: disciplina_id' in v_err) = 0 THEN
+      RAISE EXCEPTION 'Teste falhou: mensagem inesperada para disciplina cross-school: %', v_err;
+    END IF;
+  END;
+
+  BEGIN
+    INSERT INTO public.quadro_horarios (escola_id, turma_id, disciplina_id, slot_id, versao_id)
+    VALUES (v_escola_a, v_turma_a, v_disc_a, v_slot_b, v_versao_a);
+
+    RAISE EXCEPTION 'Teste falhou: inserção com slot de outra escola deveria falhar';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_err = MESSAGE_TEXT;
+    IF position('DOMAIN_CROSS_TENANT_REFERENCE: slot_id' in v_err) = 0 THEN
+      RAISE EXCEPTION 'Teste falhou: mensagem inesperada para slot cross-school: %', v_err;
+    END IF;
+  END;
+
+  BEGIN
+    INSERT INTO public.quadro_horarios (escola_id, turma_id, disciplina_id, slot_id, versao_id)
+    VALUES (v_escola_a, v_turma_b, v_disc_a, v_slot_a, v_versao_a);
+
+    RAISE EXCEPTION 'Teste falhou: inserção com turma de outra escola deveria falhar';
+  EXCEPTION WHEN OTHERS THEN
+    GET STACKED DIAGNOSTICS v_err = MESSAGE_TEXT;
+    IF position('DOMAIN_CROSS_TENANT_REFERENCE: turma_id' in v_err) = 0 THEN
+      RAISE EXCEPTION 'Teste falhou: mensagem inesperada para turma cross-school: %', v_err;
+    END IF;
+  END;
+END $$;
+
+ROLLBACK;


### PR DESCRIPTION
### Motivation

- Move agenda to a single source-of-truth based on `quadro_horarios + horario_slots` and add safe versioning/publishing for schedules. 
- Prevent temporal and cross-tenant data inconsistencies (overlapping slots, invalid ranges, cross-school references) and provide deterministic logic to choose a student's next class.

### Description

- Introduces schedule versioning with a new `horario_versoes` table, RPCs `ensure_horario_versao` and `publish_horario_versao`, and atomic publish semantics in migrations (`supabase/migrations/..._horario_versoes_publish_atomic.sql`).
- Adds tenant/cohesion constraints and validation triggers for `quadro_horarios` and upgrades FK/indexes in `..._quadro_tenant_cohesion.sql` to prevent cross-school references and enforce version/tenant integrity.
- Adds temporal guardrails for `horario_slots` (range check, non-overlap exclusion, ordering normalization) and sanity fixes in `..._horario_slots_temporal_guardrails.sql` and corresponding regression SQL tests under `supabase/ops/tests`.
- Switches read paths and compatibility: creates `vw_rotinas_compat` for legacy reads and updates seed/data jobs to use it; updates APIs to read the published schedule version instead of legacy `rotinas` (changes in `api/aluno/dashboard`, `api/professor/agenda`, `api/secretaria/*`, and `api/escolas/[id]/horarios/*`).
- Adds slot/time validation and temporal-overlap detection in the slots API (`apps/web/src/app/api/escolas/[id]/horarios/slots/route.ts`) returning clear error codes like `SLOT_TEMPORAL_CONFLICT` and `SLOT_TIME_RANGE_INVALID`.
- Implements deterministic next-slot selection logic in a new helper `apps/web/src/lib/agenda/proximaAula.ts` and replaces the heuristic in `api/aluno/dashboard` to use it; also adds `apps/web/tests/unit/proxima-aula.spec.ts` to cover selection behavior.

### Testing

- Executed unit tests in `apps/web/tests/unit/proxima-aula.spec.ts` for `escolherProximaAula`, which passed locally (cases: same-day future/current slot, fallback to next week, ISO weekday normalization).
- Added SQL regression tests under `supabase/ops/tests` for temporal constraints and cross-school references which serve as DB-level automated regression checks (to be run in DB CI).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aac08e3a8c832887439052fa70e65e)