### PR TITLE
fix(landing): avoid scroll lock when snap has only one section

### DIFF
--- a/apps/landing/app/hooks/useSnapScroll.ts
+++ b/apps/landing/app/hooks/useSnapScroll.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 export function useSnapScroll(sectionSelector = '.snap-section') {
   useEffect(() => {
     const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector))
-    if (sections.length === 0) return
+    if (sections.length < 2) return
 
     let isLocked = false
     let touchStartY = 0


### PR DESCRIPTION
### Motivation
- The landing page used a snap-scroll hook that intercepted wheel events even when there was only one `.snap-section`, preventing normal scrolling and making the page appear broken.

### Description
- Updated `useSnapScroll` to return early when fewer than two snap sections are present by changing the guard to `if (sections.length < 2) return` in `apps/landing/app/hooks/useSnapScroll.ts`, so the wheel interception logic is not attached on single-section pages.

### Testing
- `npm --prefix apps/landing run build` succeeded and produced a working production build.
- Development server was started with `npm --prefix apps/landing run dev` and a Playwright script validated scrolling (observed `before=0` → `after=200`) and produced a screenshot `artifacts/landing-scroll-fix.png`.
- `npm --prefix apps/landing run lint` failed due to missing `eslint.config.*` in the `apps/landing` package (tooling/config issue unrelated to this fix).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c524ecf083268efbcd0d599bfeee)