### PR TITLE
feat(admin): operational activity feed (DB + API + realtime + UI)

### DIFF
--- a/apps/web/src/app/api/escola/[id]/admin/activity-feed/route.ts
+++ b/apps/web/src/app/api/escola/[id]/admin/activity-feed/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createRouteClient } from "@/lib/supabase/route-client";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+import { requireRoleInSchool } from "@/lib/authz";
+import type { ActivityFeedItem } from "@/lib/admin/activityFeed";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 50;
+
+function parseLimit(raw: string | null): number {
+  const parsed = Number.parseInt(raw ?? "", 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+function decodeCursor(cursor: string | null): { occurredAt: string; id: string } | null {
+  if (!cursor) return null;
+
+  try {
+    const plain = Buffer.from(cursor, "base64").toString("utf8");
+    const [occurredAt, id] = plain.split("|");
+    if (!occurredAt || !id) return null;
+    return { occurredAt, id };
+  } catch {
+    return null;
+  }
+}
+
+function encodeCursor(item: Pick<ActivityFeedItem, "occurred_at" | "id">): string {
+  return Buffer.from(`${item.occurred_at}|${item.id}`).toString("base64");
+}
+
+export async function GET(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const { id: requestedEscolaId } = await context.params;
+
+  try {
+    const supabase = await createRouteClient();
+    const { data: authData } = await supabase.auth.getUser();
+    const user = authData?.user;
+
+    if (!user) {
+      return NextResponse.json({ ok: false, error: "Não autenticado" }, { status: 401 });
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id, requestedEscolaId);
+    if (!escolaId || escolaId !== requestedEscolaId) {
+      return NextResponse.json({ ok: false, error: "Sem permissão" }, { status: 403 });
+    }
+
+    const roleCheck = await requireRoleInSchool({
+      supabase: supabase as any,
+      escolaId,
+      roles: ["admin_escola", "admin", "staff_admin", "secretaria"],
+    });
+
+    if (roleCheck.error) return roleCheck.error;
+
+    const { searchParams } = request.nextUrl;
+    const limit = parseLimit(searchParams.get("limit"));
+    const familiesRaw = searchParams.get("families");
+    const families = familiesRaw
+      ? familiesRaw
+          .split(",")
+          .map((part) => part.trim())
+          .filter(Boolean)
+      : [];
+    const cursor = decodeCursor(searchParams.get("cursor"));
+
+    let query = (supabase as any)
+      .from("vw_admin_activity_feed_enriched")
+      .select(
+        "id, escola_id, occurred_at, event_family, event_type, actor_name, headline, subline, amount_kz, turma_nome, aluno_nome, payload"
+      )
+      .eq("escola_id", escolaId)
+      .order("occurred_at", { ascending: false })
+      .order("id", { ascending: false })
+      .limit(limit + 1);
+
+    if (families.length > 0) {
+      query = query.in("event_family", families);
+    }
+
+    if (cursor) {
+      query = query.or(
+        `occurred_at.lt.${cursor.occurredAt},and(occurred_at.eq.${cursor.occurredAt},id.lt.${cursor.id})`
+      );
+    }
+
+    const { data, error } = await query;
+    if (error) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 500 });
+    }
+
+    const rows = (data ?? []) as ActivityFeedItem[];
+    const hasNextPage = rows.length > limit;
+    const items = hasNextPage ? rows.slice(0, limit) : rows;
+    const nextCursor = hasNextPage ? encodeCursor(items[items.length - 1]) : null;
+
+    return NextResponse.json({
+      ok: true,
+      items,
+      nextCursor,
+      serverNow: new Date().toISOString(),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro inesperado";
+    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+  }
+}

--- a/apps/web/src/components/layout/escola-admin/EscolaAdminDashboardContent.tsx
+++ b/apps/web/src/components/layout/escola-admin/EscolaAdminDashboardContent.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { AlertCircle, ArrowRight, Wallet, TrendingUp, TrendingDown, Minus } from "lucide-react";
 import KpiSection      from "./KpiSection";
 import NoticesSection  from "./NoticesSection";
-import EventsSection   from "./EventsSection";
+import OperationalFeedSection from "./OperationalFeedSection";
 import AcademicSection from "./AcademicSection";
 import QuickActionsSection from "./QuickActionsSection";
 import ChartsSection   from "./ChartsSection";
@@ -18,7 +18,6 @@ import type {
   KpiStats,
   SetupStatus,
   Aviso,
-  Evento,
   CurriculoPendencias,
   DashboardCharts,
   InadimplenciaTopRow,
@@ -34,7 +33,6 @@ type Props = {
   loading?:             boolean;
   error?:               string | null;
   notices?:             Aviso[];
-  events?:              Evento[];
   charts?:              DashboardCharts;
   stats:                KpiStats;
   pendingTurmasCount?:  number | null;
@@ -158,7 +156,6 @@ export default function EscolaAdminDashboardContent({
   loading,
   error,
   notices            = [],
-  events             = [],
   charts,
   stats,
   pendingTurmasCount,
@@ -456,7 +453,7 @@ export default function EscolaAdminDashboardContent({
             missingPricingCount={missingPricingCount}
             financeiroHref={financeiroHref}
           />
-          <EventsSection events={events} />
+          <OperationalFeedSection escolaId={escolaId} />
         </div>
       </div>
 

--- a/apps/web/src/components/layout/escola-admin/EscolaAdminDashboardData.tsx
+++ b/apps/web/src/components/layout/escola-admin/EscolaAdminDashboardData.tsx
@@ -10,7 +10,6 @@ import type {
   KpiStats,
   SetupStatus,
   Aviso,
-  Evento,
   CurriculoPendencias,
   DashboardCharts,
   InadimplenciaTopRow,
@@ -244,7 +243,6 @@ export default async function EscolaAdminDashboardData({ escolaId, escolaNome }:
     const inadimplenciaTop = (inadimplenciaTopRes as any)?.data  as InadimplenciaTopRow[] ?? [];
     const pagamentosRecentes = (pagamentosRecentesRes as any)?.data as PagamentoRecenteRow[] ?? [];
     const avisos: Aviso[]  = [];
-    const eventos: Evento[] = [];
 
     return (
       <EscolaAdminDashboardContent
@@ -256,7 +254,6 @@ export default async function EscolaAdminDashboardData({ escolaId, escolaNome }:
         stats={stats}
         pendingTurmasCount={pendingTurmasCount}
         notices={avisos}
-        events={eventos}
         charts={charts}
         setupStatus={setupStatus}
         missingPricingCount={missingPricingCount}
@@ -281,7 +278,6 @@ export default async function EscolaAdminDashboardData({ escolaId, escolaNome }:
         stats={emptyKpis}
         pendingTurmasCount={0}
         notices={[]}
-        events={[]}
         charts={undefined}
         setupStatus={emptySetupStatus}
         missingPricingCount={0}

--- a/apps/web/src/components/layout/escola-admin/OperationalFeedSection.tsx
+++ b/apps/web/src/components/layout/escola-admin/OperationalFeedSection.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { Activity, ArrowRight, AlertTriangle } from "lucide-react";
+import { useEscolaId } from "@/hooks/useEscolaId";
+import { familyBadgeClasses, familyLabel, toFeedSubline } from "@/lib/admin/activityFeed";
+import { useAdminActivityFeed } from "./useAdminActivityFeed";
+
+type Props = {
+  escolaId: string;
+};
+
+function formatTime(iso: string): string {
+  const dt = new Date(iso);
+  if (Number.isNaN(dt.getTime())) return "--:--";
+  return dt.toLocaleTimeString("pt-PT", { hour: "2-digit", minute: "2-digit" });
+}
+
+export default function OperationalFeedSection({ escolaId }: Props) {
+  const { escolaSlug } = useEscolaId();
+  const escolaParam = escolaSlug || escolaId;
+  const { items, loading, realtimeState } = useAdminActivityFeed(escolaId, 20);
+
+  return (
+    <section className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="rounded-xl bg-slate-100 p-2 text-slate-600">
+            <Activity className="h-4 w-4" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="truncate text-sm font-bold text-slate-900">Feed Operacional</h3>
+            <p className="truncate text-xs text-slate-500">Eventos críticos e actividade recente da escola</p>
+          </div>
+        </div>
+
+        <Link
+          href={`/escola/${escolaParam}/admin/relatorios`}
+          className="inline-flex items-center gap-1 rounded-xl px-2 py-1 text-xs font-bold text-[#E3B23C] hover:bg-klasse-gold-50"
+        >
+          Ver histórico completo <ArrowRight className="h-3.5 w-3.5" />
+        </Link>
+      </header>
+
+      {realtimeState === "polling" && (
+        <div className="mb-3 flex items-center gap-2 rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700">
+          <AlertTriangle className="h-3.5 w-3.5" />
+          <span className="font-semibold">Ligação instável — atualizando por polling.</span>
+        </div>
+      )}
+
+      {loading ? (
+        <ul className="space-y-2">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <li key={idx} className="animate-pulse rounded-xl border border-slate-100 p-3">
+              <div className="mb-2 h-3 w-10 rounded bg-slate-100" />
+              <div className="mb-2 h-3 w-2/3 rounded bg-slate-100" />
+              <div className="h-3 w-1/2 rounded bg-slate-100" />
+            </li>
+          ))}
+        </ul>
+      ) : items.length === 0 ? (
+        <div className="rounded-xl border border-slate-100 bg-slate-50 p-4 text-sm font-semibold text-slate-600">
+          Sem atividade nas últimas horas.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {items.slice(0, 8).map((item) => (
+            <li key={item.id} className="rounded-xl border border-slate-100 px-3 py-2">
+              <div className="flex items-start gap-3">
+                <p className="w-10 flex-shrink-0 text-xs font-bold text-slate-700">{formatTime(item.occurred_at)}</p>
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1 flex flex-wrap items-center gap-2">
+                    <p className="truncate text-sm font-semibold text-slate-900">{item.headline}</p>
+                    <span className={`inline-flex rounded-full px-2 py-0.5 text-[10px] font-bold ${familyBadgeClasses(item.event_family)}`}>
+                      {familyLabel(item.event_family)}
+                    </span>
+                  </div>
+                  {toFeedSubline(item) && (
+                    <p className="truncate text-xs text-slate-500">{toFeedSubline(item)}</p>
+                  )}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/escola-admin/useAdminActivityFeed.ts
+++ b/apps/web/src/components/layout/escola-admin/useAdminActivityFeed.ts
@@ -1,0 +1,117 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { ActivityFeedItem } from "@/lib/admin/activityFeed";
+
+type FeedResponse = {
+  ok: boolean;
+  items: ActivityFeedItem[];
+  nextCursor: string | null;
+};
+
+type RealtimeState = "live" | "polling";
+
+const POLLING_MS = 15_000;
+const WS_TIMEOUT_MS = 12_000;
+
+export function useAdminActivityFeed(escolaId: string, limit = 20) {
+  const supabase = createClient();
+  const [items, setItems] = useState<ActivityFeedItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [realtimeState, setRealtimeState] = useState<RealtimeState>("live");
+  const pollingRef = useRef<NodeJS.Timeout | null>(null);
+  const wsTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const feedUrl = useMemo(
+    () => `/api/escola/${escolaId}/admin/activity-feed?limit=${Math.min(Math.max(limit, 1), 50)}`,
+    [escolaId, limit]
+  );
+
+  const fetchBootstrap = useCallback(async () => {
+    try {
+      const res = await fetch(feedUrl, { cache: "no-store" });
+      const json: FeedResponse = await res.json();
+      if (!res.ok || !json.ok) throw new Error("Falha ao carregar feed");
+      setItems(json.items ?? []);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Falha ao carregar feed");
+    } finally {
+      setLoading(false);
+    }
+  }, [feedUrl]);
+
+  const pollIncremental = useCallback(async () => {
+    await fetchBootstrap();
+  }, [fetchBootstrap]);
+
+  useEffect(() => {
+    void fetchBootstrap();
+  }, [fetchBootstrap]);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel(`admin-activity-${escolaId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "admin_activity_events",
+          filter: `escola_id=eq.${escolaId}`,
+        },
+        () => {
+          setRealtimeState("live");
+          if (wsTimeoutRef.current) clearTimeout(wsTimeoutRef.current);
+          wsTimeoutRef.current = setTimeout(() => setRealtimeState("polling"), WS_TIMEOUT_MS);
+          void fetchBootstrap();
+        }
+      )
+      .subscribe((status) => {
+        if (status === "SUBSCRIBED") {
+          setRealtimeState("live");
+          if (wsTimeoutRef.current) clearTimeout(wsTimeoutRef.current);
+          wsTimeoutRef.current = setTimeout(() => setRealtimeState("polling"), WS_TIMEOUT_MS);
+          return;
+        }
+        if (status === "CHANNEL_ERROR" || status === "TIMED_OUT" || status === "CLOSED") {
+          setRealtimeState("polling");
+        }
+      });
+
+    return () => {
+      if (wsTimeoutRef.current) clearTimeout(wsTimeoutRef.current);
+      supabase.removeChannel(channel);
+    };
+  }, [escolaId, fetchBootstrap, supabase]);
+
+  useEffect(() => {
+    if (realtimeState !== "polling") {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+      return;
+    }
+
+    pollingRef.current = setInterval(() => {
+      void pollIncremental();
+    }, POLLING_MS);
+
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+    };
+  }, [pollIncremental, realtimeState]);
+
+  return {
+    items,
+    loading,
+    error,
+    realtimeState,
+  };
+}

--- a/apps/web/src/lib/admin/activityFeed.ts
+++ b/apps/web/src/lib/admin/activityFeed.ts
@@ -1,0 +1,54 @@
+export type ActivityFamily = "financeiro" | "academico" | "documentos" | "secretaria" | "operacional";
+
+export type ActivityFeedItem = {
+  id: string;
+  escola_id: string;
+  occurred_at: string;
+  event_family: ActivityFamily;
+  event_type: string;
+  actor_name: string | null;
+  headline: string;
+  subline: string | null;
+  amount_kz: number | null;
+  turma_nome: string | null;
+  aluno_nome: string | null;
+  payload: Record<string, unknown>;
+};
+
+export function familyLabel(family: string): string {
+  switch (family) {
+    case "financeiro":
+      return "Financeiro";
+    case "academico":
+      return "Académico";
+    case "documentos":
+      return "Documentos";
+    case "secretaria":
+      return "Secretaria";
+    default:
+      return "Operacional";
+  }
+}
+
+export function familyBadgeClasses(family: string): string {
+  switch (family) {
+    case "financeiro":
+      return "bg-emerald-50 text-emerald-700";
+    case "academico":
+      return "bg-blue-50 text-blue-700";
+    case "documentos":
+      return "bg-purple-50 text-purple-700";
+    case "secretaria":
+      return "bg-amber-50 text-amber-700";
+    default:
+      return "bg-slate-100 text-slate-600";
+  }
+}
+
+export function toFeedSubline(item: ActivityFeedItem): string | null {
+  const actor = item.actor_name?.trim();
+  if (item.subline?.trim()) return item.subline;
+  if (item.aluno_nome?.trim()) return item.aluno_nome;
+  if (item.turma_nome?.trim()) return item.turma_nome;
+  return actor ? `Por ${actor}` : null;
+}

--- a/supabase/migrations/20261219110000_admin_activity_feed.sql
+++ b/supabase/migrations/20261219110000_admin_activity_feed.sql
@@ -1,0 +1,194 @@
+-- Admin operational activity feed (append-only)
+create table if not exists public.admin_activity_events (
+  id uuid primary key default gen_random_uuid(),
+  escola_id uuid not null references public.escolas(id) on delete cascade,
+  occurred_at timestamptz not null default now(),
+  event_type text not null,
+  event_family text not null,
+  actor_id uuid null,
+  actor_role text null,
+  entity_type text null,
+  entity_id text null,
+  payload jsonb not null default '{}'::jsonb,
+  source_audit_log_id bigint null references public.audit_logs(id) on delete set null,
+  dedupe_key text null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_admin_activity_events_escola_occurred_desc
+  on public.admin_activity_events (escola_id, occurred_at desc, id desc);
+
+create index if not exists idx_admin_activity_events_escola_family_occurred
+  on public.admin_activity_events (escola_id, event_family, occurred_at desc);
+
+create unique index if not exists ux_admin_activity_events_dedupe
+  on public.admin_activity_events (escola_id, dedupe_key)
+  where dedupe_key is not null;
+
+alter table public.admin_activity_events enable row level security;
+
+create policy admin_activity_events_select_policy
+  on public.admin_activity_events
+  for select
+  using (public.is_escola_member(escola_id) or public.is_escola_admin(escola_id));
+
+create or replace function public.map_admin_activity_family(p_action text)
+returns text
+language sql
+immutable
+as $$
+  select case
+    when upper(coalesce(p_action, '')) in (
+      'PAGAMENTO_REGISTRADO','PAGAMENTO_CONCILIADO','RECIBO_EMITIDO','VENDA_AVULSA_REGISTRADA',
+      'FECHO_DECLARADO','FECHO_CAIXA_ABERTO','FECHO_CAIXA_FECHADO','FECHO_CAIXA_APROVADO','FECHO_CAIXA_REPROVADO',
+      'ESTORNO_REGISTRADO','ESTORNO_APROVADO','ESTORNO_REJEITADO'
+    ) then 'financeiro'
+    when upper(coalesce(p_action, '')) in (
+      'NOTA_LANCADA_BATCH','PAUTA_FECHADA','FREQUENCIA_FECHADA','FREQUENCIA_LANCADA_BATCH',
+      'AVALIACAO_CRIADA','AVALIACAO_EDITADA'
+    ) then 'academico'
+    when upper(coalesce(p_action, '')) in ('DOCUMENTO_EMITIDO') then 'documentos'
+    when upper(coalesce(p_action, '')) like 'MATRICULA_%'
+      or upper(coalesce(p_action, '')) like 'ADMISSAO_%'
+      or upper(coalesce(p_action, '')) in ('CANDIDATURA_CRIADA','TURMAS_GERADAS_FROM_CURRICULO')
+    then 'secretaria'
+    else 'operacional'
+  end;
+$$;
+
+create or replace function public.ingest_admin_activity_event_from_audit()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_action text := upper(coalesce(new.action, new.acao, ''));
+  v_details jsonb := coalesce(new.details, new.meta, '{}'::jsonb);
+  v_payload jsonb;
+  v_dedupe_key text;
+  v_critical boolean := false;
+begin
+  if new.escola_id is null then
+    return new;
+  end if;
+
+  if v_action = '' then
+    return new;
+  end if;
+
+  if not (
+    v_action in (
+      'PAGAMENTO_REGISTRADO','PAGAMENTO_CONCILIADO','RECIBO_EMITIDO','VENDA_AVULSA_REGISTRADA',
+      'NOTA_LANCADA_BATCH','PAUTA_FECHADA','FREQUENCIA_FECHADA','FREQUENCIA_LANCADA_BATCH',
+      'DOCUMENTO_EMITIDO','CANDIDATURA_CRIADA','TURMAS_GERADAS_FROM_CURRICULO',
+      'MATRICULA_MASSA','MATRICULA_MASSA_TURMA','MATRICULA_STATUS_ATUALIZADO','MATRICULA_TRANSFERIDA',
+      'ADMISSAO_CONVERTIDA_MATRICULA','ADMISSION_RESERVED_48H'
+    )
+    or v_action like 'MATRICULA_%'
+    or v_action like 'ADMISSAO_%'
+    or v_action like 'FECHO_CAIXA_%'
+  ) then
+    return new;
+  end if;
+
+  v_critical := v_action in ('ESTORNO_REGISTRADO','ESTORNO_APROVADO','ESTORNO_REJEITADO')
+    or v_action like 'SNAPSHOT_%';
+
+  v_payload := jsonb_strip_nulls(
+    coalesce(v_details, '{}'::jsonb)
+    || jsonb_build_object(
+      'aluno_id', coalesce(v_details->>'aluno_id', v_details#>>'{aluno,id}'),
+      'turma_id', coalesce(v_details->>'turma_id', v_details#>>'{turma,id}'),
+      'periodo_id', coalesce(v_details->>'periodo_id', v_details#>>'{periodo,id}'),
+      'tipo_documento', coalesce(v_details->>'tipo_documento', v_details->>'documento', v_details->>'documento_nome'),
+      'mes_referencia', coalesce(v_details->>'mes_referencia', v_details->>'referencia'),
+      'critical', v_critical
+    )
+  );
+
+  v_dedupe_key := concat_ws(
+    ':',
+    v_action,
+    coalesce(new.actor_id::text, 'anon'),
+    coalesce(v_payload->>'aluno_id', ''),
+    coalesce(v_payload->>'turma_id', ''),
+    coalesce(v_payload->>'mes_referencia', ''),
+    to_char(date_trunc('minute', coalesce(new.created_at, now())), 'YYYYMMDDHH24MI')
+  );
+
+  insert into public.admin_activity_events (
+    escola_id,
+    occurred_at,
+    event_type,
+    event_family,
+    actor_id,
+    actor_role,
+    entity_type,
+    entity_id,
+    payload,
+    source_audit_log_id,
+    dedupe_key
+  ) values (
+    new.escola_id,
+    coalesce(new.created_at, now()),
+    v_action,
+    public.map_admin_activity_family(v_action),
+    new.actor_id,
+    new.actor_role,
+    coalesce(new.entity, new.tabela),
+    coalesce(new.entity_id, new.registro_id),
+    left(v_payload::text, 2000)::jsonb,
+    new.id,
+    v_dedupe_key
+  )
+  on conflict (escola_id, dedupe_key)
+  where dedupe_key is not null
+  do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_ingest_admin_activity_events_from_audit on public.audit_logs;
+create trigger trg_ingest_admin_activity_events_from_audit
+after insert on public.audit_logs
+for each row
+execute function public.ingest_admin_activity_event_from_audit();
+
+create or replace view public.vw_admin_activity_feed_enriched as
+select
+  e.id,
+  e.escola_id,
+  e.occurred_at,
+  e.event_family,
+  e.event_type,
+  coalesce(nullif(p.nome, ''), nullif((au.raw_user_meta_data->>'full_name'), ''), 'Sistema') as actor_name,
+  coalesce(
+    nullif(e.payload->>'headline', ''),
+    case
+      when e.event_type = 'PAGAMENTO_REGISTRADO' then 'Pagamento confirmado'
+      when e.event_type = 'NOTA_LANCADA_BATCH' then 'Lançamento de notas concluído'
+      when e.event_type = 'DOCUMENTO_EMITIDO' then 'Documento emitido'
+      when e.event_type like 'MATRICULA_%' then 'Actualização de matrícula'
+      when e.event_type like 'ADMISSAO_%' then 'Actualização de admissão'
+      else initcap(replace(lower(e.event_type), '_', ' '))
+    end
+  ) as headline,
+  coalesce(
+    nullif(e.payload->>'subline', ''),
+    e.payload->>'turma_nome',
+    e.payload->>'aluno_nome',
+    e.payload->>'documento_nome'
+  ) as subline,
+  nullif(e.payload->>'valor_numeric', '')::numeric(14,2) as amount_kz,
+  nullif(coalesce(e.payload->>'turma_nome', t.nome), '') as turma_nome,
+  nullif(coalesce(e.payload->>'aluno_nome', a.nome_completo, a.nome), '') as aluno_nome,
+  e.payload
+from public.admin_activity_events e
+left join public.profiles p on p.id = e.actor_id
+left join auth.users au on au.id = e.actor_id
+left join public.alunos a on a.id::text = coalesce(e.payload->>'aluno_id', e.entity_id)
+left join public.turmas t on t.id::text = coalesce(e.payload->>'turma_id', e.payload#>>'{turma,id}');
+
+grant select on public.vw_admin_activity_feed_enriched to authenticated;


### PR DESCRIPTION
### Motivation
- Dar à Home do Admin uma fonte de verdade de eventos operacionais (pagamentos, lançamentos de notas, documentos, matrículas, etc.) para eliminar os arrays vazios e permitir UI, realtime e agrupamento consistentes. 
- Ingerir automaticamente eventos já gravados em `audit_logs` para minimizar refactor de endpoints existentes e reduzir risco de perda de informação.
- Garantir segurança multitenant com RLS e performance (índices, view enriquecida, keyset pagination). 

### Description
- Banco: adicionada migration com a tabela append-only `public.admin_activity_events`, índices obrigatórios e RLS de leitura por membro/admin; função `map_admin_activity_family`, trigger de ingestão `trg_ingest_admin_activity_events_from_audit` e view de leitura enriquecida `vw_admin_activity_feed_enriched` para consumo UI (file: `supabase/migrations/20261219110000_admin_activity_feed.sql`).
- API: novo endpoint `GET /api/escola/[id]/admin/activity-feed` com `dynamic = "force-dynamic"`, `revalidate = 0`, tenant resolution via `resolveEscolaIdForUser`, role guard via `requireRoleInSchool`, keyset pagination por `(occurred_at,id)`, filtro por `families` e `limit` capado a 50 (file: `apps/web/src/app/api/escola/[id]/admin/activity-feed/route.ts`).
- Cliente / realtime: `useAdminActivityFeed` hook que faz bootstrap via API, subscreve `postgres_changes` em `admin_activity_events` e usa polling fallback quando o canal degrada (file: `apps/web/src/components/layout/escola-admin/useAdminActivityFeed.ts`).
- UI: novo componente `OperationalFeedSection` com loading/empty/degraded states, badges por família e CTA para histórico (file: `apps/web/src/components/layout/escola-admin/OperationalFeedSection.tsx`).
- Integração: substituído o antigo card de eventos pela nova `OperationalFeedSection` no dashboard admin e removida a prop `events` do fluxo server -> client (files: `apps/web/src/components/layout/escola-admin/EscolaAdminDashboardContent.tsx`, `apps/web/src/components/layout/escola-admin/EscolaAdminDashboardData.tsx`).
- Utilitários: tipagem e helpers de apresentação em `apps/web/src/lib/admin/activityFeed.ts`.

### Testing
- Executado `pnpm -C apps/web lint` e o lint retornou com os warnings preexistentes (não introduzidos por esta PR) e nenhuma nova falha de lint blocking. (pass)
- Executado `pnpm -C apps/web exec tsc --noEmit` para verificação de tipos e sem erros (pass).
- Tentativa automatizada de captura de tela via Playwright falhou por crash do Chromium no container (SIGSEGV) durante a execução do browser, portanto não houve screenshot de validação visual (fail — infra do runner, não do código).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b2ca962e7483269b5c41f09bb0534d)