### PR TITLE
Marketing homepage + multi-school landing, SEO metadata, robots/sitemap, and app-login redirect

### DIFF
--- a/agents/outputs/APPLY_DIFF_06d532a1-82ca-45fc-8b60-53aeb7089cf0.md
+++ b/agents/outputs/APPLY_DIFF_06d532a1-82ca-45fc-8b60-53aeb7089cf0.md
@@ -1,0 +1,13 @@
+# Apply Diff
+run_id: 06d532a1-82ca-45fc-8b60-53aeb7089cf0
+timestamp: 2026-03-18T14:38:30Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/redes-escolares/page.tsx
+- apps/web/src/app/sitemap.ts
+
+## Planned changes
+- Reposition the homepage to sell KLASSE as the modern, disciplined option against manual and outdated school systems.
+- Add a dedicated commercial landing page for school groups/networks to execute the multi-school positioning strategy.
+- Expand the sitemap with the new commercial page.

--- a/agents/outputs/APPLY_DIFF_437126dc-1b71-4c47-adb5-f7b162331aa9.md
+++ b/agents/outputs/APPLY_DIFF_437126dc-1b71-4c47-adb5-f7b162331aa9.md
@@ -1,0 +1,14 @@
+# Apply Diff
+run_id: 437126dc-1b71-4c47-adb5-f7b162331aa9
+timestamp: 2026-03-18T15:59:51Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/redes-escolares/page.tsx
+- apps/web/src/app/(auth)/login/page.tsx
+- apps/web/src/app/robots.ts
+
+## Planned changes
+- Point commercial CTAs to the dedicated app domain and remove auth/session logic from the marketing homepage.
+- Ensure `/login` behaves as an application route on `app.klasse.ao`, redirecting away from the marketing host.
+- Tighten robots rules so the commercial host only advertises public marketing routes.

--- a/agents/outputs/APPLY_DIFF_4d5fca98-8b6f-46bb-ad3d-244f8a7dca51.md
+++ b/agents/outputs/APPLY_DIFF_4d5fca98-8b6f-46bb-ad3d-244f8a7dca51.md
@@ -1,0 +1,11 @@
+# Apply Diff
+run_id: 4d5fca98-8b6f-46bb-ad3d-244f8a7dca51
+timestamp: 2026-03-18T12:38:07Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/(auth)/login/page.tsx
+
+## Planned changes
+- Revert the mistaken public landing page from the app root back to the transactional redirect flow.
+- Mark the login page as non-indexable so the app domain does not compete with the public marketing site in search.

--- a/agents/outputs/APPLY_DIFF_813eaf6c-2745-49f9-8615-fa37f49e884d.md
+++ b/agents/outputs/APPLY_DIFF_813eaf6c-2745-49f9-8615-fa37f49e884d.md
@@ -1,0 +1,12 @@
+# Apply Diff
+run_id: 813eaf6c-2745-49f9-8615-fa37f49e884d
+timestamp: 2026-03-18T13:02:55Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/sitemap.ts
+- apps/web/src/app/robots.ts
+
+## Planned changes
+- Add sitemap and robots metadata routes for the public landing and public auth pages.
+- Extend the landing with JSON-LD for Organization and SoftwareApplication plus the correct OG/social image references.

--- a/agents/outputs/APPLY_DIFF_8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2.md
+++ b/agents/outputs/APPLY_DIFF_8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2.md
@@ -1,0 +1,11 @@
+# Apply Diff
+run_id: 8aaf60f1-6bb9-4637-a5b8-e5505ed9bea2
+timestamp: 2026-03-18T12:59:05Z
+
+## Target
+- apps/web/src/app/page.tsx
+- apps/web/src/app/(auth)/login/page.tsx
+
+## Planned changes
+- Replace the root redirect with a keyword-aligned public homepage whose visible copy matches the commercial SEO targets.
+- Keep /login non-indexable and rewrite its metadata to position it as a secondary access page, not an acquisition page.

--- a/agents/outputs/APPLY_DIFF_98a2531c-b26e-47cf-b29b-0f44ba6980e1.md
+++ b/agents/outputs/APPLY_DIFF_98a2531c-b26e-47cf-b29b-0f44ba6980e1.md
@@ -1,0 +1,10 @@
+# Apply Diff
+run_id: 98a2531c-b26e-47cf-b29b-0f44ba6980e1
+timestamp: 2026-03-18T12:53:37Z
+
+## Target
+- apps/web/src/app/layout.tsx
+
+## Planned changes
+- Export typed Next.js metadata from the root layout with metadataBase, commercial titles, SEO description, canonical, Open Graph and Twitter fields.
+- Remove from <head> the tags already covered by the Metadata API, keeping only the manifest link and optional font stylesheet.

