### PR TITLE
Add marketing homepage, SEO metadata, sitemap and robots; mark /login non-indexable

### DIFF
--- a/agents/outputs/APPLY_DIFF_4d5fca98-8b6f-46bb-ad3d-244f8a7dca51.md
+++ b/agents/outputs/APPLY_DIFF_4d5fca98-8b6f-46bb-ad3d-244f8a7dca51.md
@@ -1,0 +1,11 @@
+# Apply Diff
+run_id: 4d5fca98-8b6f-46bb-ad3d-244f8a7dca51
+timestamp: 2026-03-18T12:38:07Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/(auth)/login/page.tsx
+
+## Planned changes
+- Revert the mistaken public landing page from the app root back to the transactional redirect flow.
+- Mark the login page as non-indexable so the app domain does not compete with the public marketing site in search.

--- a/agents/outputs/APPLY_DIFF_813eaf6c-2745-49f9-8615-fa37f49e884d.md
+++ b/agents/outputs/APPLY_DIFF_813eaf6c-2745-49f9-8615-fa37f49e884d.md
@@ -1,0 +1,12 @@
+# Apply Diff
+run_id: 813eaf6c-2745-49f9-8615-fa37f49e884d
+timestamp: 2026-03-18T13:02:55Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/sitemap.ts
+- apps/web/src/app/robots.ts
+
+## Planned changes
+- Add sitemap and robots metadata routes for the public landing and public auth pages.
+- Extend the landing with JSON-LD for Organization and SoftwareApplication plus the correct OG/social image references.

--- a/agents/outputs/APPLY_DIFF_8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2.md
+++ b/agents/outputs/APPLY_DIFF_8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2.md
@@ -1,0 +1,11 @@
+# Apply Diff
+run_id: 8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2
+timestamp: 2026-03-18T12:59:05Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/(auth)/login/page.tsx
+
+## Planned changes
+- Replace the root redirect with a keyword-aligned public homepage whose visible copy matches the commercial SEO targets.
+- Keep /login non-indexable and rewrite its metadata to position it as a secondary access page, not an acquisition page.

