### PR TITLE
Enable mobile snap for pricing cards and refine global snap-scroll behavior

### DIFF
--- a/apps/landing/app/components/landing/sections/PricingSection.tsx
+++ b/apps/landing/app/components/landing/sections/PricingSection.tsx
@@ -50,7 +50,7 @@ export function PricingSection({ intro, note, appUrl }: PricingSectionProps) {
           </h2>
           <p className="precos-intro">{intro}</p>
         </div>
-        <div className="precos-grid precos-grid-dark">
+        <div className="precos-grid precos-grid-dark precos-grid-mobile-snap">
           {pricingPlans.map((plan) => {
             const variant = variants[plan.slug]
             const planHref = resolveHref(plan.ctaHref)

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -31,11 +31,12 @@
 }
 html,body{height:100%}
 html{scroll-behavior:smooth;scroll-snap-type:y mandatory;scroll-padding-top:var(--snap-offset)}
-body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;scroll-snap-type:y mandatory;touch-action:pan-y}
+body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;touch-action:pan-y}
 body::after{content:'';position:fixed;inset:0;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
 .z{position:relative;z-index:1}
 .container{max-width:1120px;margin:0 auto;padding:0 24px}
-.snap-section{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset);min-height:100vh}
+section,footer{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset)}
+.snap-section{min-height:100vh}
 
 /* ── URGENCY BAR ─────────────────────────────────────────── */
 .ubar{background:var(--g);padding:10px 0;text-align:center;position:relative;z-index:200}

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -30,8 +30,8 @@
   --snap-offset:96px;
 }
 html,body{height:100%}
-html{scroll-behavior:smooth;scroll-snap-type:y mandatory;scroll-padding-top:var(--snap-offset)}
-body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;scroll-snap-type:y mandatory;touch-action:pan-y}
+html{scroll-behavior:smooth;scroll-padding-top:var(--snap-offset)}
+body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;touch-action:pan-y}
 body::after{content:'';position:fixed;inset:0;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
 .z{position:relative;z-index:1}
 .container{max-width:1120px;margin:0 auto;padding:0 24px}

--- a/apps/landing/app/globals.css
+++ b/apps/landing/app/globals.css
@@ -31,11 +31,12 @@
 }
 html,body{height:100%}
 html{scroll-behavior:smooth;scroll-snap-type:y mandatory;scroll-padding-top:var(--snap-offset)}
-body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;scroll-snap-type:y mandatory;touch-action:pan-y}
+body{font-family:'Manrope',sans-serif;background:var(--bg);color:var(--t1);overflow-x:hidden;overflow-y:auto;-webkit-font-smoothing:antialiased;touch-action:pan-y}
 body::after{content:'';position:fixed;inset:0;background-image:url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.02'/%3E%3C/svg%3E");pointer-events:none;z-index:0}
 .z{position:relative;z-index:1}
 .container{max-width:1120px;margin:0 auto;padding:0 24px}
-.snap-section{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset);min-height:100vh}
+section,footer{scroll-snap-align:start;scroll-snap-stop:always;scroll-margin-top:var(--snap-offset)}
+.snap-section{min-height:100vh}
 
 /* ── URGENCY BAR ─────────────────────────────────────────── */
 .ubar{background:var(--g);padding:10px 0;text-align:center;position:relative;z-index:200}