--- a/agents/outputs/APPLY_DIFF_d9dc8757-c490-4ff1-82b2-608ba43594fc.md
+++ b/agents/outputs/APPLY_DIFF_d9dc8757-c490-4ff1-82b2-608ba43594fc.md
@@ -1,0 +1,9 @@
+# Apply Diff
+run_id: d9dc8757-c490-4ff1-82b2-608ba43594fc
+timestamp: 2026-03-18T13:54:42Z
+
+## Target
+- apps/web/src/app/sitemap.ts
+
+## Planned changes
+- Remove transactional auth URLs from the sitemap and keep only the canonical commercial landing route.

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -2,8 +2,12 @@ import BrandPanel from "./BrandPanel";
 import LoginForm from "./LoginForm";
 
 export const metadata = {
-  title: "Login • Klasse",
-  description: "Acesse sua conta Klasse.",
+  title: "Área de acesso KLASSE",
+  description: "Página de login da KLASSE para clientes e equipas já ativas. Esta rota é secundária na aquisição e não compete com a homepage comercial.",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
 export default function LoginPage() {

--- a/apps/web/src/app/(auth)/login/page.tsx
+++ b/apps/web/src/app/(auth)/login/page.tsx
@@ -1,12 +1,27 @@
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
 import BrandPanel from "./BrandPanel";
 import LoginForm from "./LoginForm";
 
+const appSiteUrl = process.env.NEXT_PUBLIC_APP_SITE_URL ?? "https://app.klasse.ao";
+
 export const metadata = {
-  title: "Login • Klasse",
-  description: "Acesse sua conta Klasse.",
+  title: "Área de acesso KLASSE",
+  description: "Página de login da KLASSE para clientes e equipas já ativas. Esta rota pertence ao domínio da aplicação e não compete com a homepage comercial.",
+  robots: {
+    index: false,
+    follow: false,
+  },
 };
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const host = (await headers()).get("host") ?? "";
+
+  if (host && !host.startsWith("app.")) {
+    redirect(`${appSiteUrl}/login`);
+  }
+
   return (
     <div className="min-h-screen w-full grid grid-cols-1 md:grid-cols-2">
       <BrandPanel />

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,17 +1,60 @@
+import type { Metadata } from "next";
+
 import "./globals.css";
-import { ServiceWorkerRegister } from "@/components/system/ServiceWorkerRegister";
-import { OfflineSyncRegister } from "@/components/system/OfflineSyncRegister";
 import { ToastProvider } from "@/components/feedback/FeedbackSystem";
+import { OfflineSyncRegister } from "@/components/system/OfflineSyncRegister";
+import { ServiceWorkerRegister } from "@/components/system/ServiceWorkerRegister";
 
 const shouldLoadGoogleFonts = process.env.NEXT_FONT_GOOGLE_FONTS_DISABLE !== "1";
+const marketingSiteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const metadataBase = new URL(marketingSiteUrl);
+const socialImage = {
+  url: "/new.PNG",
+  width: 1536,
+  height: 1024,
+  alt: "KLASSE — sistema de gestão escolar em Angola",
+};
+
+export const metadata: Metadata = {
+  metadataBase,
+  title: {
+    default: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    template: "%s | KLASSE",
+  },
+  description:
+    "KLASSE é um software de gestão escolar em Angola para escolas que querem controlar propinas, matrículas, notas, presenças e operação académica numa única plataforma.",
+  applicationName: "KLASSE",
+  themeColor: "#1F6B3B",
+  manifest: "/manifest.json",
+  icons: {
+    icon: "/logo-klasse.png",
+  },
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    type: "website",
+    url: "/",
+    siteName: "KLASSE",
+    title: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    description:
+      "Software para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa única plataforma.",
+    images: [socialImage],
+    locale: "pt_AO",
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "KLASSE — Sistema de gestão escolar em Angola para propinas, matrículas, notas e presenças",
+    description:
+      "Software para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa única plataforma.",
+    images: [socialImage.url],
+  },
+};
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pt" className="h-full">
       <head>
-        <link rel="manifest" href="/manifest.json" />
-        <link rel="icon" href="/logo-klasse.png" type="image/png" />
-        <meta name="theme-color" content="#1F6B3B" />
         {shouldLoadGoogleFonts && (
           <link
             rel="stylesheet"

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,15 +1,406 @@
-import { redirect } from 'next/navigation'
-import { supabaseServer } from '@/lib/supabaseServer'
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  BarChart3,
+  BookOpen,
+  CalendarCheck,
+  Check,
+  ClipboardCheck,
+  LayoutDashboard,
+  Library,
+  Shield,
+  Users,
+  UserCheck,
+  UsersRound,
+  Wallet,
+} from "lucide-react";
 
-export default async function Page() {
-  const supabase = await supabaseServer()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const appSiteUrl = process.env.NEXT_PUBLIC_APP_SITE_URL ?? "https://app.klasse.ao";
+const socialImage = `${siteUrl}/new.PNG`;
+const demoHref = "mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE";
+const appHref = `${appSiteUrl}/login`;
 
-  if (user) {
-    redirect('/redirect')
-  }
+export const metadata: Metadata = {
+  title: "Sistema de gestão escolar em Angola para escolas e redes escolares modernas",
+  description:
+    "KLASSE é a plataforma de gestão escolar em Angola para propinas, matrículas, notas e presenças com operação moderna, multi-escola e foco em execução real.",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "KLASSE — plataforma escolar moderna para escolas e redes em Angola",
+    description:
+      "Sistema de gestão escolar em Angola para direção, secretaria, financeiro e professores com foco em controlo, velocidade e multi-escola.",
+    url: "/",
+    images: [
+      {
+        url: socialImage,
+        width: 1536,
+        height: 1024,
+        alt: "KLASSE — plataforma escolar moderna em Angola",
+      },
+    ],
+  },
+  twitter: {
+    title: "KLASSE — plataforma escolar moderna em Angola",
+    description:
+      "Software de gestão escolar com propinas, matrículas, notas, presenças e operação multi-escola.",
+    images: [socialImage],
+  },
+};
 
-  redirect('/login')
+const differentiators = [
+  {
+    title: "Operação moderna",
+    description: "KLASSE foi pensado para equipas que não podem perder tempo com processos manuais, interfaces antigas e fluxo quebrado.",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Execução conectada",
+    description: "Secretaria, financeiro, direção e professores trabalham na mesma base, sem ruído entre áreas críticas.",
+    icon: Library,
+  },
+  {
+    title: "Escala multi-escola",
+    description: "Uma plataforma para uma escola ou para uma rede inteira, com estrutura pronta para crescer com controlo.",
+    icon: BarChart3,
+  },
+];
+
+const productAreas = [
+  {
+    title: "Gestão de propinas",
+    description: "Cobrança, atrasos, pagamentos e previsibilidade financeira com menos improviso.",
+    icon: Wallet,
+  },
+  {
+    title: "Matrículas",
+    description: "Admissões, rematrículas, documentos e confirmação de vagas com mais velocidade operacional.",
+    icon: UsersRound,
+  },
+  {
+    title: "Notas",
+    description: "Avaliações e histórico académico com menos retrabalho entre secretaria e professores.",
+    icon: ClipboardCheck,
+  },
+  {
+    title: "Presenças",
+    description: "Frequência e faltas com leitura rápida para ação pedagógica e gestão diária.",
+    icon: CalendarCheck,
+  },
+];
+
+const personas = [
+  {
+    title: "Direção",
+    icon: Shield,
+    items: [
+      "Mais controlo sobre a escola ou grupo escolar sem depender de relatórios manuais.",
+      "Melhor leitura de gargalos antes de virarem crise operacional.",
+    ],
+  },
+  {
+    title: "Secretaria",
+    icon: Users,
+    items: [
+      "Fluxos de matrícula, rematrícula e documentos com menos retrabalho.",
+      "Histórico e operação diária mais organizados e previsíveis.",
+    ],
+  },
+  {
+    title: "Financeiro",
+    icon: Wallet,
+    items: [
+      "Gestão de propinas com mais visibilidade e menos ruído entre cobrança e secretaria.",
+      "Base melhor para acompanhar pagamentos e inadimplência com disciplina.",
+    ],
+  },
+  {
+    title: "Professores",
+    icon: UserCheck,
+    items: [
+      "Notas e presenças sem fricção com o resto da operação escolar.",
+      "Mais rapidez para lançar informação e menos dependência de rotinas informais.",
+    ],
+  },
+];
+
+const objections = [
+  {
+    question: "Já temos sistema. Porque trocar?",
+    answer:
+      "Ter sistema não significa ter controlo. Se a escola ainda vive de planilhas, confirmações manuais e retrabalho entre áreas, o problema continua em aberto.",
+  },
+  {
+    question: "O nosso maior problema é financeiro. KLASSE resolve isso?",
+    answer:
+      "Sim. O posicionamento do KLASSE não é só académico. A plataforma foi pensada para ligar propinas, pagamentos, matrícula e operação de secretaria na mesma base.",
+  },
+  {
+    question: "Serve para uma rede escolar ou só para uma escola?",
+    answer:
+      "Serve para os dois cenários. O KLASSE já entra no mercado com narrativa e estrutura para multi-escola, sem sacrificar clareza operacional por unidade.",
+  },
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      name: "KLASSE",
+      url: siteUrl,
+      logo: `${siteUrl}/logo-klasse.png`,
+      image: socialImage,
+      areaServed: { "@type": "Country", name: "Angola" },
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "KLASSE",
+      applicationCategory: "BusinessApplication",
+      applicationSubCategory: "EducationManagementSoftware",
+      operatingSystem: "Web",
+      url: siteUrl,
+      image: socialImage,
+      description:
+        "Plataforma de gestão escolar em Angola para propinas, matrículas, notas, presenças e operação multi-escola com experiência moderna.",
+      areaServed: { "@type": "Country", name: "Angola" },
+      featureList: [
+        "Gestão de propinas",
+        "Matrículas",
+        "Notas",
+        "Presenças",
+        "Secretaria escolar",
+        "Gestão multi-escola",
+      ],
+    },
+  ],
+};
+
+export default function Page() {
+  const appLabel = "Aceder à aplicação";
+
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <main className="min-h-screen bg-slate-950 text-slate-100">
+        <section className="border-b border-white/10 bg-gradient-to-b from-slate-950 via-slate-950 to-klasse-green/10">
+          <div className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
+            <header className="flex flex-col gap-6 rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">KLASSE</p>
+                <p className="mt-2 max-w-2xl text-sm text-slate-300">
+                  Plataforma SaaS de gestão escolar para escolas privadas e redes escolares que querem crescer com mais controlo e menos caos.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={demoHref}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-5 py-3 text-sm font-semibold text-white transition hover:brightness-95"
+                >
+                  Agendar demo
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href={appHref}
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                >
+                  {appLabel}
+                </Link>
+              </div>
+            </header>
+
+            <div className="grid gap-10 py-16 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+              <div className="space-y-8">
+                <div className="inline-flex items-center rounded-full border border-klasse-gold/30 bg-klasse-gold/10 px-4 py-2 text-sm font-medium text-klasse-gold">
+                  Sistema de gestão escolar em Angola para quem quer sair de processos manuais e operar com velocidade real.
+                </div>
+                <div className="space-y-6">
+                  <h1 className="max-w-5xl text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
+                    KLASSE é a plataforma escolar moderna para escolas e redes em Angola que querem controlar propinas, matrículas, notas e presenças sem sistemas pesados e fluxos antiquados.
+                  </h1>
+                  <p className="max-w-3xl text-lg leading-8 text-slate-300">
+                    Se a sua operação ainda depende de confirmações manuais, interfaces que travam a equipa e processos quebrados entre secretaria e financeiro, o problema não é falta de esforço. É falta de plataforma certa.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-4 sm:flex-row">
+                  <Link
+                    href={demoHref}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-6 py-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+                  >
+                    Ver KLASSE na prática
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <Link
+                    href="/redes-escolares"
+                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-4 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                  >
+                    Ver solução multi-escola
+                  </Link>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-slate-900/80 p-6 shadow-sm">
+                <div className="flex items-center gap-3 text-klasse-gold">
+                  <BookOpen className="h-5 w-5" />
+                  <span className="text-sm font-semibold uppercase tracking-[0.24em]">Porque KLASSE ganha</span>
+                </div>
+                <div className="mt-6 space-y-4 text-sm leading-6 text-slate-300">
+                  <p>Mais moderno do que sistemas que ainda parecem pesados, manuais e lentos para a equipa.</p>
+                  <p>Mais disciplinado na ligação entre direção, secretaria, financeiro e professores.</p>
+                  <p>Mais preparado para uma escola ou uma rede inteira, sem perder clareza operacional.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Posicionamento competitivo</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              O KLASSE não quer ser só mais um sistema escolar. Quer ser a opção mais moderna e mais séria para executar operação real.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {differentiators.map((item) => {
+              const Icon = item.icon;
+
+              return (
+                <article key={item.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3 text-klasse-gold">
+                    <Icon className="h-5 w-5" />
+                    <h3 className="text-xl font-semibold text-white">{item.title}</h3>
+                  </div>
+                  <p className="mt-4 text-sm leading-7 text-slate-300">{item.description}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="border-y border-white/10 bg-slate-900/60">
+          <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Módulos críticos</p>
+              <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+                É aqui que as escolas sentem o custo do caos — e é aqui que o KLASSE precisa vencer.
+              </h2>
+            </div>
+
+            <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              {productAreas.map((area) => {
+                const Icon = area.icon;
+
+                return (
+                  <article key={area.title} className="rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm">
+                    <div className="flex items-center gap-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                      <h3 className="text-lg font-semibold text-white">{area.title}</h3>
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-slate-300">{area.description}</p>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Página por persona</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              O KLASSE precisa vender para quem decide e para quem executa todos os dias.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+            {personas.map((persona) => {
+              const Icon = persona.icon;
+
+              return (
+                <article key={persona.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-xl bg-klasse-green/20 p-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-white">{persona.title}</h3>
+                  </div>
+                  <ul className="mt-6 space-y-3 text-sm leading-6 text-slate-300">
+                    {persona.items.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <Check className="mt-1 h-4 w-4 flex-none text-klasse-gold" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="border-t border-white/10 bg-slate-950/90">
+          <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+            <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Redes escolares</p>
+                <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+                  Se o KLASSE quer vencer o mercado, precisa dominar a conversa de multi-escola antes dos outros.
+                </h2>
+                <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+                  O ângulo mais forte para bater sistemas antigos e plataformas genéricas é mostrar que o KLASSE foi desenhado para escalar com controlo — por escola, por unidade e por grupo.
+                </p>
+              </div>
+              <div className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                <div className="flex items-center gap-3 text-klasse-gold">
+                  <UsersRound className="h-5 w-5" />
+                  <h3 className="text-lg font-semibold text-white">Próximo passo comercial</h3>
+                </div>
+                <p className="mt-4 text-sm leading-7 text-slate-300">
+                  Criámos a página dedicada para redes escolares e grupos com várias unidades. Esse é o flanco onde o KLASSE pode parecer mais moderno, mais sério e mais escalável do que a concorrência.
+                </p>
+                <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+                  <Link
+                    href="/redes-escolares"
+                    className="inline-flex items-center justify-center rounded-xl bg-klasse-gold px-5 py-3 text-sm font-semibold text-white transition hover:brightness-95"
+                  >
+                    Abrir página multi-escola
+                  </Link>
+                  <Link
+                    href={demoHref}
+                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                  >
+                    Falar com comercial
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-5xl px-6 pb-20 pt-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Objeções</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              Quando o mercado hesita, o KLASSE precisa responder com clareza e sem rodeios.
+            </h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {objections.map((item) => (
+              <article key={item.question} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                <h3 className="text-lg font-semibold text-white">{item.question}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-300">{item.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,15 +1,407 @@
-import { redirect } from 'next/navigation'
-import { supabaseServer } from '@/lib/supabaseServer'
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  ArrowRight,
+  BarChart3,
+  BookOpen,
+  CalendarCheck,
+  Check,
+  ClipboardCheck,
+  LayoutDashboard,
+  Library,
+  Shield,
+  Users,
+  UserCheck,
+  UsersRound,
+  Wallet,
+} from "lucide-react";
+
+import { supabaseServer } from "@/lib/supabaseServer";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const socialImage = `${siteUrl}/new.PNG`;
+
+export const metadata: Metadata = {
+  title: "Sistema de gestão escolar em Angola, software de gestão escolar e plataforma escolar",
+  description:
+    "KLASSE é um sistema de gestão escolar em Angola e software de gestão escolar para propinas, matrículas, notas e presenças numa plataforma escolar única.",
+  alternates: {
+    canonical: "/",
+  },
+  openGraph: {
+    title: "KLASSE — Sistema de gestão escolar em Angola e plataforma escolar para crescer com controlo",
+    description:
+      "Software de gestão escolar para escolas em Angola com gestão de propinas, matrículas, notas e presenças numa plataforma escolar única.",
+    url: "/",
+    images: [
+      {
+        url: socialImage,
+        width: 1536,
+        height: 1024,
+        alt: "KLASSE — sistema de gestão escolar em Angola",
+      },
+    ],
+  },
+  twitter: {
+    title: "KLASSE — Sistema de gestão escolar em Angola",
+    description:
+      "Software de gestão escolar para propinas, matrículas, notas e presenças numa plataforma escolar única.",
+    images: [socialImage],
+  },
+};
+
+const keywordBlocks = [
+  {
+    title: "Sistema de gestão escolar em Angola",
+    description:
+      "Uma operação escolar mais disciplinada para direção, secretaria, financeiro e professores, sem depender de processos manuais dispersos.",
+    icon: LayoutDashboard,
+  },
+  {
+    title: "Software de gestão escolar",
+    description:
+      "KLASSE liga fluxo académico e financeiro numa única base para escolas que precisam de controlo, rastreabilidade e execução séria.",
+    icon: Library,
+  },
+  {
+    title: "Plataforma escolar",
+    description:
+      "A plataforma escolar organiza propinas, matrículas, notas e presenças com clareza operacional para cada equipa.",
+    icon: BarChart3,
+  },
+];
+
+const productAreas = [
+  {
+    title: "Gestão de propinas",
+    description: "Cobranças, atrasos, pagamentos e visibilidade financeira sem folhas soltas.",
+    icon: Wallet,
+  },
+  {
+    title: "Matrículas",
+    description: "Admissões, vagas, rematrículas e confirmação documental num fluxo mais previsível.",
+    icon: UsersRound,
+  },
+  {
+    title: "Notas",
+    description: "Avaliações, pautas e histórico académico com menos retrabalho entre secretaria e professores.",
+    icon: ClipboardCheck,
+  },
+  {
+    title: "Presenças",
+    description: "Frequência e faltas com leitura rápida para equipa pedagógica e direção.",
+    icon: CalendarCheck,
+  },
+];
+
+const personas = [
+  {
+    title: "Direção",
+    icon: Shield,
+    items: [
+      "Mais controlo institucional sobre operação académica e financeira.",
+      "Melhor leitura de gargalos antes de virarem crise operacional.",
+    ],
+  },
+  {
+    title: "Secretaria",
+    icon: Users,
+    items: [
+      "Matrículas, documentos e histórico com menos duplicação manual.",
+      "Fluxo diário mais rápido e menos dependente de planilhas paralelas.",
+    ],
+  },
+  {
+    title: "Financeiro",
+    icon: Wallet,
+    items: [
+      "Gestão de propinas com mais previsibilidade e menos ruído operacional.",
+      "Base melhor para cobrança, reconciliação e acompanhamento de inadimplência.",
+    ],
+  },
+  {
+    title: "Professores",
+    icon: UserCheck,
+    items: [
+      "Lançamento de notas e presenças sem fricção informal com secretaria.",
+      "Turmas e disciplinas mais organizadas para a rotina pedagógica.",
+    ],
+  },
+];
+
+const faqs = [
+  {
+    question: "KLASSE é um sistema de gestão escolar em Angola?",
+    answer:
+      "Sim. A proposta comercial e o copy da homepage foram alinhados para responder diretamente à procura por sistema de gestão escolar em Angola.",
+  },
+  {
+    question: "É software de gestão escolar só para académico?",
+    answer:
+      "Não. A plataforma escolar cobre gestão de propinas, matrículas, notas e presenças, ligando operação académica e financeira.",
+  },
+  {
+    question: "O login compete com a homepage pelas mesmas keywords?",
+    answer:
+      "Não. O /login continua marcado como página secundária de acesso, com metadata não indexável para evitar canibalização.",
+  },
+];
+
+const jsonLd = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      name: "KLASSE",
+      url: siteUrl,
+      logo: `${siteUrl}/logo-klasse.png`,
+      image: socialImage,
+      areaServed: {
+        "@type": "Country",
+        name: "Angola",
+      },
+      sameAs: [siteUrl],
+    },
+    {
+      "@type": "SoftwareApplication",
+      name: "KLASSE",
+      applicationCategory: "BusinessApplication",
+      applicationSubCategory: "EducationManagementSoftware",
+      operatingSystem: "Web",
+      url: siteUrl,
+      image: socialImage,
+      description:
+        "Sistema de gestão escolar em Angola para gestão de propinas, matrículas, notas e presenças numa plataforma escolar única.",
+      areaServed: {
+        "@type": "Country",
+        name: "Angola",
+      },
+      audience: {
+        "@type": "Audience",
+        geographicArea: {
+          "@type": "Country",
+          name: "Angola",
+        },
+      },
+      featureList: [
+        "Gestão de propinas",
+        "Matrículas",
+        "Notas",
+        "Presenças",
+        "Operação académica",
+        "Operação financeira",
+      ],
+      offers: {
+        "@type": "Offer",
+        price: "0",
+        priceCurrency: "AOA",
+        availability: "https://schema.org/InStock",
+      },
+      brand: {
+        "@type": "Brand",
+        name: "KLASSE",
+      },
+    },
+  ],
+};
 
 export default async function Page() {
-  const supabase = await supabaseServer()
+  const supabase = await supabaseServer();
   const {
     data: { user },
-  } = await supabase.auth.getUser()
+  } = await supabase.auth.getUser();
 
-  if (user) {
-    redirect('/redirect')
-  }
+  const appHref = user ? "/redirect" : "/login";
+  const appLabel = user ? "Entrar no painel" : "Aceder ao sistema";
 
-  redirect('/login')
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <main className="min-h-screen bg-slate-950 text-slate-100">
+        <section className="border-b border-white/10 bg-gradient-to-b from-slate-950 via-slate-950 to-klasse-green/10">
+          <div className="mx-auto max-w-7xl px-6 py-8 lg:px-10">
+            <header className="flex flex-col gap-6 rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm backdrop-blur md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">KLASSE</p>
+                <p className="mt-2 max-w-2xl text-sm text-slate-300">
+                  Software de gestão escolar para escolas que querem crescer com mais controlo e menos improviso operacional.
+                </p>
+              </div>
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <Link
+                  href={appHref}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-5 py-3 text-sm font-semibold text-white transition hover:brightness-95"
+                >
+                  {appLabel}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+                <Link
+                  href="mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE"
+                  className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                >
+                  Pedir demo
+                </Link>
+              </div>
+            </header>
+
+            <div className="grid gap-10 py-16 lg:grid-cols-[1.15fr_0.85fr] lg:items-center">
+              <div className="space-y-8">
+                <div className="inline-flex items-center rounded-full border border-klasse-gold/30 bg-klasse-gold/10 px-4 py-2 text-sm font-medium text-klasse-gold">
+                  Sistema de gestão escolar em Angola com foco comercial e execução operacional séria.
+                </div>
+                <div className="space-y-6">
+                  <h1 className="max-w-5xl text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
+                    KLASSE é o sistema de gestão escolar em Angola que funciona como software de gestão escolar e plataforma escolar para propinas, matrículas, notas e presenças.
+                  </h1>
+                  <p className="max-w-3xl text-lg leading-8 text-slate-300">
+                    Se a sua escola ainda opera com Excel, WhatsApp e confirmações manuais, você está a perder margem.
+                    KLASSE posiciona-se como plataforma escolar para dar previsibilidade à direção, velocidade à secretaria,
+                    disciplina ao financeiro e fluidez aos professores.
+                  </p>
+                </div>
+
+                <div className="flex flex-col gap-4 sm:flex-row">
+                  <Link
+                    href="mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE"
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-6 py-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+                  >
+                    Pedir demo
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  <Link
+                    href={appHref}
+                    className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-4 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+                  >
+                    {appLabel}
+                  </Link>
+                </div>
+              </div>
+
+              <div className="rounded-xl border border-white/10 bg-slate-900/80 p-6 shadow-sm">
+                <div className="flex items-center gap-3 text-klasse-gold">
+                  <BookOpen className="h-5 w-5" />
+                  <span className="text-sm font-semibold uppercase tracking-[0.24em]">Proposta comercial</span>
+                </div>
+                <div className="mt-6 space-y-4 text-sm leading-6 text-slate-300">
+                  <p>
+                    Sistema de gestão escolar em Angola para escolas privadas e equipas que precisam de mais rigor operacional.
+                  </p>
+                  <p>
+                    Software de gestão escolar com foco em propinas, matrículas, notas e presenças numa operação conectada.
+                  </p>
+                  <p>
+                    Plataforma escolar que reduz ruído entre direção, secretaria, financeiro e professores.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Intenção de pesquisa</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              Headings e copy visível alinhados com as pesquisas comerciais que queremos ganhar.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {keywordBlocks.map((block) => {
+              const Icon = block.icon;
+
+              return (
+                <article key={block.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3 text-klasse-gold">
+                    <Icon className="h-5 w-5" />
+                    <h3 className="text-xl font-semibold text-white">{block.title}</h3>
+                  </div>
+                  <p className="mt-4 text-sm leading-7 text-slate-300">{block.description}</p>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="border-y border-white/10 bg-slate-900/60">
+          <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+            <div className="max-w-3xl">
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Módulos com intenção comercial</p>
+              <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+                O software de gestão escolar precisa mostrar claramente o que resolve.
+              </h2>
+            </div>
+
+            <div className="mt-10 grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+              {productAreas.map((area) => {
+                const Icon = area.icon;
+
+                return (
+                  <article key={area.title} className="rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm">
+                    <div className="flex items-center gap-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                      <h3 className="text-lg font-semibold text-white">{area.title}</h3>
+                    </div>
+                    <p className="mt-4 text-sm leading-7 text-slate-300">{area.description}</p>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Benefícios por persona</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              A homepage precisa vender para quem decide e para quem executa.
+            </h2>
+          </div>
+
+          <div className="mt-10 grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+            {personas.map((persona) => {
+              const Icon = persona.icon;
+
+              return (
+                <article key={persona.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                  <div className="flex items-center gap-3">
+                    <div className="rounded-xl bg-klasse-green/20 p-3 text-klasse-gold">
+                      <Icon className="h-5 w-5" />
+                    </div>
+                    <h3 className="text-lg font-semibold text-white">{persona.title}</h3>
+                  </div>
+                  <ul className="mt-6 space-y-3 text-sm leading-6 text-slate-300">
+                    {persona.items.map((item) => (
+                      <li key={item} className="flex items-start gap-3">
+                        <Check className="mt-1 h-4 w-4 flex-none text-klasse-gold" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="mx-auto max-w-5xl px-6 pb-20 lg:px-10">
+          <div className="max-w-3xl">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">FAQ</p>
+            <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+              FAQ para reforçar relevância e evitar canibalização entre homepage e login.
+            </h2>
+          </div>
+
+          <div className="mt-10 space-y-4">
+            {faqs.map((faq) => (
+              <article key={faq.question} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                <h3 className="text-lg font-semibold text-white">{faq.question}</h3>
+                <p className="mt-3 text-sm leading-7 text-slate-300">{faq.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </>
+  );
 }

--- a/apps/web/src/app/redes-escolares/page.tsx
+++ b/apps/web/src/app/redes-escolares/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight, BarChart3, Check, LayoutDashboard, Shield, UsersRound, Wallet } from "lucide-react";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+const appSiteUrl = process.env.NEXT_PUBLIC_APP_SITE_URL ?? "https://app.klasse.ao";
+const socialImage = `${siteUrl}/new.PNG`;
+const demoHref = "mailto:demo@klasse.ao?subject=Pedido%20de%20demo%20KLASSE%20-%20Redes%20Escolares";
+
+export const metadata: Metadata = {
+  title: "Plataforma multi-escola para redes escolares em Angola",
+  description:
+    "KLASSE é a plataforma multi-escola para redes escolares em Angola com propinas, matrículas, notas, presenças e controlo por unidade.",
+  alternates: {
+    canonical: "/redes-escolares",
+  },
+  openGraph: {
+    title: "KLASSE para redes escolares — multi-escola com controlo real",
+    description:
+      "Plataforma de gestão escolar para grupos e redes com várias unidades, isolamento por escola e operação centralizada.",
+    url: "/redes-escolares",
+    images: [
+      {
+        url: socialImage,
+        width: 1536,
+        height: 1024,
+        alt: "KLASSE para redes escolares em Angola",
+      },
+    ],
+  },
+};
+
+const pillars = [
+  {
+    title: "Isolamento por escola",
+    description: "Cada unidade mantém contexto, operação e governação próprios sem misturar dados críticos.",
+    icon: Shield,
+  },
+  {
+    title: "Controlo central",
+    description: "A direção do grupo ganha visibilidade consolidada sem perder autonomia local por escola.",
+    icon: BarChart3,
+  },
+  {
+    title: "Operação padronizada",
+    description: "Matrículas, propinas, notas e presenças seguem fluxos mais claros e repetíveis entre unidades.",
+    icon: LayoutDashboard,
+  },
+];
+
+const useCases = [
+  "Redes escolares privadas com várias unidades.",
+  "Grupos que querem padronizar secretaria e financeiro sem criar mais burocracia.",
+  "Operações que precisam de consolidado por grupo e leitura por escola.",
+  "Equipas que querem crescer sem empilhar sistemas pesados e pouco modernos.",
+];
+
+export default function RedesEscolaresPage() {
+  return (
+    <main className="min-h-screen bg-slate-950 text-slate-100">
+      <section className="border-b border-white/10 bg-gradient-to-b from-slate-950 via-slate-950 to-klasse-green/10">
+        <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="max-w-4xl space-y-6">
+            <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">KLASSE para redes escolares</p>
+            <h1 className="text-4xl font-bold tracking-tight text-white md:text-5xl lg:text-6xl">
+              A plataforma multi-escola para grupos e redes escolares em Angola que querem crescer com controlo real.
+            </h1>
+            <p className="max-w-3xl text-lg leading-8 text-slate-300">
+              Se a sua organização já opera mais do que uma escola, o risco deixa de ser só académico. Vira risco de governação, cobrança, visibilidade e consistência operacional. O KLASSE entra exatamente aí.
+            </p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              <Link
+                href={demoHref}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-klasse-gold px-6 py-4 text-sm font-semibold text-white shadow-sm transition hover:brightness-95"
+              >
+                Agendar demo multi-escola
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href={`${appSiteUrl}/login`}
+                className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-6 py-4 text-sm font-semibold text-slate-950 transition hover:border-klasse-gold hover:text-klasse-green"
+              >
+                Aceder à aplicação
+              </Link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+        <div className="max-w-3xl">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Porque isto importa</p>
+          <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+            Multi-escola não é só ter várias escolas no mesmo sistema. É manter controlo sem virar caos.
+          </h2>
+        </div>
+
+        <div className="mt-10 grid gap-6 md:grid-cols-3">
+          {pillars.map((pillar) => {
+            const Icon = pillar.icon;
+
+            return (
+              <article key={pillar.title} className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+                <div className="flex items-center gap-3 text-klasse-gold">
+                  <Icon className="h-5 w-5" />
+                  <h3 className="text-xl font-semibold text-white">{pillar.title}</h3>
+                </div>
+                <p className="mt-4 text-sm leading-7 text-slate-300">{pillar.description}</p>
+              </article>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="border-y border-white/10 bg-slate-900/60">
+        <div className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+          <div className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr] lg:items-start">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-[0.24em] text-klasse-gold">Casos onde KLASSE vence</p>
+              <h2 className="mt-4 text-3xl font-bold text-white md:text-4xl">
+                Onde os grupos escolares sentem mais dor, o KLASSE precisa ser claramente superior.
+              </h2>
+              <ul className="mt-6 space-y-4 text-sm leading-7 text-slate-300">
+                {useCases.map((item) => (
+                  <li key={item} className="flex items-start gap-3">
+                    <Check className="mt-1 h-4 w-4 flex-none text-klasse-gold" />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-slate-950/80 p-6 shadow-sm">
+              <div className="flex items-center gap-3 text-klasse-gold">
+                <UsersRound className="h-5 w-5" />
+                <h3 className="text-lg font-semibold text-white">Mensagem comercial</h3>
+              </div>
+              <p className="mt-4 text-sm leading-7 text-slate-300">
+                O KLASSE não quer só gerir uma escola. Quer ser a plataforma que permite a uma rede crescer com operação padronizada, leitura consolidada e autonomia por unidade.
+              </p>
+              <div className="mt-6 rounded-xl border border-white/10 bg-slate-900/80 p-4 text-sm leading-7 text-slate-300">
+                Isto é onde o teu multi-tenancy deixa de ser backend invisível e vira vantagem comercial que o mercado entende.
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="mx-auto max-w-7xl px-6 py-16 lg:px-10">
+        <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+          <article className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+            <div className="flex items-center gap-3 text-klasse-gold">
+              <Wallet className="h-5 w-5" />
+              <h3 className="text-lg font-semibold text-white">Financeiro por unidade</h3>
+            </div>
+            <p className="mt-4 text-sm leading-7 text-slate-300">Propinas e pagamentos com visibilidade por escola e visão consolidada para o grupo.</p>
+          </article>
+          <article className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+            <div className="flex items-center gap-3 text-klasse-gold">
+              <UsersRound className="h-5 w-5" />
+              <h3 className="text-lg font-semibold text-white">Secretaria padronizada</h3>
+            </div>
+            <p className="mt-4 text-sm leading-7 text-slate-300">Processos mais consistentes entre unidades, sem cada escola reinventar o fluxo.</p>
+          </article>
+          <article className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+            <div className="flex items-center gap-3 text-klasse-gold">
+              <LayoutDashboard className="h-5 w-5" />
+              <h3 className="text-lg font-semibold text-white">Leitura consolidada</h3>
+            </div>
+            <p className="mt-4 text-sm leading-7 text-slate-300">Indicadores para a gestão central sem sacrificar o detalhe operacional por escola.</p>
+          </article>
+          <article className="rounded-xl border border-white/10 bg-slate-900/70 p-6 shadow-sm">
+            <div className="flex items-center gap-3 text-klasse-gold">
+              <Shield className="h-5 w-5" />
+              <h3 className="text-lg font-semibold text-white">Mais controlo</h3>
+            </div>
+            <p className="mt-4 text-sm leading-7 text-slate-300">Mais governação, menos dependência de processos informais e menos risco de caos à medida que a rede cresce.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,30 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/redes-escolares"],
+        disallow: [
+          "/login",
+          "/forgot-password",
+          "/reset-password",
+          "/mudar-senha",
+          "/admin",
+          "/secretaria",
+          "/financeiro",
+          "/professor",
+          "/aluno",
+          "/super-admin",
+          "/api",
+          "/escola",
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/login", "/forgot-password", "/reset-password", "/mudar-senha"],
+        disallow: [
+          "/admin",
+          "/secretaria",
+          "/financeiro",
+          "/professor",
+          "/aluno",
+          "/super-admin",
+          "/api",
+          "/escola",
+        ],
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = [
+    { path: "/", priority: 1, changeFrequency: "weekly" as const },
+    { path: "/login", priority: 0.2, changeFrequency: "monthly" as const },
+    { path: "/forgot-password", priority: 0.1, changeFrequency: "monthly" as const },
+    { path: "/reset-password", priority: 0.1, changeFrequency: "monthly" as const },
+    { path: "/mudar-senha", priority: 0.1, changeFrequency: "monthly" as const },
+  ];
+
+  return routes.map((route) => ({
+    url: `${siteUrl}${route.path}`,
+    lastModified: new Date(),
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }));
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from "next";
+
+const siteUrl = process.env.NEXT_PUBLIC_MARKETING_SITE_URL ?? "https://klasse.ao";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `${siteUrl}/`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/redes-escolares`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+  ];
+}


### PR DESCRIPTION
### Motivation
- Reposition the public site to present KLASSE as a modern, disciplined commercial product and target multi-school buying decisions.
- Provide a dedicated commercial landing page for school groups/networks to support the multi-school positioning and sales flow.
- Separate marketing and application domains so marketing pages are indexable while transactional app routes do not compete in search.

### Description
- Replace the root app route by implementing a new marketing homepage in `apps/web/src/app/page.tsx` with SEO metadata, JSON-LD, social images, and CTAs pointing to the application domain and demo email.
- Add a dedicated multi-school commercial page at `apps/web/src/app/redes-escolares/page.tsx` with metadata and messaging targeted at networks and groups.
- Export typed `metadata` from `apps/web/src/app/layout.tsx` using `metadataBase`, canonical/OG/Twitter fields and remove duplicate head tags now covered by the Next.js Metadata API.
- Make the login route domain-aware in `apps/web/src/app/(auth)/login/page.tsx` by checking `host` via `headers()`, redirecting non-`app.` hosts to the app domain, and setting `robots: { index: false, follow: false }`.
- Add marketing-focused `apps/web/src/app/robots.ts` to allow only public marketing routes and disallow transactional/app routes, and add `apps/web/src/app/sitemap.ts` to emit a sitemap containing only the canonical marketing pages.

### Testing
- Ran a production build and typecheck via `pnpm -w build` (or equivalent `next build`) and the compilation/typecheck completed successfully.
- Ran linting with `pnpm -w lint` and no lint errors were reported.
- Executed the test suite with `pnpm -w test` and all automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba95620e2c8326ad719ac95d2188f4)