### PR TITLE
Refine snap-scrolling behavior and update global snap CSS

### DIFF
--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -31,11 +31,12 @@
 }
 html,body{height:100%}
 html{scroll-behavior:smooth;scroll-snap-type:y mandatory;scroll-padding-top:var(--snap-offset)}
-body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;scroll-snap-type:y mandatory;touch-action:pan-y}
+body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;touch-action:pan-y}
 body::after{content:'';position:fixed;inset:0;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
 .z{position:relative;z-index:1}
 .container{max-width:1120px;margin:0 auto;padding:0 24px}
-.snap-section{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset);min-height:100vh}
+section,footer{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset)}
+.snap-section{min-height:100vh}
 
 /* ── URGENCY BAR ─────────────────────────────────────────── */
 .ubar{background:var(--g);padding:10px 0;text-align:center;position:relative;z-index:200}

--- a/apps/landing/app/hooks/useSnapScroll.ts
+++ b/apps/landing/app/hooks/useSnapScroll.ts
@@ -1,33 +1,38 @@
 import { useEffect } from 'react'
 
-export function useSnapScroll(sectionSelector = '.snap-section') {
+export function useSnapScroll(sectionSelector = 'section, footer') {
   useEffect(() => {
-    const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector))
+    const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector)).filter(
+      (section) => section.offsetHeight > 0
+    )
+
     if (sections.length < 2) return
+    if (window.matchMedia('(pointer: coarse)').matches) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
 
     let isLocked = false
-    let touchStartY = 0
-    let scrollTimeout: number | undefined
     let lockUntil = 0
-    const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches
-    const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+    let scrollTimeout: number | undefined
+    let wheelAccumulator = 0
 
     const scrollToIndex = (index: number) => {
       const target = sections[Math.max(0, Math.min(sections.length - 1, index))]
       if (!target) return
       isLocked = true
-      lockUntil = Date.now() + 900
+      lockUntil = Date.now() + 820
       target.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
 
     const getCurrentIndex = () => {
-      const scrollTop = window.scrollY + window.innerHeight * 0.25
+      const scrollTop = window.scrollY + window.innerHeight * 0.35
       let currentIndex = 0
+
       sections.forEach((section, index) => {
         if (section.offsetTop <= scrollTop) {
           currentIndex = index
         }
       })
+
       return currentIndex
     }
 
@@ -36,34 +41,41 @@ export function useSnapScroll(sectionSelector = '.snap-section') {
       scrollTimeout = window.setTimeout(() => {
         if (Date.now() >= lockUntil) {
           isLocked = false
+          wheelAccumulator = 0
         }
-      }, 520)
+      }, 420)
     }
 
     const handleWheel = (event: WheelEvent) => {
-      if (isLocked) return
-      if (Math.abs(event.deltaY) < 10) return
+      if (event.ctrlKey) return
+      if (isLocked) {
+        event.preventDefault()
+        return
+      }
+
+      wheelAccumulator += event.deltaY
+      if (Math.abs(wheelAccumulator) < 30) return
+
       event.preventDefault()
       const currentIndex = getCurrentIndex()
-      const direction = event.deltaY > 0 ? 1 : -1
+      const direction = wheelAccumulator > 0 ? 1 : -1
+      wheelAccumulator = 0
       scrollToIndex(currentIndex + direction)
     }
 
     const handleScroll = () => {
-      if (!isLocked) return
-      releaseLock()
+      if (isLocked) {
+        releaseLock()
+      }
     }
 
-    if (!isCoarsePointer && isLocalhost) {
-      window.addEventListener('wheel', handleWheel, { passive: false })
-      window.addEventListener('scroll', handleScroll, { passive: true })
-    }
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    window.addEventListener('scroll', handleScroll, { passive: true })
 
     return () => {
-      if (!isCoarsePointer && isLocalhost) {
-        window.removeEventListener('wheel', handleWheel)
-        window.removeEventListener('scroll', handleScroll)
-      }
+      window.removeEventListener('wheel', handleWheel)
+      window.removeEventListener('scroll', handleScroll)
+      if (scrollTimeout) window.clearTimeout(scrollTimeout)
     }
   }, [sectionSelector])
 }


### PR DESCRIPTION
### Motivation
- Make snap-scroll behavior more robust and consistent across sections and devices by adjusting CSS snap targets and tightening wheel handling in the scroll hook. 
- Reduce accidental or overly-sensitive snap triggers while keeping smooth, keyboard-free section navigation. 

### Description
- Move scroll snap alignment from a single `.snap-section` selector to `section` and `footer` and simplify `.snap-section` to only enforce `min-height:100vh` while removing duplicate `scroll-snap-type` from `body`. 
- Change the default selector used by `useSnapScroll` to `section, footer` and ignore zero-height sections. 
- Add early returns for coarse pointers and `prefers-reduced-motion`, tighten lock timing and thresholds (lock shortened to `820ms`, release timeout to `420ms`, detection offset increased to `innerHeight * 0.35`), and add a `wheelAccumulator` to debounce small wheel events and ignore `ctrl+wheel` zoom gestures. 
- Always attach the wheel/scroll listeners (with proper cleanup) and reset accumulators on lock release to avoid stale state. 

### Testing
- Ran the repository build and typecheck (`pnpm build`) and the run-time type checks, which completed successfully. 
- Executed the automated unit tests (`pnpm test`) covering the hook and UI utilities, and they passed. 
- Performed automated linting (`pnpm lint`) which reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80a862178832680523ad45d920b65)