### PR TITLE
Add Mapa de Aproveitamento report (UI, API, sidebar and DB functions)

### DIFF
--- a/apps/web/src/app/api/secretaria/relatorios/mapa-aproveitamento/route.ts
+++ b/apps/web/src/app/api/secretaria/relatorios/mapa-aproveitamento/route.ts
@@ -1,0 +1,83 @@
+import { NextResponse } from "next/server";
+import { supabaseServer } from "@/lib/supabaseServer";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+
+export const dynamic = "force-dynamic";
+
+type TurmaOption = { id: string; nome: string; codigo: string | null; turno: string | null };
+type PeriodoOption = { id: string; numero: number | null; tipo: string | null };
+
+export async function GET(req: Request) {
+  try {
+    const supabase = await supabaseServer();
+    const { data: auth } = await supabase.auth.getUser();
+    const user = auth?.user;
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado." }, { status: 401 });
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id);
+    if (!escolaId) {
+      return NextResponse.json({ ok: false, error: "Escola não encontrada para o utilizador." }, { status: 400 });
+    }
+
+    const url = new URL(req.url);
+    const turmaId = url.searchParams.get("turma_id");
+    const periodoId = url.searchParams.get("periodo_letivo_id");
+
+    const [turmasRes, periodosRes] = await Promise.all([
+      supabase
+        .from("turmas")
+        .select("id, nome, turma_codigo, turno")
+        .eq("escola_id", escolaId)
+        .order("nome", { ascending: true })
+        .limit(200),
+      supabase
+        .from("periodos_letivos")
+        .select("id, numero, tipo")
+        .eq("escola_id", escolaId)
+        .order("numero", { ascending: true }),
+    ]);
+
+    if (turmasRes.error) {
+      return NextResponse.json({ ok: false, error: turmasRes.error.message }, { status: 500 });
+    }
+
+    if (periodosRes.error) {
+      return NextResponse.json({ ok: false, error: periodosRes.error.message }, { status: 500 });
+    }
+
+    const turmas: TurmaOption[] = (turmasRes.data ?? []).map((t: any) => ({
+      id: String(t.id),
+      nome: String(t.nome ?? "Sem nome"),
+      codigo: t.turma_codigo ? String(t.turma_codigo) : null,
+      turno: t.turno ? String(t.turno) : null,
+    }));
+
+    const periodos: PeriodoOption[] = (periodosRes.data ?? []).map((p: any) => ({
+      id: String(p.id),
+      numero: typeof p.numero === "number" ? p.numero : null,
+      tipo: p.tipo ? String(p.tipo) : null,
+    }));
+
+    if (!turmaId) {
+      return NextResponse.json({ ok: true, filtros: { turmas, periodos }, report: null });
+    }
+
+    const { data: report, error: rpcError } = await supabase.rpc("gerar_mapa_aproveitamento_turma", {
+      p_escola_id: escolaId,
+      p_turma_id: turmaId,
+      p_periodo_letivo_id: periodoId || null,
+    });
+
+    if (rpcError) {
+      return NextResponse.json({ ok: false, error: rpcError.message, filtros: { turmas, periodos } }, { status: 500 });
+    }
+
+    return NextResponse.json({ ok: true, filtros: { turmas, periodos }, report: report ?? { colunas: [], linhas: [] } });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado.";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/mapa-aproveitamento/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/mapa-aproveitamento/page.tsx
@@ -1,0 +1,7 @@
+import MapaAproveitamentoClient from "./ui";
+
+export const dynamic = "force-dynamic";
+
+export default function MapaAproveitamentoPage() {
+  return <MapaAproveitamentoClient />;
+}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/mapa-aproveitamento/ui.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/mapa-aproveitamento/ui.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { BarChart3, Filter } from "lucide-react";
+
+type TurmaOption = { id: string; nome: string; codigo: string | null; turno: string | null };
+type PeriodoOption = { id: string; numero: number | null; tipo: string | null };
+type Coluna = { id: string; key: string; sigla: string; nome: string };
+type Linha = {
+  matricula_id: string;
+  numero_processo: string | null;
+  nome_aluno: string;
+  notas: Record<string, number | null>;
+  estatisticas: { media_geral: number | null; qtd_negativas: number; status: string };
+};
+
+type ApiData = {
+  ok: boolean;
+  error?: string;
+  filtros?: { turmas: TurmaOption[]; periodos: PeriodoOption[] };
+  report?: { colunas: Coluna[]; linhas: Linha[] } | null;
+};
+
+export default function MapaAproveitamentoClient() {
+  const [turmaId, setTurmaId] = useState("");
+  const [periodoId, setPeriodoId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [data, setData] = useState<ApiData | null>(null);
+
+  const turmas = data?.filtros?.turmas ?? [];
+  const periodos = data?.filtros?.periodos ?? [];
+  const colunas = data?.report?.colunas ?? [];
+  const linhas = data?.report?.linhas ?? [];
+
+  const statusTone = useMemo(
+    () => ({
+      Reprovado: "bg-red-100 text-red-700",
+      Recurso: "bg-amber-100 text-amber-700",
+      Aprovado: "bg-emerald-100 text-emerald-700",
+    }),
+    []
+  );
+
+  async function carregar(incluirDados: boolean) {
+    setLoading(true);
+    setError(null);
+
+    const params = new URLSearchParams();
+    if (incluirDados && turmaId) params.set("turma_id", turmaId);
+    if (incluirDados && periodoId) params.set("periodo_letivo_id", periodoId);
+
+    try {
+      const res = await fetch(`/api/secretaria/relatorios/mapa-aproveitamento?${params.toString()}`, {
+        cache: "no-store",
+      });
+      const json = (await res.json()) as ApiData;
+      if (!res.ok || !json.ok) {
+        throw new Error(json.error || "Falha ao carregar mapa de aproveitamento.");
+      }
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Erro inesperado.");
+      if (!data) setData({ ok: false, filtros: { turmas: [], periodos: [] }, report: null });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="mb-4 flex items-center gap-2 text-[#1F6B3B]">
+          <BarChart3 className="h-5 w-5" />
+          <h1 className="text-lg font-semibold">Mapa de Aproveitamento da Turma</h1>
+        </div>
+
+        <div className="grid gap-3 md:grid-cols-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Turma</label>
+            <select
+              value={turmaId}
+              onFocus={() => {
+                if (!data) void carregar(false);
+              }}
+              onChange={(e) => setTurmaId(e.target.value)}
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-klasse-gold focus:ring-4 focus:ring-klasse-gold/20"
+            >
+              <option value="">Selecione a turma</option>
+              {turmas.map((turma) => (
+                <option key={turma.id} value={turma.id}>
+                  {turma.nome} {turma.codigo ? `(${turma.codigo})` : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-slate-700">Período letivo</label>
+            <select
+              value={periodoId}
+              onFocus={() => {
+                if (!data) void carregar(false);
+              }}
+              onChange={(e) => setPeriodoId(e.target.value)}
+              className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:border-klasse-gold focus:ring-4 focus:ring-klasse-gold/20"
+            >
+              <option value="">Todos</option>
+              {periodos.map((periodo) => (
+                <option key={periodo.id} value={periodo.id}>
+                  {periodo.numero ? `${periodo.numero}º` : "Período"} {periodo.tipo ? `• ${periodo.tipo}` : ""}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-end">
+            <button
+              type="button"
+              disabled={!turmaId || loading}
+              onClick={() => void carregar(true)}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-klasse-gold px-4 py-2 text-sm font-medium text-white hover:brightness-95 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Filter className="h-4 w-4" />
+              {loading ? "A carregar..." : "Gerar mapa"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      ) : null}
+
+      <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-full text-sm">
+          <thead className="bg-slate-950 text-slate-200">
+            <tr>
+              <th className="px-3 py-2 text-left">Aluno</th>
+              <th className="px-3 py-2 text-left">Processo</th>
+              {colunas.map((coluna) => (
+                <th key={coluna.key} className="px-3 py-2 text-center" title={coluna.nome}>
+                  {coluna.sigla}
+                </th>
+              ))}
+              <th className="px-3 py-2 text-center">Média</th>
+              <th className="px-3 py-2 text-center">Negativas</th>
+              <th className="px-3 py-2 text-center">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {linhas.map((linha) => (
+              <tr key={linha.matricula_id} className="border-t border-slate-100">
+                <td className="px-3 py-2 text-slate-800">{linha.nome_aluno}</td>
+                <td className="px-3 py-2 text-slate-600">{linha.numero_processo || "—"}</td>
+                {colunas.map((coluna) => (
+                  <td key={`${linha.matricula_id}-${coluna.key}`} className="px-3 py-2 text-center text-slate-700">
+                    {typeof linha.notas?.[coluna.key] === "number" ? Number(linha.notas[coluna.key]).toFixed(1) : "—"}
+                  </td>
+                ))}
+                <td className="px-3 py-2 text-center font-medium text-slate-800">
+                  {typeof linha.estatisticas.media_geral === "number" ? linha.estatisticas.media_geral.toFixed(1) : "—"}
+                </td>
+                <td className="px-3 py-2 text-center text-slate-700">{linha.estatisticas.qtd_negativas}</td>
+                <td className="px-3 py-2 text-center">
+                  <span
+                    className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${
+                      statusTone[linha.estatisticas.status as keyof typeof statusTone] || "bg-slate-100 text-slate-700"
+                    }`}
+                  >
+                    {linha.estatisticas.status}
+                  </span>
+                </td>
+              </tr>
+            ))}
+            {linhas.length === 0 ? (
+              <tr>
+                <td colSpan={6 + colunas.length} className="px-3 py-8 text-center text-slate-500">
+                  Selecione a turma e clique em "Gerar mapa" para visualizar o relatório.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/page.tsx
+++ b/apps/web/src/app/secretaria/(portal-secretaria)/relatorios/page.tsx
@@ -89,6 +89,12 @@ export default async function Page(props: { searchParams?: Promise<SearchParams>
               >
                 Exportar JSON
               </a>
+              <a
+                href="/secretaria/relatorios/mapa-aproveitamento"
+                className="px-2.5 py-1 rounded-xl border border-slate-200 bg-white text-slate-700 hover:text-klasse-gold"
+              >
+                Abrir Mapa de Aproveitamento
+              </a>
             </div>
           </div>
           <form action="" className="flex gap-2 text-sm">

--- a/apps/web/src/lib/sidebarNav.ts
+++ b/apps/web/src/lib/sidebarNav.ts
@@ -107,6 +107,15 @@ export const sidebarConfig: SidebarConfig = {
     { href: "/escola/[escolaId]/secretaria/documentos-oficiais", label: "Documentos Oficiais", icon: "FileText" },
     { href: "/escola/[escolaId]/secretaria/operacoes-academicas", label: "Operações Acadêmicas", icon: "Activity" },
     { href: "/escola/[escolaId]/secretaria/importacoes", label: "Histórico de Importações", icon: "History" },
+    {
+      href: "/escola/[escolaId]/secretaria/relatorios",
+      label: "Relatórios",
+      icon: "BarChart3",
+      children: [
+        { href: "/escola/[escolaId]/secretaria/relatorios", label: "Auditoria" },
+        { href: "/escola/[escolaId]/secretaria/relatorios/mapa-aproveitamento", label: "Mapa de Aproveitamento" },
+      ],
+    },
   ],
   financeiro: [
     { href: "/financeiro", label: "Dashboard", icon: "LayoutDashboard" },

--- a/supabase/migrations/20261218090000_harden_mapa_aproveitamento_rpc.sql
+++ b/supabase/migrations/20261218090000_harden_mapa_aproveitamento_rpc.sql
@@ -1,0 +1,182 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.configuracoes_pedagogicas (
+  escola_id uuid PRIMARY KEY REFERENCES public.escolas(id) ON DELETE CASCADE,
+  negativas_para_reprovar integer NOT NULL DEFAULT 3,
+  media_minima_aprovacao numeric NOT NULL DEFAULT 10.0,
+  permitir_recurso boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT configuracoes_pedagogicas_negativas_ck CHECK (negativas_para_reprovar >= 0)
+);
+
+ALTER TABLE public.configuracoes_pedagogicas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS configuracoes_pedagogicas_select ON public.configuracoes_pedagogicas;
+
+CREATE POLICY configuracoes_pedagogicas_select
+  ON public.configuracoes_pedagogicas
+  FOR SELECT
+  TO authenticated
+  USING (escola_id = public.current_tenant_escola_id());
+
+CREATE OR REPLACE FUNCTION public.calcular_status_pedagogico(
+  p_qtd_negativas integer,
+  p_media_geral numeric,
+  p_escola_id uuid
+)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_config record;
+BEGIN
+  SELECT *
+  INTO v_config
+  FROM public.configuracoes_pedagogicas
+  WHERE escola_id = p_escola_id;
+
+  IF v_config.escola_id IS NULL THEN
+    IF p_qtd_negativas >= 3 THEN
+      RETURN 'Reprovado';
+    END IF;
+    IF p_qtd_negativas > 0 THEN
+      RETURN 'Recurso';
+    END IF;
+    RETURN 'Aprovado';
+  END IF;
+
+  IF p_qtd_negativas >= v_config.negativas_para_reprovar THEN
+    RETURN 'Reprovado';
+  ELSIF p_qtd_negativas > 0 AND v_config.permitir_recurso THEN
+    RETURN 'Recurso';
+  ELSIF p_qtd_negativas > 0 AND NOT v_config.permitir_recurso THEN
+    RETURN 'Reprovado';
+  ELSE
+    RETURN 'Aprovado';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.gerar_mapa_aproveitamento_turma(
+  p_escola_id uuid,
+  p_turma_id uuid,
+  p_periodo_letivo_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_escola_id uuid := public.current_tenant_escola_id();
+  v_colunas jsonb;
+  v_linhas jsonb;
+BEGIN
+  IF v_user_escola_id IS NULL OR v_user_escola_id <> p_escola_id THEN
+    RAISE EXCEPTION 'AUTH: Acesso negado. Violação de isolamento de Tenant.';
+  END IF;
+
+  IF NOT public.user_has_role_in_school(p_escola_id, ARRAY['admin_escola', 'secretaria', 'diretor_pedagogico']) THEN
+    RAISE EXCEPTION 'AUTH: Permissão insuficiente para gerar mapas estatísticos.';
+  END IF;
+
+  CREATE TEMP TABLE tmp_base_notas ON COMMIT DROP AS
+  WITH base_raw AS (
+    SELECT
+      m.id AS matricula_id,
+      al.numero_processo,
+      al.nome_completo AS nome_aluno,
+      d.id AS disciplina_id,
+      ('d_' || d.id::text) AS disciplina_key,
+      d.sigla AS disciplina_sigla,
+      d.nome AS disciplina_nome,
+      vbm.nota_final
+    FROM public.matriculas m
+    JOIN public.alunos al ON al.id = m.aluno_id
+    JOIN public.vw_boletim_por_matricula vbm ON vbm.matricula_id = m.id
+    JOIN public.disciplinas d ON d.id = vbm.disciplina_id
+    WHERE m.escola_id = p_escola_id
+      AND m.turma_id = p_turma_id
+      AND m.status = 'ativo'
+      AND vbm.conta_para_media_med IS TRUE
+      AND (p_periodo_letivo_id IS NULL OR vbm.periodo_letivo_id = p_periodo_letivo_id)
+  )
+  SELECT
+    matricula_id,
+    numero_processo,
+    nome_aluno,
+    disciplina_id,
+    disciplina_key,
+    disciplina_sigla,
+    disciplina_nome,
+    MAX(nota_final) AS nota_final
+  FROM base_raw
+  GROUP BY
+    matricula_id,
+    numero_processo,
+    nome_aluno,
+    disciplina_id,
+    disciplina_key,
+    disciplina_sigla,
+    disciplina_nome;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', disciplina_id,
+      'key', disciplina_key,
+      'sigla', COALESCE(NULLIF(TRIM(disciplina_sigla), ''), 'N/A'),
+      'nome', disciplina_nome
+    )
+    ORDER BY disciplina_nome
+  )
+  INTO v_colunas
+  FROM (
+    SELECT DISTINCT disciplina_id, disciplina_key, disciplina_sigla, disciplina_nome
+    FROM tmp_base_notas
+  ) colunas_src;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'matricula_id', matricula_id,
+      'numero_processo', numero_processo,
+      'nome_aluno', nome_aluno,
+      'notas', notas_disciplinas,
+      'estatisticas', jsonb_build_object(
+        'media_geral', media_geral,
+        'qtd_negativas', qtd_negativas,
+        'status', public.calcular_status_pedagogico(qtd_negativas::int, media_geral, p_escola_id)
+      )
+    )
+    ORDER BY nome_aluno
+  )
+  INTO v_linhas
+  FROM (
+    SELECT
+      matricula_id,
+      numero_processo,
+      nome_aluno,
+      jsonb_object_agg(disciplina_key, nota_final) AS notas_disciplinas,
+      ROUND(AVG(nota_final)::numeric, 1) AS media_geral,
+      COUNT(nota_final) FILTER (WHERE nota_final < 10) AS qtd_negativas
+    FROM tmp_base_notas
+    GROUP BY matricula_id, numero_processo, nome_aluno
+  ) linhas_src;
+
+  RETURN jsonb_build_object(
+    'colunas', COALESCE(v_colunas, '[]'::jsonb),
+    'linhas', COALESCE(v_linhas, '[]'::jsonb)
+  );
+END;
+$$;
+
+ALTER FUNCTION public.calcular_status_pedagogico(integer, numeric, uuid) OWNER TO postgres;
+ALTER FUNCTION public.gerar_mapa_aproveitamento_turma(uuid, uuid, uuid) OWNER TO postgres;
+
+GRANT EXECUTE ON FUNCTION public.calcular_status_pedagogico(integer, numeric, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.gerar_mapa_aproveitamento_turma(uuid, uuid, uuid) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20261218100000_refine_mapa_aproveitamento_consolidation.sql
+++ b/supabase/migrations/20261218100000_refine_mapa_aproveitamento_consolidation.sql
@@ -1,0 +1,121 @@
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.gerar_mapa_aproveitamento_turma(
+  p_escola_id uuid,
+  p_turma_id uuid,
+  p_periodo_letivo_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_user_escola_id uuid := public.current_tenant_escola_id();
+  v_colunas jsonb;
+  v_linhas jsonb;
+BEGIN
+  IF v_user_escola_id IS NULL OR v_user_escola_id <> p_escola_id THEN
+    RAISE EXCEPTION 'AUTH: Acesso negado. Violação de isolamento de Tenant.';
+  END IF;
+
+  IF NOT public.user_has_role_in_school(p_escola_id, ARRAY['admin_escola', 'secretaria', 'diretor_pedagogico']) THEN
+    RAISE EXCEPTION 'AUTH: Permissão insuficiente para gerar mapas estatísticos.';
+  END IF;
+
+  CREATE TEMP TABLE tmp_base_notas ON COMMIT DROP AS
+  WITH base_raw AS (
+    SELECT
+      m.id AS matricula_id,
+      al.numero_processo,
+      al.nome_completo AS nome_aluno,
+      d.id AS disciplina_id,
+      ('d_' || d.id::text) AS disciplina_key,
+      d.sigla AS disciplina_sigla,
+      d.nome AS disciplina_nome,
+      vbm.trimestre,
+      vbm.nota_final
+    FROM public.matriculas m
+    JOIN public.alunos al ON al.id = m.aluno_id
+    JOIN public.vw_boletim_por_matricula vbm ON vbm.matricula_id = m.id
+    JOIN public.disciplinas d ON d.id = vbm.disciplina_id
+    WHERE m.escola_id = p_escola_id
+      AND m.turma_id = p_turma_id
+      AND m.status = 'ativo'
+      AND vbm.conta_para_media_med IS TRUE
+      AND (p_periodo_letivo_id IS NULL OR vbm.periodo_letivo_id = p_periodo_letivo_id)
+  ),
+  base_ranked AS (
+    SELECT
+      base_raw.*,
+      row_number() OVER (
+        PARTITION BY base_raw.matricula_id, base_raw.disciplina_id
+        ORDER BY base_raw.trimestre DESC NULLS LAST, base_raw.nota_final DESC NULLS LAST
+      ) AS rn
+    FROM base_raw
+  )
+  SELECT
+    matricula_id,
+    numero_processo,
+    nome_aluno,
+    disciplina_id,
+    disciplina_key,
+    disciplina_sigla,
+    disciplina_nome,
+    nota_final
+  FROM base_ranked
+  WHERE rn = 1;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'id', disciplina_id,
+      'key', disciplina_key,
+      'sigla', COALESCE(NULLIF(TRIM(disciplina_sigla), ''), 'N/A'),
+      'nome', disciplina_nome
+    )
+    ORDER BY disciplina_nome
+  )
+  INTO v_colunas
+  FROM (
+    SELECT DISTINCT disciplina_id, disciplina_key, disciplina_sigla, disciplina_nome
+    FROM tmp_base_notas
+  ) colunas_src;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'matricula_id', matricula_id,
+      'numero_processo', numero_processo,
+      'nome_aluno', nome_aluno,
+      'notas', notas_disciplinas,
+      'estatisticas', jsonb_build_object(
+        'media_geral', media_geral,
+        'qtd_negativas', qtd_negativas,
+        'status', public.calcular_status_pedagogico(qtd_negativas::int, media_geral, p_escola_id)
+      )
+    )
+    ORDER BY nome_aluno
+  )
+  INTO v_linhas
+  FROM (
+    SELECT
+      matricula_id,
+      numero_processo,
+      nome_aluno,
+      jsonb_object_agg(disciplina_key, nota_final) AS notas_disciplinas,
+      ROUND(AVG(nota_final)::numeric, 1) AS media_geral,
+      COUNT(nota_final) FILTER (WHERE nota_final < 10) AS qtd_negativas
+    FROM tmp_base_notas
+    GROUP BY matricula_id, numero_processo, nome_aluno
+  ) linhas_src;
+
+  RETURN jsonb_build_object(
+    'colunas', COALESCE(v_colunas, '[]'::jsonb),
+    'linhas', COALESCE(v_linhas, '[]'::jsonb)
+  );
+END;
+$$;
+
+ALTER FUNCTION public.gerar_mapa_aproveitamento_turma(uuid, uuid, uuid) OWNER TO postgres;
+GRANT EXECUTE ON FUNCTION public.gerar_mapa_aproveitamento_turma(uuid, uuid, uuid) TO authenticated;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Provide a new "Mapa de Aproveitamento" report for secretariat users to view per-class student grades, statistics and pedagogical status.
- Ensure the report is tenant-safe and uses DB-side logic to compute consolidated grades and status rules.

### Description
- Added a server API endpoint at `apps/web/src/app/api/secretaria/relatorios/mapa-aproveitamento/route.ts` that resolves the user's school, returns filters (`turmas` and `periodos`) and calls the RPC `gerar_mapa_aproveitamento_turma` to produce the report JSON. 
- Implemented a client page and component at `apps/web/src/app/secretaria/(portal-secretaria)/relatorios/mapa-aproveitamento` (`page.tsx` + `ui.tsx`) that loads filters, requests the API, and renders a responsive table with columns, per-student grades, averages and status badges. 
- Added navigation: a link to the report from the reports toolbar (`relatorios/page.tsx`) and a sidebar entry under secretariat reports in `apps/web/src/lib/sidebarNav.ts`.
- Added two Supabase migrations to create/support DB logic: `20261218090000_harden_mapa_aproveitamento_rpc.sql` creates `configuracoes_pedagogicas`, `calcular_status_pedagogico` and the initial `gerar_mapa_aproveitamento_turma` with RLS and grants; `20261218100000_refine_mapa_aproveitamento_consolidation.sql` refines the `gerar_mapa_aproveitamento_turma` function to select the most relevant grade per discipline (using trimestre ranking). 

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b02648126483268778b0b55373cf8c)