@@ -446,6 +447,7 @@ footer{padding:40px 0;border-top:1px solid var(--bd)}
 /* ── RESPONSIVE ──────────────────────────────────────────── */
 @media(max-width:900px){
   :root{--snap-offset:112px}
+  html{scroll-snap-type:y proximity}
   .hero-grid,.feat-panel,.oferta-grid,.dep-grid,.precos-grid,.portais-top,.portais-bottom{grid-template-columns:1fr}
   .steps,.num-grid{grid-template-columns:1fr 1fr}
   .problema-grid,.faq-grid{grid-template-columns:1fr}
@@ -457,6 +459,8 @@ footer{padding:40px 0;border-top:1px solid var(--bd)}
   .product-features{grid-template-columns:1fr 1fr}
   .product-steps{grid-template-columns:1fr}
   .precos-grid{grid-template-columns:1fr}
+  .precos-grid-mobile-snap{max-height:calc(100svh - var(--snap-offset) - 8px);overflow-y:auto;overscroll-behavior-y:contain;scroll-snap-type:y mandatory;padding-right:4px}
+  .precos-grid-mobile-snap .pricing-card{min-height:calc(100svh - var(--snap-offset) - 24px);max-height:calc(100svh - var(--snap-offset) - 24px);overflow-y:auto;scroll-snap-align:start;scroll-snap-stop:always}
 }
 @media(max-width:600px){
   :root{--snap-offset:124px}

--- a/apps/landing/app/hooks/useSnapScroll.ts
+++ b/apps/landing/app/hooks/useSnapScroll.ts
@@ -3,7 +3,7 @@ import { useEffect } from 'react'
 export function useSnapScroll(sectionSelector = '.snap-section') {
   useEffect(() => {
     const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector))
-    if (sections.length === 0) return
+    if (sections.length < 2) return
 
     let isLocked = false
     let touchStartY = 0

--- a/apps/landing/app/hooks/useSnapScroll.ts
+++ b/apps/landing/app/hooks/useSnapScroll.ts
@@ -1,33 +1,38 @@
 import { useEffect } from 'react'
 
-export function useSnapScroll(sectionSelector = '.snap-section') {
+export function useSnapScroll(sectionSelector = 'section, footer') {
   useEffect(() => {
-    const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector))
+    const sections = Array.from(document.querySelectorAll<HTMLElement>(sectionSelector)).filter(
+      (section) => section.offsetHeight > 0
+    )
+
     if (sections.length < 2) return
+    if (window.matchMedia('(pointer: coarse)').matches) return
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return
 
     let isLocked = false
-    let touchStartY = 0
-    let scrollTimeout: number | undefined
     let lockUntil = 0
-    const isCoarsePointer = window.matchMedia('(pointer: coarse)').matches
-    const isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1'
+    let scrollTimeout: number | undefined
+    let wheelAccumulator = 0
 
     const scrollToIndex = (index: number) => {
       const target = sections[Math.max(0, Math.min(sections.length - 1, index))]
       if (!target) return
       isLocked = true
-      lockUntil = Date.now() + 900
+      lockUntil = Date.now() + 820
       target.scrollIntoView({ behavior: 'smooth', block: 'start' })
     }
 
     const getCurrentIndex = () => {
-      const scrollTop = window.scrollY + window.innerHeight * 0.25
+      const scrollTop = window.scrollY + window.innerHeight * 0.35
       let currentIndex = 0
+
       sections.forEach((section, index) => {
         if (section.offsetTop <= scrollTop) {
           currentIndex = index
         }
       })
+
       return currentIndex
     }
 
@@ -36,34 +41,41 @@ export function useSnapScroll(sectionSelector = '.snap-section') {
       scrollTimeout = window.setTimeout(() => {
         if (Date.now() >= lockUntil) {
           isLocked = false
+          wheelAccumulator = 0
         }
-      }, 520)
+      }, 420)
     }
 
     const handleWheel = (event: WheelEvent) => {
-      if (isLocked) return
-      if (Math.abs(event.deltaY) < 10) return
+      if (event.ctrlKey) return
+      if (isLocked) {
+        event.preventDefault()
+        return
+      }
+
+      wheelAccumulator += event.deltaY
+      if (Math.abs(wheelAccumulator) < 30) return
+
       event.preventDefault()
       const currentIndex = getCurrentIndex()
-      const direction = event.deltaY > 0 ? 1 : -1
+      const direction = wheelAccumulator > 0 ? 1 : -1
+      wheelAccumulator = 0
       scrollToIndex(currentIndex + direction)
     }
 
     const handleScroll = () => {
-      if (!isLocked) return
-      releaseLock()
+      if (isLocked) {
+        releaseLock()
+      }
     }
 
-    if (!isCoarsePointer && isLocalhost) {
-      window.addEventListener('wheel', handleWheel, { passive: false })
-      window.addEventListener('scroll', handleScroll, { passive: true })
-    }
+    window.addEventListener('wheel', handleWheel, { passive: false })
+    window.addEventListener('scroll', handleScroll, { passive: true })
 
     return () => {
-      if (!isCoarsePointer && isLocalhost) {
-        window.removeEventListener('wheel', handleWheel)
-        window.removeEventListener('scroll', handleScroll)
-      }
+      window.removeEventListener('wheel', handleWheel)
+      window.removeEventListener('scroll', handleScroll)
+      if (scrollTimeout) window.clearTimeout(scrollTimeout)
     }
   }, [sectionSelector])
 }


### PR DESCRIPTION
### Motivation

- Improve mobile UX for the pricing grid by enabling vertical snap/scroll per card so each pricing card is presented full-screen on small viewports. 
- Make global snap-scroll logic more robust across environments and pointer types, and avoid noisy behavior for coarse pointers and users who prefer reduced motion.

### Description

- Add `precos-grid-mobile-snap` class to the pricing grid and CSS rules that limit height, enable per-card snapping, and make each `.pricing-card` fill the viewport for mobile.
- Move scroll-snap rules from a single `.snap-section` selector to `section, footer` and adjust `.snap-section` to preserve min-height semantics in `globals.css`.
- Adjust responsive snap behaviour by changing `html` to `scroll-snap-type: y proximity` under `@media(max-width:900px)` and add mobile-specific styling for the pricing grid and cards.
- Replace the snap-scroll hook default selector to `section, footer` and refine `useSnapScroll` to filter out zero-height sections, early-return for coarse pointers and `prefers-reduced-motion`, accumulate wheel deltas to avoid accidental triggers, ignore `ctrl+wheel`, tweak the scroll-lock timings and thresholds, and ensure proper cleanup of timers and listeners.

### Testing

- Ran TypeScript type-check (`tsc --noEmit`) against the changed files and it succeeded. 
- Built the landing app (`next build` for the landing app) to validate the CSS and hook changes and the build completed successfully. 
- Verified the updated snap behavior manually in a dev environment for desktop and mobile viewport sizes (no automated UI tests were added).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b80a862178832680523ad45d920b65)