### PR TITLE
Add 360° student timeline and year-range filters to financeiro UI and API

### DIFF
--- a/apps/web/src/app/api/aluno/financeiro/route.ts
+++ b/apps/web/src/app/api/aluno/financeiro/route.ts
@@ -6,12 +6,24 @@ import { resolveAuthorizedStudentIds, resolveSelectedStudentId } from "@/lib/por
 type MensalidadeRow = {
   id: string;
   ano_referencia: number | null;
+  ano_letivo: string | null;
   mes_referencia: number | null;
   valor_previsto: number | null;
   data_vencimento: string | null;
   status: string | null;
   data_pagamento_efetiva: string | null;
 };
+
+const MIN_ANO = 2000;
+const MAX_SPAN = 10;
+
+function parseYear(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed)) return null;
+  if (parsed < MIN_ANO || parsed > new Date().getFullYear() + 1) return null;
+  return parsed;
+}
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -21,6 +33,20 @@ export async function GET(request: Request) {
     const { supabase, ctx } = await getAlunoContext();
     if (!ctx || !ctx.escolaId || !ctx.userId) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
 
+    const url = new URL(request.url);
+    const fromAno = parseYear(url.searchParams.get("fromAno"));
+    const toAno = parseYear(url.searchParams.get("toAno"));
+
+    if (fromAno == null || toAno == null) {
+      return NextResponse.json({ ok: false, error: "Parâmetros obrigatórios: fromAno e toAno." }, { status: 400 });
+    }
+    if (fromAno > toAno) {
+      return NextResponse.json({ ok: false, error: "Intervalo inválido: fromAno deve ser <= toAno." }, { status: 400 });
+    }
+    if (toAno - fromAno > MAX_SPAN) {
+      return NextResponse.json({ ok: false, error: `Intervalo máximo permitido é ${MAX_SPAN + 1} anos.` }, { status: 400 });
+    }
+
     const { data: userRes } = await supabase.auth.getUser();
     const authorizedIds = await resolveAuthorizedStudentIds({
       supabase,
@@ -29,17 +55,21 @@ export async function GET(request: Request) {
       userEmail: userRes?.user?.email,
     });
 
-    const selectedId = new URL(request.url).searchParams.get("studentId");
+    const selectedId = url.searchParams.get("studentId");
     const alunoId = resolveSelectedStudentId({ selectedId, authorizedIds, fallbackId: ctx.alunoId });
     if (!alunoId) return NextResponse.json({ ok: true, mensalidades: [] });
 
-    const query = supabase
+    const { data, error } = await supabase
       .from("mensalidades")
       .select("id, ano_referencia, ano_letivo, mes_referencia, valor_previsto, data_vencimento, status, data_pagamento_efetiva, matricula_id")
       .eq("aluno_id", alunoId)
-      .eq("escola_id", ctx.escolaId);
+      .eq("escola_id", ctx.escolaId)
+      .gte("ano_referencia", fromAno)
+      .lte("ano_referencia", toAno)
+      .order("ano_referencia", { ascending: true })
+      .order("mes_referencia", { ascending: true })
+      .order("id", { ascending: true });
 
-    const { data, error } = await query.order("ano_referencia", { ascending: true }).order("mes_referencia", { ascending: true }).limit(50);
     if (error) return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
 
     const hoje = new Date().toISOString().slice(0, 10);
@@ -54,7 +84,7 @@ export async function GET(request: Request) {
       return { id: m.id, competencia, valor: Number(m.valor_previsto ?? 0), vencimento, status, pago_em };
     });
 
-    return NextResponse.json({ ok: true, mensalidades: rows });
+    return NextResponse.json({ ok: true, mensalidades: rows, filters: { fromAno, toAno } });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });

--- a/apps/web/src/app/api/secretaria/alunos/[id]/timeline-360/route.ts
+++ b/apps/web/src/app/api/secretaria/alunos/[id]/timeline-360/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { supabaseServerTyped } from "@/lib/supabaseServer";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+import { requireRoleInSchool } from "@/lib/authz";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const ParamsSchema = z.object({
+  id: z.string().uuid("alunoId inválido"),
+});
+
+export async function GET(_req: Request, context: { params: Promise<{ id: string }> }) {
+  try {
+    const params = ParamsSchema.safeParse(await context.params);
+    if (!params.success) {
+      return NextResponse.json({ ok: false, error: params.error.issues[0]?.message ?? "Parâmetros inválidos" }, { status: 400 });
+    }
+
+    const supabase = await supabaseServerTyped<any>();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id);
+    if (!escolaId) return NextResponse.json({ ok: false, error: "Escola inválida" }, { status: 403 });
+
+    const roleCheck = await requireRoleInSchool({
+      supabase,
+      escolaId,
+      roles: ["admin", "admin_escola", "secretaria", "staff_admin"],
+    });
+    if (roleCheck.error) return roleCheck.error;
+
+    const { data, error } = await supabase.rpc("get_aluno_timeline_360", {
+      p_escola_id: escolaId,
+      p_aluno_id: params.data.id,
+    });
+
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+    }
+
+    return NextResponse.json({
+      ok: true,
+      aluno_id: params.data.id,
+      timeline: Array.isArray(data) ? data : [],
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/aluno/AlunoPerfilPage.tsx
+++ b/apps/web/src/components/aluno/AlunoPerfilPage.tsx
@@ -33,7 +33,7 @@ export default async function AlunoPerfilPage({ escolaId, alunoId, role }: { esc
           aluno={aluno}
           slotPerfil={<DossierPerfilSection aluno={aluno} />}
           slotFinanceiro={<DossierFinanceiroSection aluno={aluno} />}
-          slotHistorico={<DossierHistoricoSection aluno={aluno} />}
+          slotHistorico={<DossierHistoricoSection aluno={aluno} alunoId={alunoId} role={role} escolaId={resolvedEscolaId} />}
           slotDocumentos={<DossierDocumentosSection alunoId={alunoId} />}
         />
         {role === "secretaria" && (

--- a/apps/web/src/components/aluno/DossierHistoricoTimelineSection.tsx
+++ b/apps/web/src/components/aluno/DossierHistoricoTimelineSection.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { BookOpen, CalendarCheck, CircleAlert, Eye, Wallet } from "lucide-react";
+import { StatusPill } from "@/components/ui/StatusPill";
+import { formatDate, formatKwanza } from "@/lib/formatters";
+import type { DossierRole } from "@/components/aluno/DossierAcoes";
+
+type TimelineDisciplina = {
+  disciplina_id: string | null;
+  disciplina_nome: string | null;
+  media_final: number | null;
+  resultado: string | null;
+  em_risco?: boolean | null;
+};
+
+type TimelinePagamento = {
+  pagamento_id: string;
+  data_pagamento: string | null;
+  valor_pago: number | null;
+  metodo: string | null;
+  status: string | null;
+};
+
+type TimelineAno = {
+  ano_letivo: number;
+  ano_letivo_id: string | null;
+  matricula: {
+    matricula_id: string | null;
+    numero_matricula: string | null;
+    status: string | null;
+    data_matricula: string | null;
+  };
+  academico: {
+    media_geral: number | null;
+    estado_final: string | null;
+    disciplinas_chave: TimelineDisciplina[];
+  };
+  presenca: {
+    fonte: string;
+    faltas: number;
+    presencas: number;
+    aulas_previstas: number;
+    frequencia_min_percent: number | null;
+    percentual_presenca: number | null;
+  };
+  financeiro: {
+    total_previsto: number;
+    total_pago: number;
+    total_em_atraso: number;
+    mensalidades_em_atraso: number;
+    ultimos_pagamentos: TimelinePagamento[];
+  };
+};
+
+function detalheAnoHref(role: DossierRole, alunoId: string, ano: number, escolaId?: string | null) {
+  if (role === "admin" && escolaId) {
+    return `/escola/${escolaId}/admin/alunos/${alunoId}?tab=historico&ano=${ano}`;
+  }
+  return `/secretaria/alunos/${alunoId}?tab=historico&ano=${ano}`;
+}
+
+function Pill({ label, risk = false }: { label: string; risk?: boolean }) {
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${
+        risk
+          ? "border-red-200 bg-red-50 text-red-700"
+          : "border-slate-200 bg-slate-50 text-slate-600"
+      }`}
+    >
+      {label}
+    </span>
+  );
+}
+
+export function DossierHistoricoTimelineSection({
+  alunoId,
+  role,
+  escolaId,
+}: {
+  alunoId: string;
+  role: DossierRole;
+  escolaId?: string | null;
+}) {
+  const [timeline, setTimeline] = useState<TimelineAno[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/secretaria/alunos/${alunoId}/timeline-360`, { cache: "no-store" });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok || !json?.ok) {
+          throw new Error(json?.error ?? "Falha ao carregar timeline 360.");
+        }
+        if (!alive) return;
+        setTimeline(Array.isArray(json.timeline) ? json.timeline : []);
+      } catch (err) {
+        if (!alive) return;
+        setError(err instanceof Error ? err.message : "Erro desconhecido.");
+        setTimeline([]);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    }
+
+    void load();
+    return () => {
+      alive = false;
+    };
+  }, [alunoId]);
+
+  const cards = useMemo(() => timeline, [timeline]);
+
+  if (loading) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-slate-400">Percurso académico 360º</p>
+        <div className="space-y-3">
+          {[1, 2, 3].map((item) => (
+            <div key={item} className="animate-pulse rounded-xl border border-slate-200 p-4">
+              <div className="mb-3 h-4 w-32 rounded-full bg-slate-200" />
+              <div className="grid gap-2 md:grid-cols-3">
+                <div className="h-16 rounded-xl bg-slate-100" />
+                <div className="h-16 rounded-xl bg-slate-100" />
+                <div className="h-16 rounded-xl bg-slate-100" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700 shadow-sm">
+        <p className="flex items-center gap-2 font-semibold">
+          <CircleAlert size={16} /> Falha ao carregar timeline anual
+        </p>
+        <p className="mt-1 text-xs">{error}</p>
+      </div>
+    );
+  }
+
+  if (!cards.length) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-6 text-center text-sm text-slate-500 shadow-sm">
+        <BookOpen className="mx-auto mb-2 text-slate-400" size={18} />
+        Sem dados anuais para este aluno.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <p className="mb-3 text-[10px] font-bold uppercase tracking-widest text-slate-400">Percurso académico 360º</p>
+        <div className="space-y-3">
+          {cards.map((ano) => {
+            const presencaAtual = typeof ano.presenca.percentual_presenca === "number" ? ano.presenca.percentual_presenca : null;
+            const minimo = typeof ano.presenca.frequencia_min_percent === "number" ? ano.presenca.frequencia_min_percent : 75;
+            const presencaOk = presencaAtual == null ? null : presencaAtual >= minimo;
+            const saldoAtraso = ano.financeiro.total_em_atraso;
+            const disciplinas = Array.isArray(ano.academico.disciplinas_chave) ? ano.academico.disciplinas_chave : [];
+            const risco = disciplinas.filter((d) => d.em_risco);
+            const top = disciplinas.filter((d) => !d.em_risco).slice(0, 3);
+
+            return (
+              <article key={ano.ano_letivo} className="rounded-xl border border-slate-200 p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-[#1F6B3B]">Ano letivo {ano.ano_letivo}</p>
+                    <p className="text-xs text-slate-500">
+                      Matrícula {ano.matricula.numero_matricula ?? "—"} · {formatDate(ano.matricula.data_matricula)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {ano.matricula.status ? <StatusPill status={ano.matricula.status} variant="matricula" size="xs" /> : null}
+                    <Link
+                      href={detalheAnoHref(role, alunoId, ano.ano_letivo, escolaId)}
+                      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-[#E3B23C] hover:text-[#E3B23C]"
+                    >
+                      <Eye size={16} /> Ver detalhe do ano
+                    </Link>
+                  </div>
+                </div>
+
+                <div className="mt-3 grid gap-3 md:grid-cols-3">
+                  <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Resumo académico</p>
+                    <p className="mt-1 text-sm font-semibold text-slate-800">Média: {ano.academico.media_geral ?? "—"}</p>
+                    <p className="text-xs text-slate-500">Resultado final: {ano.academico.estado_final ?? "—"}</p>
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {top.map((d) => (
+                        <Pill key={`${ano.ano_letivo}-${d.disciplina_id ?? d.disciplina_nome}`} label={d.disciplina_nome ?? "Disciplina"} />
+                      ))}
+                      {risco.slice(0, 2).map((d) => (
+                        <Pill key={`${ano.ano_letivo}-risk-${d.disciplina_id ?? d.disciplina_nome}`} label={`${d.disciplina_nome ?? "Disciplina"} em risco`} risk />
+                      ))}
+                    </div>
+                  </section>
+
+                  <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Resumo de presença</p>
+                    <p className="mt-1 text-sm font-semibold text-slate-800">
+                      {ano.presenca.faltas} falta(s) · {presencaAtual == null ? "—" : `${presencaAtual}%`}
+                    </p>
+                    <p className="mt-1 text-xs">
+                      <span className={presencaOk == null ? "text-slate-500" : presencaOk ? "text-[#1F6B3B]" : "text-red-600"}>
+                        {presencaOk == null ? "Sem base para comparação" : presencaOk ? "Acima do mínimo" : "Abaixo do mínimo"}
+                      </span>
+                      <span className="text-slate-500"> · mínimo {minimo}%</span>
+                    </p>
+                    <p className="mt-1 text-xs text-slate-500 flex items-center gap-1"><CalendarCheck size={14} /> Fonte: {ano.presenca.fonte}</p>
+                  </section>
+
+                  <section className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400">Resumo financeiro</p>
+                    <p className="mt-1 text-xs text-slate-600">Previsto: <span className="font-semibold text-slate-900">{formatKwanza(ano.financeiro.total_previsto)}</span></p>
+                    <p className="text-xs text-slate-600">Pago: <span className="font-semibold text-[#1F6B3B]">{formatKwanza(ano.financeiro.total_pago)}</span></p>
+                    <p className="text-xs text-slate-600">Atraso: <span className={saldoAtraso > 0 ? "font-semibold text-red-600" : "font-semibold text-slate-900"}>{formatKwanza(saldoAtraso)}</span></p>
+                    <p className="mt-1 text-xs text-slate-500 flex items-center gap-1"><Wallet size={14} /> Últimos pagamentos</p>
+                    <ul className="mt-1 space-y-1">
+                      {(ano.financeiro.ultimos_pagamentos ?? []).slice(0, 2).map((pag) => (
+                        <li key={pag.pagamento_id} className="text-xs text-slate-600">
+                          {formatDate(pag.data_pagamento)} · {formatKwanza(pag.valor_pago ?? 0)}
+                        </li>
+                      ))}
+                      {!(ano.financeiro.ultimos_pagamentos ?? []).length ? <li className="text-xs text-slate-400">Sem pagamentos registados.</li> : null}
+                    </ul>
+                  </section>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/aluno/DossierSeccoes.tsx
+++ b/apps/web/src/components/aluno/DossierSeccoes.tsx
@@ -3,6 +3,8 @@ import { CheckCircle2, FileText, TrendingDown, Wallet } from "lucide-react";
 import { StatusPill } from "@/components/ui/StatusPill";
 import { formatDate, formatKwanza, monthName } from "@/lib/formatters";
 import type { AlunoNormalizado, DossierMensalidade } from "@/lib/aluno/types";
+import type { DossierRole } from "@/components/aluno/DossierAcoes";
+import { DossierHistoricoTimelineSection } from "@/components/aluno/DossierHistoricoTimelineSection";
 
 export function DossierPerfilSection({ aluno }: { aluno: AlunoNormalizado }) {
   const p = aluno.perfil;
@@ -190,43 +192,17 @@ export function DossierFinanceiroSection({ aluno }: { aluno: AlunoNormalizado })
   );
 }
 
-export function DossierHistoricoSection({ aluno }: { aluno: AlunoNormalizado }) {
-  if (!aluno.historico.length) {
-    return <div className="text-center py-6 text-slate-400">Sem histórico de matrículas.</div>;
-  }
-
-  return (
-    <div className="space-y-4">
-      <div className="rounded-2xl border border-slate-200 bg-white p-4">
-        <p className="text-[10px] font-bold uppercase tracking-widest text-slate-400 mb-3">Histórico de matrículas</p>
-        <div className="space-y-3">
-          {aluno.historico.map((mat, idx) => (
-            <div
-              key={mat.numero_matricula ?? idx}
-              className={`rounded-xl border p-4 ${
-                mat.is_atual ? "border-[#1F6B3B]/20 bg-[#1F6B3B]/5" : "border-slate-200"
-              }`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="text-sm font-bold text-slate-900">{mat.ano_letivo}</p>
-                  <p className="text-sm text-slate-700">{mat.turma}</p>
-                </div>
-                <StatusPill status={mat.status} variant="matricula" size="xs" />
-              </div>
-              <div className="mt-2 text-xs text-slate-500">
-                {mat.curso ? `${mat.curso} · ` : ""}
-                {mat.classe ? `${mat.classe} · ` : ""}
-                <span>
-                  Turno: {mat.turno ? mat.turno : <span className="text-slate-400 italic">Não preenchido</span>}
-                </span>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </div>
-  );
+export function DossierHistoricoSection({
+  alunoId,
+  role,
+  escolaId,
+}: {
+  aluno: AlunoNormalizado;
+  alunoId: string;
+  role: DossierRole;
+  escolaId?: string | null;
+}) {
+  return <DossierHistoricoTimelineSection alunoId={alunoId} role={role} escolaId={escolaId} />;
 }
 
 export function DossierDocumentosSection({ alunoId }: { alunoId: string }) {

--- a/apps/web/src/components/aluno/financeiro/FinanceiroResumo.tsx
+++ b/apps/web/src/components/aluno/financeiro/FinanceiroResumo.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabaseClient";
 
 export function FinanceiroResumo() {
   const [resumo, setResumo] = useState<{ pendentes: number; emDia: boolean } | null>(null);
@@ -10,10 +9,15 @@ export function FinanceiroResumo() {
     let mounted = true;
     (async () => {
       try {
-        const res = await fetch('/api/aluno/financeiro', { cache: 'no-store' });
+
+        const currentYear = new Date().getFullYear();
+        const fromAno = currentYear - 4;
+        const toAno = currentYear;
+        const params = new URLSearchParams({ fromAno: String(fromAno), toAno: String(toAno) });
+        const res = await fetch(`/api/aluno/financeiro?${params.toString()}`, { cache: 'no-store' });
         const json = await res.json();
         if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao carregar financeiro');
-        const pend = (json.mensalidades || []).filter((m: any) => m.status === 'pendente' || m.status === 'atrasado').length;
+        const pend = (json.mensalidades || []).filter((m: { status?: string }) => m.status === 'pendente' || m.status === 'atrasado').length;
         if (mounted) setResumo({ pendentes: pend, emDia: pend === 0 });
       } catch {
         if (mounted) setResumo({ pendentes: 0, emDia: true });

--- a/apps/web/src/components/aluno/financeiro/MensalidadesTable.tsx
+++ b/apps/web/src/components/aluno/financeiro/MensalidadesTable.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { createClient } from "@/lib/supabaseClient";
 import StatusPill from "./StatusPill";
 
 type Mensalidade = {
@@ -21,8 +20,13 @@ export function MensalidadesTable() {
     let mounted = true;
     (async () => {
       try {
+
+        const currentYear = new Date().getFullYear();
+        const fromAno = currentYear - 4;
+        const toAno = currentYear;
+        const params = new URLSearchParams({ fromAno: String(fromAno), toAno: String(toAno) });
         setLoading(true);
-        const res = await fetch('/api/aluno/financeiro', { cache: 'no-store' });
+        const res = await fetch(`/api/aluno/financeiro?${params.toString()}`, { cache: 'no-store' });
         const json = await res.json();
         if (!res.ok || !json?.ok) throw new Error(json?.error || 'Falha ao carregar mensalidades');
         if (mounted) setRows(json.mensalidades || []);

--- a/apps/web/src/components/aluno/tabs/TabFinanceiro.tsx
+++ b/apps/web/src/components/aluno/tabs/TabFinanceiro.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Check, Wallet } from "lucide-react";
+import { Check, Filter, Wallet } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { PaymentDrawer } from "@/components/aluno/financeiro-portal/PaymentDrawer";
 import { usePortalSWR } from "@/components/aluno/usePortalSWR";
@@ -22,14 +22,31 @@ function normalizeStatus(value: string): Item["status"] {
 export function TabFinanceiro() {
   const searchParams = useSearchParams();
   const studentId = useMemo(() => searchParams?.get("aluno") ?? null, [searchParams]);
+  const currentYear = new Date().getFullYear();
+
   const [loading, setLoading] = useState(true);
   const [rows, setRows] = useState<Item[]>([]);
   const [selected, setSelected] = useState<Item | null>(null);
   const [refreshing, setRefreshing] = useState(false);
+  const [fromAno, setFromAno] = useState(currentYear - 4);
+  const [toAno, setToAno] = useState(currentYear);
 
-  const query = studentId ? `?studentId=${studentId}` : "";
+  const years = useMemo(() => {
+    const list: number[] = [];
+    for (let year = currentYear + 1; year >= currentYear - 12; year -= 1) list.push(year);
+    return list;
+  }, [currentYear]);
+
+  const query = useMemo(() => {
+    const params = new URLSearchParams();
+    if (studentId) params.set("studentId", studentId);
+    params.set("fromAno", String(fromAno));
+    params.set("toAno", String(toAno));
+    return `?${params.toString()}`;
+  }, [studentId, fromAno, toAno]);
+
   const req = usePortalSWR({
-    key: `financeiro-${studentId ?? "default"}`,
+    key: `financeiro-${studentId ?? "default"}-${fromAno}-${toAno}`,
     url: `/api/aluno/financeiro${query}`,
     intervalMs: 30000,
     parse: (payload) => (((payload as ApiResponse).mensalidades ?? []).map((m) => ({ ...m, status: normalizeStatus(m.status) }))),
@@ -62,6 +79,40 @@ export function TabFinanceiro() {
         >
           {refreshing ? "A atualizar..." : "Atualizar"}
         </button>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-3 shadow-sm">
+        <div className="flex flex-wrap items-end gap-3">
+          <div>
+            <label htmlFor="fromAno" className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-slate-400">De</label>
+            <select
+              id="fromAno"
+              value={fromAno}
+              onChange={(e) => setFromAno(Number(e.target.value))}
+              className="min-h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 focus:border-[#E3B23C] focus:outline-none focus:ring-4 focus:ring-[#E3B23C]/20"
+            >
+              {years.map((year) => (
+                <option key={`from-${year}`} value={year}>{year}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor="toAno" className="mb-1 block text-[10px] font-bold uppercase tracking-widest text-slate-400">Até</label>
+            <select
+              id="toAno"
+              value={toAno}
+              onChange={(e) => setToAno(Number(e.target.value))}
+              className="min-h-10 rounded-xl border border-slate-200 bg-white px-3 text-sm text-slate-700 focus:border-[#E3B23C] focus:outline-none focus:ring-4 focus:ring-[#E3B23C]/20"
+            >
+              {years.map((year) => (
+                <option key={`to-${year}`} value={year}>{year}</option>
+              ))}
+            </select>
+          </div>
+          <Button tone="secondary" size="sm" className="min-h-10" onClick={refresh}>
+            <Filter className="h-4 w-4" /> Aplicar filtro
+          </Button>
+        </div>
       </div>
 
       <div className="grid gap-3 sm:grid-cols-2">
@@ -102,6 +153,7 @@ export function TabFinanceiro() {
                 )}
               </li>
             ))}
+            {!sorted.length ? <li className="rounded-xl border border-slate-100 p-4 text-sm text-slate-500">Sem mensalidades no intervalo selecionado.</li> : null}
           </ul>
         )}
       </section>

--- a/supabase/migrations/20261219083000_create_get_aluno_timeline_360_rpc.sql
+++ b/supabase/migrations/20261219083000_create_get_aluno_timeline_360_rpc.sql
@@ -1,0 +1,278 @@
+CREATE OR REPLACE FUNCTION public.get_aluno_timeline_360(
+  p_escola_id uuid,
+  p_aluno_id uuid
+)
+RETURNS jsonb
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+WITH matriculas_ranked AS (
+  SELECT
+    m.id,
+    m.escola_id,
+    m.aluno_id,
+    m.ano_letivo,
+    m.numero_matricula,
+    m.status,
+    m.data_matricula,
+    ROW_NUMBER() OVER (
+      PARTITION BY m.escola_id, m.aluno_id, m.ano_letivo
+      ORDER BY m.data_matricula DESC NULLS LAST, m.created_at DESC NULLS LAST, m.id DESC
+    ) AS rn
+  FROM public.matriculas m
+  WHERE m.escola_id = p_escola_id
+    AND m.aluno_id = p_aluno_id
+    AND m.ano_letivo IS NOT NULL
+),
+matriculas_base AS (
+  SELECT
+    id,
+    ano_letivo,
+    numero_matricula,
+    status,
+    data_matricula
+  FROM matriculas_ranked
+  WHERE rn = 1
+),
+anos_base AS (
+  SELECT DISTINCT ano_letivo
+  FROM (
+    SELECT mb.ano_letivo FROM matriculas_base mb
+    UNION ALL
+    SELECT ha.ano_letivo
+    FROM public.historico_anos ha
+    WHERE ha.escola_id = p_escola_id
+      AND ha.aluno_id = p_aluno_id
+      AND ha.ano_letivo IS NOT NULL
+    UNION ALL
+    SELECT m.ano_referencia
+    FROM public.mensalidades m
+    WHERE m.escola_id = p_escola_id
+      AND m.aluno_id = p_aluno_id
+      AND m.ano_referencia IS NOT NULL
+  ) years
+),
+anos_enriquecidos AS (
+  SELECT
+    ab.ano_letivo,
+    al.id AS ano_letivo_id,
+    mb.id AS matricula_id,
+    mb.numero_matricula,
+    mb.status AS status_matricula,
+    mb.data_matricula
+  FROM anos_base ab
+  LEFT JOIN matriculas_base mb
+    ON mb.ano_letivo = ab.ano_letivo
+  LEFT JOIN LATERAL (
+    SELECT a.id
+    FROM public.anos_letivos a
+    WHERE a.escola_id = p_escola_id
+      AND a.ano = ab.ano_letivo
+    ORDER BY a.ativo DESC, a.updated_at DESC NULLS LAST, a.created_at DESC, a.id DESC
+    LIMIT 1
+  ) al ON TRUE
+),
+academico AS (
+  SELECT
+    ha.ano_letivo,
+    ROUND(AVG(COALESCE(ha.media_geral, hd.nota_media_ano))::numeric, 2) AS media_geral,
+    (
+      ARRAY_AGG(ha.resultado_final ORDER BY ha.data_fechamento DESC NULLS LAST, ha.id DESC)
+    )[1] AS estado_final,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'disciplina_id', kd.disciplina_id,
+          'disciplina_nome', kd.disciplina_nome,
+          'media_final', kd.media_final,
+          'resultado', kd.resultado,
+          'em_risco', kd.em_risco
+        )
+        ORDER BY kd.prioridade, kd.media_final DESC NULLS LAST, kd.disciplina_nome
+      ) FILTER (WHERE kd.disciplina_id IS NOT NULL),
+      '[]'::jsonb
+    ) AS disciplinas_chave
+  FROM public.historico_anos ha
+  LEFT JOIN LATERAL (
+    SELECT AVG(hd.nota_final) AS nota_media_ano
+    FROM public.historico_disciplinas hd
+    WHERE hd.historico_ano_id = ha.id
+  ) hd ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT
+      hdx.disciplina_id,
+      hdx.disciplina_nome,
+      ROUND(hdx.nota_final::numeric, 2) AS media_final,
+      hdx.status_final AS resultado,
+      COALESCE(hdx.nota_final, 0) < 10 OR COALESCE(LOWER(hdx.status_final), '') LIKE '%reprov%' AS em_risco,
+      CASE
+        WHEN LOWER(COALESCE(hdx.disciplina_nome, '')) LIKE '%portug%' THEN 1
+        WHEN LOWER(COALESCE(hdx.disciplina_nome, '')) LIKE '%matem%' THEN 2
+        WHEN LOWER(COALESCE(hdx.disciplina_nome, '')) LIKE '%fisic%' THEN 3
+        WHEN LOWER(COALESCE(hdx.disciplina_nome, '')) LIKE '%quim%' THEN 4
+        WHEN LOWER(COALESCE(hdx.disciplina_nome, '')) LIKE '%biolog%' THEN 5
+        ELSE 99
+      END AS prioridade
+    FROM public.historico_disciplinas hdx
+    WHERE hdx.historico_ano_id = ha.id
+    ORDER BY prioridade, hdx.nota_final DESC NULLS LAST, hdx.disciplina_nome
+    LIMIT 8
+  ) kd ON TRUE
+  WHERE ha.escola_id = p_escola_id
+    AND ha.aluno_id = p_aluno_id
+  GROUP BY ha.ano_letivo
+),
+presenca_snapshot AS (
+  SELECT
+    m.ano_letivo,
+    SUM(fsp.faltas) AS faltas,
+    SUM(fsp.presencas) AS presencas,
+    SUM(fsp.aulas_previstas) AS aulas_previstas,
+    ROUND(AVG(fsp.frequencia_min_percent)::numeric, 2) AS frequencia_min_percent
+  FROM public.frequencia_status_periodo fsp
+  INNER JOIN public.matriculas m
+    ON m.id = fsp.matricula_id
+   AND m.escola_id = p_escola_id
+   AND m.aluno_id = p_aluno_id
+   AND m.ano_letivo IS NOT NULL
+  WHERE fsp.escola_id = p_escola_id
+    AND fsp.aluno_id = p_aluno_id
+  GROUP BY m.ano_letivo
+),
+presenca_fallback AS (
+  SELECT
+    m.ano_letivo,
+    COUNT(*) FILTER (WHERE COALESCE(f.status, '') IN ('falta', 'ausente'))::int AS faltas,
+    COUNT(*) FILTER (WHERE COALESCE(f.status, '') IN ('presente', 'presenca'))::int AS presencas,
+    COUNT(*)::int AS aulas_previstas
+  FROM public.frequencias f
+  INNER JOIN public.matriculas m
+    ON m.id = f.matricula_id
+   AND m.escola_id = p_escola_id
+   AND m.aluno_id = p_aluno_id
+   AND m.ano_letivo IS NOT NULL
+  WHERE f.escola_id = p_escola_id
+  GROUP BY m.ano_letivo
+),
+financeiro_mensalidades AS (
+  SELECT
+    COALESCE(m.ano_referencia, mb.ano_letivo) AS ano_letivo,
+    SUM(COALESCE(m.valor_previsto, m.valor, 0)) AS total_previsto,
+    SUM(COALESCE(m.valor_pago_total, 0)) AS total_pago_mensalidades,
+    SUM(
+      CASE
+        WHEN COALESCE(m.status, '') <> 'pago'
+         AND m.data_vencimento < CURRENT_DATE
+        THEN GREATEST(COALESCE(m.valor_previsto, m.valor, 0) - COALESCE(m.valor_pago_total, 0), 0)
+        ELSE 0
+      END
+    ) AS total_em_atraso,
+    COUNT(*) FILTER (
+      WHERE COALESCE(m.status, '') <> 'pago'
+        AND m.data_vencimento < CURRENT_DATE
+    )::int AS mensalidades_em_atraso
+  FROM public.mensalidades m
+  LEFT JOIN matriculas_base mb
+    ON mb.id = m.matricula_id
+  WHERE m.escola_id = p_escola_id
+    AND m.aluno_id = p_aluno_id
+  GROUP BY COALESCE(m.ano_referencia, mb.ano_letivo)
+),
+financeiro_pagamentos AS (
+  SELECT
+    COALESCE(m.ano_referencia, mb.ano_letivo, EXTRACT(YEAR FROM p.data_pagamento)::int) AS ano_letivo,
+    SUM(
+      CASE
+        WHEN COALESCE(p.status, '') IN ('pago', 'confirmado', 'concluido', 'aprovado')
+        THEN COALESCE(p.valor_pago, 0)
+        ELSE 0
+      END
+    ) AS total_pago_pagamentos,
+    COALESCE(
+      jsonb_agg(
+        jsonb_build_object(
+          'pagamento_id', p.id,
+          'data_pagamento', p.data_pagamento,
+          'valor_pago', p.valor_pago,
+          'metodo', COALESCE(p.metodo_pagamento, p.metodo),
+          'status', p.status
+        )
+        ORDER BY p.data_pagamento DESC NULLS LAST, p.created_at DESC
+      ) FILTER (WHERE p.id IS NOT NULL),
+      '[]'::jsonb
+    ) AS pagamentos_ordenados
+  FROM public.pagamentos p
+  LEFT JOIN public.mensalidades m
+    ON m.id = p.mensalidade_id
+   AND m.escola_id = p_escola_id
+  LEFT JOIN matriculas_base mb
+    ON mb.id = m.matricula_id
+  WHERE p.escola_id = p_escola_id
+    AND (
+      p.aluno_id = p_aluno_id
+      OR m.aluno_id = p_aluno_id
+    )
+  GROUP BY COALESCE(m.ano_referencia, mb.ano_letivo, EXTRACT(YEAR FROM p.data_pagamento)::int)
+)
+SELECT COALESCE(
+  jsonb_agg(
+    jsonb_build_object(
+      'ano_letivo', ae.ano_letivo,
+      'ano_letivo_id', ae.ano_letivo_id,
+      'matricula', jsonb_build_object(
+        'matricula_id', ae.matricula_id,
+        'numero_matricula', ae.numero_matricula,
+        'status', ae.status_matricula,
+        'data_matricula', ae.data_matricula
+      ),
+      'academico', jsonb_build_object(
+        'media_geral', ac.media_geral,
+        'estado_final', ac.estado_final,
+        'disciplinas_chave', COALESCE(ac.disciplinas_chave, '[]'::jsonb)
+      ),
+      'presenca', jsonb_build_object(
+        'fonte', CASE WHEN ps.ano_letivo IS NOT NULL THEN 'snapshot_frequencia_status_periodo' ELSE 'fallback_frequencias' END,
+        'faltas', COALESCE(ps.faltas, pf.faltas, 0),
+        'presencas', COALESCE(ps.presencas, pf.presencas, 0),
+        'aulas_previstas', COALESCE(ps.aulas_previstas, pf.aulas_previstas, 0),
+        'frequencia_min_percent', COALESCE(ps.frequencia_min_percent, 75),
+        'percentual_presenca',
+          CASE
+            WHEN COALESCE(ps.aulas_previstas, pf.aulas_previstas, 0) > 0 THEN
+              ROUND((COALESCE(ps.presencas, pf.presencas, 0)::numeric / COALESCE(ps.aulas_previstas, pf.aulas_previstas, 0)::numeric) * 100, 2)
+            ELSE NULL
+          END
+      ),
+      'financeiro', jsonb_build_object(
+        'total_previsto', COALESCE(fm.total_previsto, 0),
+        'total_pago', GREATEST(COALESCE(fm.total_pago_mensalidades, 0), COALESCE(fp.total_pago_pagamentos, 0)),
+        'total_em_atraso', COALESCE(fm.total_em_atraso, 0),
+        'mensalidades_em_atraso', COALESCE(fm.mensalidades_em_atraso, 0),
+        'ultimos_pagamentos', COALESCE((
+          SELECT jsonb_agg(up.item ORDER BY up.pos)
+          FROM (
+            SELECT value AS item, ordinality AS pos
+            FROM jsonb_array_elements(COALESCE(fp.pagamentos_ordenados, '[]'::jsonb)) WITH ORDINALITY
+            ORDER BY ordinality
+            LIMIT 3
+          ) up
+        ), '[]'::jsonb)
+      )
+    )
+    ORDER BY ae.ano_letivo ASC
+  ),
+  '[]'::jsonb
+)
+FROM anos_enriquecidos ae
+LEFT JOIN academico ac
+  ON ac.ano_letivo = ae.ano_letivo
+LEFT JOIN presenca_snapshot ps
+  ON ps.ano_letivo = ae.ano_letivo
+LEFT JOIN presenca_fallback pf
+  ON pf.ano_letivo = ae.ano_letivo
+LEFT JOIN financeiro_mensalidades fm
+  ON fm.ano_letivo = ae.ano_letivo
+LEFT JOIN financeiro_pagamentos fp
+  ON fp.ano_letivo = ae.ano_letivo;
+$$;


### PR DESCRIPTION
### Motivation

- Provide a consolidated "timeline 360º" view per student combining academic, presence and financial summaries for each year. 
- Allow filtering of student mensalidades by a validated year range to avoid returning excessive historical data. 
- Surface the timeline to the dossier UI and make financeiro components fetch data for a configurable year window.

### Description

- Added year-range filtering to the student financeiro API by parsing `fromAno`/`toAno`, validating them (`parseYear`, `MIN_ANO`, `MAX_SPAN`) and applying `.gte/.lte` and ordering on `ano_referencia` and `mes_referencia` in `/api/aluno/financeiro/route.ts`, and returning `filters` in the response. 
- Updated frontend consumers (`TabFinanceiro`, `FinanceiroResumo`, `MensalidadesTable`) to request mensalidades with a default 5-year window (current year - 4 to current year) and added UI controls in `TabFinanceiro` to pick `fromAno`/`toAno` and refresh the SWR key. 
- Implemented a new secretary-only endpoint `/api/secretaria/alunos/[id]/timeline-360` which validates params, authorizes the user and calls the new RPC `get_aluno_timeline_360`. 
- Added the `DossierHistoricoTimelineSection` client component and plugged it into `DossierSeccoes` and `AlunoPerfilPage` so the dossier shows the 360º per-year cards with academic, presence and financial summaries. 
- Created a new Supabase migration that defines the `get_aluno_timeline_360` SQL RPC which aggregates matriculas, historico_anos, frequencias and pagamentos to produce a JSON per year with `academico`, `presenca` and `financeiro` blocks.

### Testing

- Ran TypeScript type-check and a project build to validate integration of new API and components, and both completed successfully. 
- Exercised the new `/api/aluno/financeiro` year-filtering manually via UI flows in `TabFinanceiro` and verified the SWR refresh and filtered results returned expected data. 
- Executed the existing automated test suite and linters (`pnpm -w test` / `pnpm -w lint`) in CI-like environment and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2b9257c38832694550ba46a9fa309)