### PR TITLE
fix: redirect app.klasse.ao root traffic to system (/redirect)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,17 @@
       ],
       "destination": "https://klasse.ao/:path*",
       "permanent": true
+    },
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "app.klasse.ao"
+        }
+      ],
+      "destination": "/redirect",
+      "permanent": false
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- The app subdomain root (`app.klasse.ao/`) was serving the marketing homepage instead of entering the authenticated system flow, causing users to land on the wrong page; the intent is to route subdomain root traffic into the existing auth-aware entry so logged-in users reach their portal and anonymous users go to login.

### Description
- Add a host-specific Vercel redirect in `vercel.json` to send requests for `app.klasse.ao/` to `/redirect`, reusing the existing `/(auth)/redirect` page which handles role-based routing and login forwarding.

### Testing
- Ran a TypeScript transpile check on `apps/web/src/app/page.tsx` with `ts.transpileModule` which returned `TS syntax OK`; validated `vercel.json` with `jq empty` successfully; attempted `pnpm -C apps/web build` and `VERCEL=1 pnpm -C apps/web build` but full production build cannot be completed in this environment because `db:types` requires Supabase CLI/auth and `apps/web/next.config.ts` expects `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`, so those builds failed due to missing deploy environment variables rather than code syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bad1c8efd8832687f91c816ef2d204)