--- a/agents/outputs/APPLY_DIFF_98a2531c-b26e-47cf-b29b-0f44ba6980e1.md
+++ b/agents/outputs/APPLY_DIFF_98a2531c-b26e-47cf-b29b-0f44ba6980e1.md
@@ -1,0 +1,10 @@
+# Apply Diff
+run_id: 98a2531c-b26e-47cf-b29b-0f44ba6980e1
+timestamp: 2026-03-18T12:53:37Z
+
+## Target
+- apps/web/src/app/layout.tsx
+
+## Planned changes
+- Export typed Next.js metadata from the root layout with metadataBase, commercial titles, SEO description, canonical, Open Graph and Twitter fields.
+- Remove from <head> the tags already covered by the Metadata API, keeping only the manifest link and optional font stylesheet.

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -2,8 +2,12 @@ import BrandPanel from "./BrandPanel";
 import LoginForm from "./LoginForm";
 
 export const metadata = {
-  title: "Login • Klasse",
-  description: "Acesse sua conta Klasse.",
+  title: "Área de acesso KLASSE",
+  description: "Página de login da KLASSE para clientes e equipas já ativas. Esta rota é secundária na aquisição e não compete com a homepage comercial.",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function LoginPage() {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,17 +1,60 @@
+import type { Metadata } from "next";
+
 import "./globals.css";
-import { ServiceWorkerRegister } from "@/components/system/ServiceWorkerRegister";
-import { OfflineSyncRegister } from "@/components/system/OfflineSyncRegister";
 import { ToastProvider } from "@/components/feedback/FeedbackSystem";
+import { OfflineSyncRegister } from "@/components/system/OfflineSyncRegister";
+import { ServiceWorkerRegister } from "@/components/system/ServiceWorkerRegister";
 
 const shouldLoadGoogleFonts = process.env.NEXT_FONT_GOOGLE_FONTS_DISABLE !== "1";
+const marketingSiteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const metadataBase = new URL(marketingSiteUrl);
+const socialImage = {
+  url: "/new.PNG",
+  width: 1536,
+  height: 1024,
+  alt: "KLASSE — sistema de gestão escolar em Angola",
+};
+
+export const metadata: Metadata = {
+  metadataBase,
+  title: {
+    default: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    template: "%s | KLASSE",
+  },
+  description:
+    "KLASSE é um software de gestão escolar em Angola para escolas que querem controlar propinas, matrículas, notas, presenças e operação académica numa única plataforma.",
+  applicationName: "KLASSE",
+  themeColor: "#1F6B3B",
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/logo-klasse.png",
+  },
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: "/",
+    siteName: "KLASSE",
+    title: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    description:
+      "Software para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa única plataforma.",
+    images: [socialImage],
+    locale: "pt_AO",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    description:
+      "Software para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa única plataforma.",
+    images: [socialImage.url],
+  },
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt" className="h-full">
       <head>
-        <link rel="manifest" href="/manifest.json" />
-        <link rel="icon" href="/logo-klasse.png" type="image/png" />
-        <meta name="theme-color" content="#1F6B3B" />
         {shouldLoadGoogleFonts && (
           <link
             rel="stylesheet"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,15 +1,407 @@
-import { redirect } from 'next/navigation'
-import { supabaseServer } from '@/lib/supabaseServer'
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  BarChart3,
+  BookOpen,
+  CalendarCheck,
+  Check,
+  ClipboardCheck,
+  LayoutDashboard,
+  Library,
+  Shield,
+  Users,
+  UserCheck,
+  UsersRound,
+  Wallet,
+} from "lucide-react";
+
+import { supabaseServer } from "@/lib/supabaseServer";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const socialImage = `${siteUrl}/new.PNG`;
+
+export const metadata: Metadata = {
+  title: "Sistema de gestão escolar em Angola, software de gestão escolar e plataforma escolar",
+  description:
+    "KLASSE é um sistema de gestão escolar em Angola e software de gestão escolar para propinas, matrículas, notas e presenças numa plataforma escolar única.",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "KLASSE — Sistema de gestão escolar em Angola e plataforma escolar para crescer com controlo",
+    description:
+      "Software de gestão escolar para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa plataforma escolar única.",
+    url: "/",
+    images: [
+      {
+        url: socialImage,
+        width: 1536,
+        height: 1024,
+        alt: "KLASSE — sistema de gestão escolar em Angola",
+      },
+    ],
+  },
+  twitter: {
+    title: "KLASSE — Sistema de gestão escolar em Angola",
+    description:
+      "Software de gestão escolar para propinas, matrículas, notas e presenças numa plataforma escolar única.",
+    images: [socialImage],
+  },
+};
+
+const keywordBlocks = [
+  {
+    title: "Sistema de gestão escolar em Angola",
+    description:
+      "Uma operação escolar mais disciplinada para direção, secretaria, financeiro e professores, sem depender de processos manuais dispersos.",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Software de gestão escolar",
+    description:
+      "KLASSE liga fluxo académico e financeiro numa única base para escolas que precisam de controlo, rastreabilidade e execução séria.",
+    icon: Library,
+  },
+  {
+    title: "Plataforma escolar",
+    description:
+      "A plataforma escolar organiza propinas, matrículas, notas e presenças com clareza operacional para cada equipa.",
+    icon: BarChart3,
+  },
+];
+
+const productAreas = [
+  {
+    title: "Gestão de propinas",
+    description: "Cobranças, atrasos, pagamentos e visibilidade financeira sem folhas soltas.",
+    icon: Wallet,
+  },
+  {
+    title: "Matrículas",
+    description: "Admissões, vagas, rematrículas e confirmação documental num fluxo mais previsível.",
+    icon: UsersRound,
+  },
+  {
+    title: "Notas",
+    description: "Avaliações, pautas e histórico académico com menos retrabalho entre secretaria e professores.",
+    icon: ClipboardCheck,
+  },
+  {
+    title: "Presenças",
+    description: "Frequência e faltas com leitura rápida para equipa pedagógica e direção.",
+    icon: CalendarCheck,
+  },
+];
+
+const personas = [
+  {
+    title: "Direção",
+    icon: Shield,
+    items: [
+      "Mais controlo institucional sobre operação académica e financeira.",
+      "Melhor leitura de gargalos antes de virarem crise operacional.",
+    ],
+  },
+  {
+    title: "Secretaria",
+    icon: Users,
+    items: [
+      "Matrículas, documentos e histórico com menos duplicação manual.",
+      "Fluxo diário mais rápido e menos dependente de planilhas paralelas.",
+    ],
+  },
+  {
+    title: "Financeiro",
+    icon: Wallet,
+    items: [
+      "Gestão de propinas com mais previsibilidade e menos ruído operacional.",
+      "Base melhor para cobrança, reconciliação e acompanhamento de inadimplência.",
+    ],
+  },
+  {
+    title: "Professores",
+    icon: UserCheck,
+    items: [
+      "Lançamento de notas e presenças sem fricção informal com secretaria.",
+      "Turmas e disciplinas mais organizadas para a rotina pedagógica.",
+    ],
+  },
+];
+
+const faqs = [
+  {
+    question: "KLASSE é um sistema de gestão escolar em Angola?",
+    answer:
+      "Sim. A proposta comercial e o copy da homepage foram alinhados para responder diretamente à procura por sistema de gestão escolar em Angola.",
+  },
+  {
+    question: "É software de gestão escolar só para académico?",
+    answer:
+      "Não. A plataforma escolar cobre gestão de propinas, matrículas, notas e presenças, ligando operação académica e financeira.",
+  },
+  {
+    question: "O login compete com a homepage pelas mesmas keywords?",
+    answer:
+      "Não. O /login continua marcado como página secundária de acesso, com metadata não indexável para evitar canibalização.",
+  },
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      name: "KLASSE",
+      url: siteUrl,
+      logo: `${siteUrl}/logo-klasse.png`,
+      image: socialImage,
+      areaServed: {
+        "@type": "Country",
+        name: "Angola",
+      },
+      sameAs: [siteUrl],
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "KLASSE",
+      applicationCategory: "BusinessApplication",
+      applicationSubCategory: "EducationManagementSoftware",
+      operatingSystem: "Web",
+      url: siteUrl,
+      image: socialImage,
+      description:
+        "Sistema de gestão escolar em Angola para gestão de propinas, matrículas, notas e presenças numa plataforma escolar única.",
+      areaServed: {
+        "@type": "Country",
+        name: "Angola",
+      },
+      audience: {
+        "@type": "Audience",
+        geographicArea: {
+          "@type": "Country",
+          name: "Angola",
+        },
+      },
+      featureList: [
+        "Gestão de propinas",
+        "Matrículas",
+        "Notas",
+        "Presenças",
+        "Operação académica",
+        "Operação financeira",
+      ],
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "AOA",
+        availability: "https://schema.org/InStock",
+      },
+      brand: {
+        "@type": "Brand",
+        name: "KLASSE",
+      },
+    },
+  ],
+};
 
 export default async function Page() {
-  const supabase = await supabaseServer()
+  const supabase = await supabaseServer();
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser();
 
-  if (user) {
-    redirect('/redirect')
-  }
+  const appHref = user ? "/redirect" : "/login";
+  const appLabel = user ? "Entrar no painel" : "Aceder ao sistema";
 
-  redirect('/login')
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <main className="min-h-screen bg-slate-950 text-slate-100">
+        <section className="border-b border-white/10 bg-gradient-to-b from-slate-950 via-slate-950 to-klasse-green/10">
+          <div className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
+            <header className="flex flex-col gap-6 rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">KLASSE</p>
+                <p className="mt-2 max-w-2xl text-sm text-slate-300">
+                  Software de gestão escolar para escolas que querem crescer com mais controlo e menos improviso operacional.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={appHref}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-5 py-3 text-sm font-semibold text-white transition hover:brightness-95"
+                >
+                  {appLabel}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE"
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                >
+                  Pedir demo
+                </Link>
+              </div>
+            </header>
+
+            <div className="grid gap-10 py-16 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+              <div className="space-y-8">
+                <div className="inline-flex items-center rounded-full border border-klasse-gold/30 bg-klasse-gold/10 px-4 py-2 text-sm font-medium text-klasse-gold">
+                  Sistema de gestão escolar em Angola com foco comercial e execução operacional séria.
+                </div>
+                <div className="space-y-6">
+                  <h1 className="max-w-5xl text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
+                    KLASSE é o sistema de gestão escolar em Angola que funciona como software de gestão escolar e plataforma escolar para propinas, matrículas, notas e presenças.
+                  </h1>
+                  <p className="max-w-3xl text-lg leading-8 text-slate-300">
+                    Se a sua escola ainda opera com Excel, WhatsApp e confirmações manuais, você está a perder margem.
+                    KLASSE posiciona-se como plataforma escolar para dar previsibilidade à direção, velocidade à secretaria,
+                    disciplina ao financeiro e fluidez aos professores.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-4 sm:flex-row">
+                  <Link
+                    href="mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-6 py-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+                  >
+                    Pedir demo
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <Link
+                    href={appHref}
+                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-4 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                  >
+                    {appLabel}
+                  </Link>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-slate-900/80 p-6 shadow-sm">
+                <div className="flex items-center gap-3 text-klasse-gold">
+                  <BookOpen className="h-5 w-5" />
+                  <span className="text-sm font-semibold uppercase tracking-[0.24em]">Proposta comercial</span>
+                </div>
+                <div className="mt-6 space-y-4 text-sm leading-6 text-slate-300">
+                  <p>
+                    Sistema de gestão escolar em Angola para escolas privadas e equipas que precisam de mais rigor operacional.
+                  </p>
+                  <p>
+                    Software de gestão escolar com foco em propinas, matrículas, notas e presenças numa operação conectada.
+                  </p>
+                  <p>
+                    Plataforma escolar que reduz ruído entre direção, secretaria, financeiro e professores.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Intenção de pesquisa</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              Headings e copy visível alinhados com as pesquisas comerciais que queremos ganhar.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {keywordBlocks.map((block) => {
+              const Icon = block.icon;
+
+              return (
+                <article key={block.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3 text-klasse-gold">
+                    <Icon className="h-5 w-5" />
+                    <h3 className="text-xl font-semibold text-white">{block.title}</h3>
+                  </div>
+                  <p className="mt-4 text-sm leading-7 text-slate-300">{block.description}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="border-y border-white/10 bg-slate-900/60">
+          <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Módulos com intenção comercial</p>
+              <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+                O software de gestão escolar precisa mostrar claramente o que resolve.
+              </h2>
+            </div>
+
+            <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              {productAreas.map((area) => {
+                const Icon = area.icon;
+
+                return (
+                  <article key={area.title} className="rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm">
+                    <div className="flex items-center gap-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                      <h3 className="text-lg font-semibold text-white">{area.title}</h3>
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-slate-300">{area.description}</p>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Benefícios por persona</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              A homepage precisa vender para quem decide e para quem executa.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+            {personas.map((persona) => {
+              const Icon = persona.icon;
+
+              return (
+                <article key={persona.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-xl bg-klasse-green/20 p-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-white">{persona.title}</h3>
+                  </div>
+                  <ul className="mt-6 space-y-3 text-sm leading-6 text-slate-300">
+                    {persona.items.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <Check className="mt-1 h-4 w-4 flex-none text-klasse-gold" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-5xl px-6 pb-20 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">FAQ</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              FAQ para reforçar relevância e evitar canibalização entre homepage e login.
+            </h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {faqs.map((faq) => (
+              <article key={faq.question} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                <h3 className="text-lg font-semibold text-white">{faq.question}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-300">{faq.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
 }

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/login", "/forgot-password", "/reset-password", "/mudar-senha"],
+        disallow: [
+          "/admin",
+          "/secretaria",
+          "/financeiro",
+          "/professor",
+          "/aluno",
+          "/super-admin",
+          "/api",
+          "/escola",
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = [
+    { path: "/", priority: 1, changeFrequency: "weekly" as const },
+    { path: "/login", priority: 0.2, changeFrequency: "monthly" as const },
+    { path: "/forgot-password", priority: 0.1, changeFrequency: "monthly" as const },
+    { path: "/reset-password", priority: 0.1, changeFrequency: "monthly" as const },
+    { path: "/mudar-senha", priority: 0.1, changeFrequency: "monthly" as const },
+  ];
+
+  return routes.map((route) => ({
+    url: `${siteUrl}${route.path}`,
+    lastModified: new Date(),
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
+}


### PR DESCRIPTION
### Motivation

- Restore a public marketing homepage at the app root to target commercial SEO keywords instead of redirecting to the transactional app flow. 
- Prevent the `/login` route from competing with the public marketing site by marking it non-indexable and positioning it as a secondary access page. 
- Provide canonical/open graph/twitter metadata, JSON-LD, and discovery files so search engines index only the intended marketing pages. 

### Description

- Replaced the root redirect with a marketing homepage in `apps/web/src/app/page.tsx` that includes visible copy aligned to target keywords, Open Graph/Twitter metadata, JSON-LD for `Organization` and `SoftwareApplication`, and conditional CTA linking to `/redirect` or `/login` depending on auth state. 
- Exported typed Next.js `metadata` from `apps/web/src/app/layout.tsx`, added `metadataBase`, social image references, manifest and icon references, and removed duplicate `<meta>`/icon tags from `<head>` while preserving the optional Google Fonts link. 
- Updated `apps/web/src/app/(auth)/login/page.tsx` to change the title/description and set `robots: { index: false, follow: false }` so the login page is not indexed. 
- Added `apps/web/src/app/sitemap.ts` and `apps/web/src/app/robots.ts` to generate a sitemap and robots policy that expose marketing pages and hide internal/app routes. 

### Testing

- Ran a TypeScript typecheck (`pnpm -w tsc --noEmit`) to validate typings and it succeeded. 
- Performed a Next.js production build (`pnpm -w build`) to ensure pages compile and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba95620e2c8326ad719ac95d2188f4)