### PR TITLE
fix: align app domain to app.klasse.ao and add web vercel redirect

### DIFF
--- a/agents/outputs/APPLY_DIFF_20260318-app-klasse-domain.md
+++ b/agents/outputs/APPLY_DIFF_20260318-app-klasse-domain.md
@@ -1,0 +1,37 @@
+# Apply diff — Agent 3
+run_id:    20260318-app-klasse-domain
+timestamp: 2026-03-18T18:01:28.374265+00:00
+
+## Acção proposta
+Alinhar o app project e os fallbacks de URLs transacionais para `app.klasse.ao`, evitando que o código continue a emitir links para o domínio legado `portal.klasse.ao` e documentando o redirect esperado no deployment do app.
+
+## Diff
+```diff
+--- a/apps/web/src/app/api/jobs/outbox/route.ts
++++ b/apps/web/src/app/api/jobs/outbox/route.ts
+@@
+-  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://portal.klasse.ao").replace(/\/$/, "");
++  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://app.klasse.ao").replace(/\/$/, "");
+
+--- /dev/null
++++ b/apps/web/vercel.json
+@@
++{
++  "redirects": [
++    {
++      "source": "/",
++      "has": [
++        {
++          "type": "host",
++          "value": "app.klasse.ao"
++        }
++      ],
++      "destination": "/redirect",
++      "permanent": false
++    }
++  ]
++}
+```
+
+## Risco
+Baixo: muda apenas o domínio fallback de links do worker e explicita o redirect do root no projecto web; não altera schema nem dados.

--- a/apps/web/src/app/api/jobs/outbox/route.ts
+++ b/apps/web/src/app/api/jobs/outbox/route.ts
@@ -106,7 +106,7 @@ async function provisionStudent(admin: NonNullable<ReturnType<typeof getAdminCli
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/(^-|-$)/g, "");
-  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://portal.klasse.ao").replace(/\/$/, "");
+  const baseUrl = (process.env.NEXT_PUBLIC_APP_URL || "https://app.klasse.ao").replace(/\/$/, "");
   const activationQuery = new URLSearchParams();
   if (aluno.codigo_ativacao) activationQuery.set("codigo", aluno.codigo_ativacao);
   if (token) activationQuery.set("token", token);

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,0 +1,15 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "app.klasse.ao"
+        }
+      ],
+      "destination": "/redirect",
+      "permanent": false
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Ensure the web app uses the canonical `app.klasse.ao` host so activation links and transactional URLs point to the correct domain. 
- Prevent users from hitting `404: DEPLOYMENT_NOT_FOUND` caused by misaligned repo-side routing and missing app-level redirect configuration. 
- Record and apply a minimal, low-risk change that does not touch DB schema or RLS policies. 

### Description
- Added `apps/web/vercel.json` with a host-based redirect that routes `app.klasse.ao/` to the authenticated entrypoint `/redirect`.
- Replaced the legacy fallback `https://portal.klasse.ao` with `https://app.klasse.ao` in `apps/web/src/app/api/jobs/outbox/route.ts` so generated activation/onboarding links default to the app domain when `NEXT_PUBLIC_APP_URL` is not set.
- Saved the planned change in `agents/outputs/APPLY_DIFF_20260318-app-klasse-domain.md` per the repo Agent 3 apply workflow and committed the changes under the message `fix: align app deployment domain to app.klasse.ao`.

### Testing
- Verified the new `apps/web/vercel.json` is valid JSON with `node -e "JSON.parse(require('fs').readFileSync('apps/web/vercel.json','utf8'))"` which succeeded.
- Ran `git diff --check` which reported no whitespace/errors and confirmed the intended diff was created and committed.
- Attempted `pnpm -C apps/web typecheck` which failed due to environment `pnpm` fetch error `ERR_PNPM_FETCH_403` when the pretypecheck step tried to fetch the Supabase CLI, so full typecheck could not be completed here.
- Attempted `pnpm -C apps/web exec tsc --noEmit` which timed out in this environment, so a full compile check was not completed here.

Note: This change aligns the repo configuration and code fallback, but the live `404: DEPLOYMENT_NOT_FOUND` indicates the custom domain must still be attached to the Vercel project that deploys `apps/web`, the project root must be set to `apps/web`, and a fresh production deployment is required alongside `NEXT_PUBLIC_APP_URL=https://app.klasse.ao` in Vercel environment variables.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae77fa5a48326aec44e07af040919)