### PR TITLE
fix(landing): restore natural page scrolling by removing mandatory snap

### DIFF
--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -30,8 +30,8 @@
   --snap-offset:96px;
 }
 html,body{height:100%}
-html{scroll-behavior:smooth;scroll-snap-type:y mandatory;scroll-padding-top:var(--snap-offset)}
-body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;scroll-snap-type:y mandatory;touch-action:pan-y}
+html{scroll-behavior:smooth;scroll-padding-top:var(--snap-offset)}
+body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;touch-action:pan-y}
 body::after{content:'';position:fixed;inset:0;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
 .z{position:relative;z-index:1}
 .container{max-width:1120px;margin:0 auto;padding:0 24px}


### PR DESCRIPTION
### Motivation
- The landing page used a global `scroll-snap-type: y mandatory` which forced strict snap behaviour across the whole document and caused the UX issue where the page appeared not to scroll naturally.

### Description
- Removed the global `scroll-snap-type: y mandatory` from `html` and `body` in `apps/landing/app/globals.css` while keeping `scroll-behavior: smooth` and `scroll-padding-top: var(--snap-offset)` so anchor offset and smooth scrolling remain.

### Testing
- Ran `pnpm -C apps/landing build` which completed successfully (static pages generated) and produced a visual screenshot after the change; `pnpm -C apps/landing lint` failed in this environment due to missing ESLint v9 `eslint.config.*` in the landing workspace (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80a862178832680523ad45d920b65)