### PR TITLE
Add fiscal foundation: DB migrations, RLS, consistency guards and documentation

### DIFF
--- a/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-API-CONTRACT.md
+++ b/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-API-CONTRACT.md
@@ -1,0 +1,15 @@
+# Apply Diff — Fiscal API Contract
+run_id: 2026-03-19-FISCAL-API-CONTRACT
+created_at: 2026-03-19T00:00:00Z
+
+## Planned changes
+- add Zod schema for POST /api/fiscal/documentos request
+- add guarded route handler for fiscal document emission preflight
+- add semantic lookup index for active fiscal series
+- add API documentation for fiscal documents endpoint
+
+## Safety notes
+- no destructive SQL
+- no data mutation migration
+- no RLS policy changes
+- route intentionally blocks fiscal emission until atomic issuer exists

--- a/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-INVENTORY.md
+++ b/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-INVENTORY.md
@@ -1,0 +1,10 @@
+# Apply Diff
+run_id: 2026-03-19-FISCAL-INVENTORY
+
+diff --git a/agents/outputs/RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md b/agents/outputs/RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md
+new file mode 100644
+--- /dev/null
++++ b/agents/outputs/RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md
+@@
++# Relatório — Inventário do Módulo Fiscal no KLASSE
++# ... relatório completo de inventário e gaps do Fiscal v3

--- a/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-PHASE0-PHASE1.md
+++ b/agents/outputs/APPLY_DIFF_2026-03-19-FISCAL-PHASE0-PHASE1.md
@@ -1,0 +1,10 @@
+# Apply Diff
+run_id: 2026-03-19-FISCAL-PHASE0-PHASE1
+
+## Files
+- agents/outputs/KLASSE_FISCAL_PHASE0_PHASE1_2026-03-19.md
+- supabase/migrations/20260319000000_create_fiscal_foundation.sql
+
+## Summary
+- document phase 0 contract decisions for the new fiscal bounded context
+- create fiscal foundation tables, roles, bindings, guardrail functions, number reservation and RLS

--- a/agents/outputs/KLASSE_FISCAL_PHASE0_PHASE1_2026-03-19.md
+++ b/agents/outputs/KLASSE_FISCAL_PHASE0_PHASE1_2026-03-19.md
@@ -1,0 +1,102 @@
+# KLASSE Fiscal — Fase 0 e Fase 1
+
+Data: 2026-03-19
+Objetivo: materializar as decisões mínimas de contrato (Fase 0) e a fundação de dados fiscal (Fase 1) sem contaminar o domínio legado de `documentos_emitidos` e `recibos`.
+
+## Fase 0 — Decisões fechadas agora
+
+### 1. Bounded context fiscal separado
+O módulo fiscal nasce separado do fluxo legado de `documentos_emitidos`, `emitir_recibo(...)` e `next_documento_numero(...)`.
+
+**Decisão:** o núcleo novo vive em tabelas `fiscal_*` e não em extensões oportunistas do legado.
+
+### 2. Tenant fiscal explícito
+O tenant fiscal é `empresa_id`, não `escola_id`.
+
+**Decisão:** a fundação cria `fiscal_empresas`, `fiscal_empresa_users` e `fiscal_escola_bindings`.
+
+### 3. Ponte escola → empresa fiscal
+Uma escola pode ser ligada a uma empresa fiscal sem assumir equivalência estrutural eterna entre escola e empresa.
+
+**Decisão:** a relação fica explícita em `fiscal_escola_bindings`, com suporte a vínculo primário e janela temporal.
+
+### 4. Segurança e acesso
+Acesso fiscal não fica “herdado por acidente” do tenant escolar.
+
+**Decisão:** RLS fiscal usa membership em `fiscal_empresa_users`; ligação escola→empresa serve para operação e onboarding, não para furar a fronteira fiscal.
+
+### 5. Séries, chaves e ledger imutável
+A fundação já prepara o contrato para:
+
+- séries fiscais por empresa;
+- chaves versionadas por empresa;
+- documento fiscal com `key_version`, `hash_control` e encadeamento;
+- itens, eventos e exportações em tabelas próprias.
+
+### 6. Escopo intencionalmente fora desta entrega
+Ainda não foi implementado nesta fase:
+
+- assinatura RSA real;
+- emissão/rectificação/anulação por API;
+- SAF-T(AO) XML;
+- UI fiscal no portal financeiro.
+
+Essas etapas dependem da fundação de dados ficar estável primeiro.
+
+---
+
+## Fase 1 — Foundation entregue
+
+A migration desta fase cria:
+
+- `public.fiscal_empresas`
+- `public.fiscal_empresa_users`
+- `public.fiscal_escola_bindings`
+- `public.fiscal_series`
+- `public.fiscal_chaves`
+- `public.fiscal_documentos`
+- `public.fiscal_documento_itens`
+- `public.fiscal_documentos_eventos`
+- `public.fiscal_saft_exports`
+- funções `current_tenant_empresa_id()`, `user_has_role_in_empresa(...)`, `fiscal_reservar_numero_serie(...)`
+- triggers de `updated_at`
+- guardrails de consistência cross-tenant para documentos, itens e eventos
+- RLS forte por `empresa_id`
+
+## Notas de arquitectura
+
+### Porque não herdar acesso fiscal de `escola_users`
+Porque o fiscal vai precisar suportar cenários onde:
+
+- a entidade emissora não é 1:1 com a escola;
+- múltiplas escolas partilham a mesma empresa fiscal;
+- um auditor fiscal deve ver a empresa, mas não necessariamente todo o ERP escolar;
+- uma mudança de vínculo escolar não pode implicitamente reconfigurar o ledger fiscal.
+
+### Porque `fiscal_escola_bindings` existe já
+Para evitar acoplamento oculto. A ponte escola→empresa precisa ser modelada no banco desde cedo, mesmo antes da API final, para não obrigar retrofit perigoso depois.
+
+### Porque a trigger de imutabilidade entrou já
+Porque documento emitido não pode virar “quase imutável”. Se deixarmos update livre agora, a dívida regulatória nasce no primeiro endpoint.
+
+---
+
+## Próximo corte recomendado
+
+### Fase 2 imediata
+1. API privada de setup fiscal (`/api/fiscal/setup/...`) para:
+   - criar empresa fiscal;
+   - vincular escola;
+   - cadastrar série;
+   - cadastrar chave pública/metadata de key version.
+2. serviço backend de canonical string + assinatura;
+3. emissão de `POST /api/fiscal/documentos` transaccional.
+
+### Risco que continua aberto
+Ainda falta decidir como a chave privada será operada em produção:
+
+- KMS gerido;
+- HSM;
+- secret manager com serviço isolado.
+
+Sem essa decisão, a Fase 2 só deve avançar até interfaces e contratos, não até emissão “oficial”.

--- a/agents/outputs/RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md
+++ b/agents/outputs/RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md
@@ -1,0 +1,544 @@
+# Relatório — Inventário do Módulo Fiscal no KLASSE
+
+Data: 2026-03-19
+Escopo analisado: `apps/web`, `supabase/migrations`, `agents/outputs`
+Objetivo: mapear o que já existe no KLASSE para suportar um módulo fiscal AGT v3, identificar o que pode ser reaproveitado sem duplicação e listar as lacunas reais para plugar o módulo no portal financeiro.
+
+## Veredito executivo
+
+O KLASSE **já tem uma base útil**, mas **ainda não tem um módulo fiscal certificável**.
+
+Hoje o produto já oferece:
+
+- isolamento multi-tenant por `escola_id` com `resolveEscolaIdForUser` e políticas RLS em vários fluxos;
+- um subsistema de **documentos emitidos** com snapshot imutável de conteúdo, `public_id`, `hash_validacao`, QR/URL pública de validação e auditoria;
+- um subsistema financeiro operacional com pagamentos, mensalidades, fecho de caixa, conciliação, cobrança, dashboards e MVs;
+- controles de plano/permissão que já antecipam a ideia de fiscal premium (`emitir_nota_fiscal`, `fin_recibo_pdf`, plano “Financeiro + Fiscal”).
+
+Mas o que existe hoje resolve **comprovativos e recibos operacionais**, não **faturação fiscal regulada**.
+
+O gap estrutural é claro:
+
+1. o tenant fiscal actual é a **escola**; o Fiscal v3 exige **empresa/NIF** como fronteira de ledger;
+2. `documentos_emitidos` foi desenhada para **documentos genéricos da secretaria + recibos**, não para séries fiscais, rectificações, anulações formais e encadeamento criptográfico;
+3. o “hash” actual é um token de validação, **não assinatura RSA em cadeia**;
+4. não existe motor de **numeração contínua por série fiscal**;
+5. não existe **SAF-T(AO)** nem modelo orientado a exportação fiscal;
+6. não existe trilho fiscal append-only por evento com semântica de emissão, rectificação, anulação, reimpressão e exportação.
+
+Conclusão direta: **não devemos adaptar o módulo actual de recibos como se fosse o módulo fiscal**. Devemos **reaproveitar infra transversal** e **criar um bounded context fiscal separado**, plugado ao portal financeiro.
+
+---
+
+## 1) Inventário do que já existe e pode ser reutilizado
+
+### 1.1 Multi-tenant, autenticação e resolução de contexto
+
+**Existe hoje:**
+
+- `resolveEscolaIdForUser` está disseminado nas APIs humanas para resolver contexto de tenant antes de query/mutação.
+- O financeiro usa `escola_id` de forma consistente em endpoints críticos.
+- Há uso de `current_tenant_escola_id()` e `user_has_role_in_school(...)` em policies e RPCs financeiras.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- a disciplina de tenant já existe;
+- o padrão de resolver contexto no backend antes de tocar dados já está institucionalizado;
+- dá para reutilizar o mesmo shape operacional, trocando o contexto fiscal para `empresa_id` onde a conformidade exigir.
+
+**Reutilizar sem duplicar:**
+
+- middleware/auth server-side;
+- pattern de `resolveTenant → authorize → mutate → audit`;
+- claims e memberships já usados no produto.
+
+**Limite:**
+
+- o fiscal não pode depender só de `escola_id`; precisa de um **novo contexto fiscal explícito** (`empresa_id`) com ponte controlada escola → empresa fiscal.
+
+### 1.2 Documentos emitidos e snapshot imutável
+
+**Existe hoje:**
+
+- a tabela `documentos_emitidos` já guarda snapshot JSON, `public_id`, `hash_validacao`, `created_by` e revogação formal via `revoked_at` / `revoked_by`.
+- Há emissão de documentos finais da secretaria por RPC (`emitir_documento_final`) e emissão de comprovante de matrícula por helper/rota.
+- O sistema já expõe consulta pública por token/hash para validação de documento.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- o produto já entendeu a diferença entre “render actual” e “snapshot emitido”; isso é valioso;
+- já existe noção de documento publicado, verificável e auditável;
+- o padrão de documento como artefacto persistido está maduro o suficiente para servir de referência.
+
+**Reutilizar sem duplicar:**
+
+- bucket mental: snapshot persistido e render posterior a partir do snapshot;
+- infra de impressão/PDF e de URL pública de validação;
+- auditoria de emissão e integração com notificações/outbox;
+- componente de QR e padrão de documento com identificador público.
+
+**Não reutilizar como base fiscal principal:**
+
+- a própria tabela `documentos_emitidos` não serve como ledger fiscal canónico;
+- `hash_validacao` não cumpre o papel regulatório de assinatura RSA versionada;
+- a numeração actual (`next_documento_numero`) é genérica da escola, não por série fiscal.
+
+### 1.3 Recibos operacionais já emitidos no financeiro
+
+**Existe hoje:**
+
+- endpoint `POST /api/financeiro/recibos/emitir` com `Idempotency-Key`, `requireFeature("fin_recibo_pdf")`, auditoria e RPC `emitir_recibo`.
+- componente `ReciboImprimivel` com QR code, URL de validação e impressão pós-emissão.
+- o recibo é idempotente por mensalidade e nasce só quando a mensalidade está paga.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- já há fluxo de emissão pós-pagamento;
+- já há gating comercial e autorização;
+- a equipa/produto já fala a linguagem de “emitir documento oficial” dentro do financeiro.
+
+**Reutilizar sem duplicar:**
+
+- a experiência UX de emitir um documento finalizado, não editável e imprimível;
+- a estrutura de idempotência por operação;
+- o endpoint pattern e os componentes de impressão.
+
+**O que não serve para AGT v3:**
+
+- o recibo actual não usa série fiscal;
+- não há assinatura RSA;
+- não há rectificação/anulação formal;
+- o snapshot não guarda cadeia fiscal nem `HashControl` real.
+
+### 1.4 Auditoria, outbox e retenção
+
+**Existe hoje:**
+
+- `recordAuditServer(...)` em vários fluxos sensíveis;
+- `audit_logs` e `outbox_events` são usados por emissão de documentos e pagamentos;
+- já existe automação de arquivamento/live events em torno de documentos.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- o produto já tem primitives de append-only operacional;
+- dá para reaproveitar outbox para exportações, submissões, notificações e trilho de eventos fiscais;
+- retenção/arquivamento já existe como preocupação de plataforma.
+
+**Reutilizar sem duplicar:**
+
+- outbox worker;
+- audit trail transversal;
+- storage de artefactos finais;
+- observabilidade de emissão.
+
+**Gap:**
+
+- o fiscal precisa de **tabela própria de eventos fiscais imutáveis**, não apenas logs genéricos.
+
+### 1.5 Motor financeiro operacional
+
+**Existe hoje:**
+
+- tabelas e APIs para `pagamentos`, `mensalidades`, `fecho_caixa`, `conciliacao_uploads`, cobranças e dashboards;
+- MVs e wrappers para radar de inadimplência e status de pagamentos;
+- listagens e exports operacionais no portal financeiro.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- o módulo fiscal precisa de fontes confiáveis de cobrança, pagamento e catálogo escolar;
+- grande parte dos dados comerciais já existe no ERP escolar;
+- dá para gerar faturas/recibos fiscais a partir de eventos financeiros reais, em vez de criar um sistema paralelo.
+
+**Reutilizar sem duplicar:**
+
+- `pagamentos` e `mensalidades` como origem operacional;
+- configuração de preços/tabelas;
+- telas financeiras existentes como ponto de entrada;
+- dashboards e MVs não fiscais para visibilidade operacional.
+
+**Gap:**
+
+- o modelo financeiro actual não é um ledger fiscal fechado;
+- nem tudo que existe em `pagamentos`/`mensalidades` tem semântica fiscal suficiente para SAF-T(AO).
+
+### 1.6 Permissões, features e posicionamento comercial
+
+**Existe hoje:**
+
+- permissões incluem `emitir_recibo` e `emitir_nota_fiscal`;
+- o plano premium já comunica “Financeiro + Fiscal”; 
+- o feature flag `fin_recibo_pdf` está implementado no backend e no frontend.
+
+**Porque isto interessa ao Fiscal v3:**
+
+- o conceito de monetizar fiscal como capability premium já está parcialmente modelado;
+- dá para plugar o módulo novo sem reinventar o plano/entitlements layer.
+
+**Reutilizar sem duplicar:**
+
+- `app_plan_limits` / feature flags;
+- UI de assinatura/upsell;
+- guardas backend por plano.
+
+**Gap:**
+
+- não há feature gates específicas do fiscal (`fiscal_core`, `fiscal_saft_export`, `fiscal_series_admin`, etc.).
+
+---
+
+## 2) O que existe mas NÃO deve ser reutilizado como núcleo fiscal
+
+### 2.1 `documentos_emitidos` como tabela canónica fiscal
+
+É tentador estender essa tabela, mas isso seria erro de arquitectura.
+
+**Porquê:**
+
+- mistura documentos académicos, comprovantes e recibos;
+- o tenant é `escola_id`, não `empresa_id`;
+- a revogação actual não modela rectificação/origem do documento fiscal;
+- o hash actual é de validação pública, não assinatura regulamentar;
+- não há itens, impostos, séries, chaves, exportações, origem documental e encadeamento.
+
+**Decisão certa:**
+
+- manter `documentos_emitidos` para documentos não fiscais e recibos legados/operacionais;
+- criar **novo schema/tabelas fiscais** para o ledger AGT.
+
+### 2.2 `next_documento_numero(...)`
+
+Também não deve ser reaproveitado como gerador fiscal.
+
+**Porquê:**
+
+- é sequencial genérico por escola;
+- não respeita a unidade de continuidade `empresa + tipo + série + origem`;
+- não suporta descontinuação de série, formação, contingência ou recuperação manual.
+
+**Decisão certa:**
+
+- novo reservador transacional por `serie_id` com `SELECT ... FOR UPDATE`.
+
+### 2.3 `hash_validacao`
+
+**Não confundir** hash de validação pública com assinatura fiscal.
+
+**Porquê:**
+
+- hoje ele é gerado com `sha256(randomUUID + timestamp + ids...)`;
+- isso resolve verificação pública simples, mas não prova integridade normativa do encadeamento documental;
+- não há `key_version`, `public_key_pem`, `HashControl` formal nem cadeia por documento anterior.
+
+**Decisão certa:**
+
+- manter `hash_validacao` só como mecanismo legado/documental onde fizer sentido;
+- introduzir subsistema RSA fiscal separado.
+
+---
+
+## 3) Lacunas reais para o KLASSE Fiscal v3
+
+### 3.1 Bounded context fiscal inexistente
+
+Hoje não há nenhum núcleo com:
+
+- `empresas`;
+- `empresa_users`;
+- `fiscal_series`;
+- `fiscal_chaves`;
+- `fiscal_documentos`;
+- `fiscal_documento_itens`;
+- `fiscal_documentos_eventos`;
+- `fiscal_saft_exports`.
+
+**Isto é blocker absoluto.** Sem isso, o produto continua a emitir documentos operacionais, não documentos fiscais certificáveis.
+
+### 3.2 Assinatura RSA e gestão de chaves inexistentes
+
+Não encontrei no código/migrations:
+
+- geração/armazenamento de chaves fiscais versionadas;
+- assinatura RSA server-side;
+- `key_version` persistida por documento;
+- cadeia por assinatura/documento anterior.
+
+**Isto é o maior gap de conformidade.**
+
+### 3.3 SAF-T(AO) inexistente
+
+Não encontrei:
+
+- schema de exportação fiscal;
+- gerador XML SAF-T(AO);
+- validação XSD;
+- tabela de artefactos de export fiscal;
+- trilho de export por período.
+
+**Sem isso, o módulo não passa de faturação interna.**
+
+### 3.4 Séries fiscais, rectificação, anulação e origem documental inexistentes
+
+Não existe modelação actual para:
+
+- série activa/inactiva/descontinuada;
+- origem do documento (`interno`, `manual_recuperado`, `integrado`, `formacao`, `contingencia`);
+- rectificação formal sem `UPDATE` destrutivo;
+- documento originado de outro documento com referência obrigatória;
+- anulação formal com evidência fiscal própria.
+
+### 3.5 Ledger fiscal imutável separado do operativo inexistente
+
+Hoje o sistema guarda snapshots imutáveis de alguns documentos, mas não existe:
+
+- append-only fiscal por evento;
+- separação clara entre rascunho comercial e documento fiscal emitido;
+- proibição sistémica de mutação fiscal com trilho de evidência específico.
+
+### 3.6 Tenant fiscal por empresa/NIF inexistente
+
+Hoje o multi-tenant do produto gira em torno de `escola_id`.
+
+Isso é suficiente para o ERP escolar, mas **não garante o modelo correcto do fiscal** quando existir:
+
+- grupo económico;
+- mais de uma entidade emissora;
+- escola com operação em nome de empresa diferente;
+- multi-campus com mesma empresa fiscal;
+- eventual B2B/B2G fora da estrutura escolar.
+
+### 3.7 Portal financeiro sem módulo fiscal funcional
+
+Existe a rota `/escola/[id]/(portal)/financeiro/fiscal/page.tsx`, mas ela só redirecciona para `/financeiro`.
+
+Na prática, o portal financeiro **ainda não tem cockpit fiscal**.
+
+---
+
+## 4) O que precisamos construir agora, sem duplicação
+
+### 4.1 Camada de domínio fiscal nova
+
+Criar novas tabelas/migrations para o núcleo fiscal, separadas do legado de documentos:
+
+- `empresas`
+- `empresa_users`
+- `fiscal_series`
+- `fiscal_chaves`
+- `fiscal_documentos`
+- `fiscal_documento_itens`
+- `fiscal_documentos_eventos`
+- `fiscal_saft_exports`
+
+**Regra prática:** não mover o legado para dentro disso agora; criar ponte gradual.
+
+### 4.2 Mapeamento escola → empresa fiscal
+
+Precisamos de uma decisão explícita de produto e dados:
+
+- uma escola tem exactamente uma empresa fiscal?
+- uma empresa fiscal pode servir várias escolas/unidades?
+- escolas piloto existentes já têm NIF/razão social válidos?
+
+**Minha recomendação:**
+
+- criar relação explícita `escola_fiscal_binding(escola_id, empresa_id, is_primary, effective_from, effective_to)`;
+- não assumir implicitamente que `escola == empresa` para sempre.
+
+### 4.3 Serviço de assinatura server-side
+
+Construir serviço interno de assinatura com:
+
+- lookup da chave activa por `empresa_id`;
+- construção de string canónica;
+- assinatura RSA no backend/KMS;
+- persistência de `assinatura_base64`, `hash_control`, `key_version`;
+- rollback transacional se qualquer etapa falhar.
+
+### 4.4 Numeração transacional por série
+
+Implementar função do tipo `fiscal_reservar_numero_serie(...)` com lock pessimista.
+
+**Sem improviso no frontend. Sem sequencial genérico.**
+
+### 4.5 API fiscal separada do recibo operacional
+
+Criar namespace novo:
+
+- `POST /api/fiscal/documentos`
+- `POST /api/fiscal/documentos/{id}/rectificar`
+- `POST /api/fiscal/documentos/{id}/anular`
+- `GET /api/fiscal/documentos`
+- `GET /api/fiscal/documentos/{id}`
+- `POST /api/fiscal/saft/export`
+
+**Não acoplar isto em `/api/financeiro/recibos/emitir`.**
+
+### 4.6 UI fiscal plugada ao portal financeiro
+
+O portal financeiro deve ganhar área própria para:
+
+- séries;
+- empresa/NIF emissor;
+- chaves e certificação;
+- emissão de factura;
+- rectificação/anulação;
+- exportações SAF-T;
+- trilho de eventos fiscais;
+- estado de contingência/formação.
+
+**Mas sem duplicar** dashboards operacionais já existentes de pagamentos, radar e fecho.
+
+### 4.7 Ponte com dados já existentes
+
+Precisamos de adaptadores, não duplicação:
+
+- `mensalidades` e `pagamentos` continuam como origem operacional;
+- o fiscal consome esses dados para gerar documento fiscal quando aplicável;
+- recibo operacional actual pode coexistir durante transição;
+- documentos fiscais emitidos passam a ser a fonte oficial para XML/PDF fiscal.
+
+---
+
+## 5) Mapa de reaproveitamento recomendado
+
+### Reaproveitar directamente
+
+- autenticação server-side Supabase;
+- `resolveEscolaIdForUser` como inspiração para um `resolveEmpresaFiscalForUser`;
+- `recordAuditServer` e outbox;
+- infra de storage para PDFs/XMLs;
+- idempotência por operação;
+- guards de plano/permissões;
+- componentes de render final, QR e impressão pós-emissão;
+- consultas operacionais a `pagamentos`, `mensalidades`, `alunos`, `escolas`.
+
+### Reaproveitar só como referência de design
+
+- `documentos_emitidos`;
+- `emitir_documento_final(...)`;
+- `emitir_recibo(...)`;
+- URL pública `/api/public/documentos/[publicId]`.
+
+### Não reaproveitar como núcleo do fiscal
+
+- `hash_validacao`;
+- `next_documento_numero(...)`;
+- tabela única de documentos mistos;
+- recibo actual como substituto de fatura fiscal;
+- redirect placeholder da rota `/financeiro/fiscal`.
+
+---
+
+## 6) Riscos e pressupostos que eu NÃO compraria sem validação
+
+### Pressuposto perigoso 1
+“Se já emitimos recibo com QR, estamos perto da certificação.”
+
+**Não.** Isso é conforto falso. QR + hash público resolve validação superficial, não conformidade fiscal.
+
+### Pressuposto perigoso 2
+“Dá para evoluir `documentos_emitidos` incrementalmente até virar fiscal.”
+
+**Risco alto.** Vai misturar domínios, gerar dívida regulatória e tornar migração/SAF-T mais frágil.
+
+### Pressuposto perigoso 3
+“Podemos usar `escola_id` como empresa fiscal.”
+
+**Só como atalho temporário de bootstrap**, nunca como contrato permanente.
+
+### Pressuposto perigoso 4
+“Assinatura pode ficar para depois; emitimos primeiro.”
+
+**Errado para v3.** Sem assinatura e numeração certa, vais emitir histórico que depois não consegues ‘corrigir’ sem risco regulatório.
+
+---
+
+## 7) Plano de implementação pragmático
+
+### Fase 0 — Descoberta e decisões de contrato
+
+- fechar a modelagem escola ↔ empresa fiscal;
+- definir tipos documentais do v3 inicial;
+- decidir provider de chaves (KMS/HSM/secret manager);
+- confirmar layout mínimo de PDF fiscal e dados obrigatórios;
+- congelar a string canónica e o formato de `HashControl`.
+
+### Fase 1 — Fundamentos de dados
+
+- migrations do núcleo fiscal;
+- RLS por `empresa_id`;
+- binds escola/empresa;
+- políticas e índices;
+- eventos append-only;
+- storage buckets de artefactos fiscais.
+
+### Fase 2 — Emissão fiscal
+
+- reservar número por série;
+- montar documento e itens;
+- assinar com RSA;
+- persistir documento + evento;
+- gerar PDF final;
+- bloquear alteração posterior.
+
+### Fase 3 — Rectificação, anulação e reimpressão
+
+- rectificativo formal;
+- anulação formal;
+- eventos obrigatórios;
+- regras de origem e referência.
+
+### Fase 4 — SAF-T(AO)
+
+- extractor por período;
+- serialização XML;
+- validação XSD;
+- storage + checksum;
+- UI de export e histórico.
+
+### Fase 5 — Plug final no portal financeiro
+
+- cockpit fiscal;
+- série/chaves/empresa;
+- emissão/listagem/detalhe;
+- exports SAF-T;
+- alertas de conformidade.
+
+---
+
+## 8) Resposta objetiva à pergunta “o que já existe e o que é necessário?”
+
+### Já existe
+
+- multi-tenant escolar e guards maduros;
+- auditoria/outbox/storage;
+- documentos emitidos com snapshot e validação pública;
+- recibos operacionais emitidos no financeiro;
+- pagamentos, mensalidades, fecho, conciliação, cobranças, dashboards e MVs;
+- permissões e gating comercial para evoluir fiscal.
+
+### Necessário para plugar o Fiscal v3
+
+- tenant fiscal por `empresa_id`;
+- ledger fiscal novo;
+- séries fiscais e numeração contínua;
+- assinatura RSA com `key_version`;
+- `HashControl` formal;
+- rectificação/anulação/origem documental;
+- eventos fiscais append-only;
+- exportação SAF-T(AO);
+- cockpit fiscal próprio no portal financeiro.
+
+### A decisão de arquitectura certa
+
+**Plugar o módulo fiscal ao portal financeiro, sim.**
+
+**Reusar o core actual de recibos/documentos como se já fosse o fiscal, não.**
+
+A abordagem correta é:
+
+- **reusar infra transversal**;
+- **isolar domínio fiscal novo**;
+- **integrar com o financeiro operacional existente**.
+
+Isso evita duplicação, preserva o que já funciona e não compromete a futura certificação.

--- a/apps/web/src/app/api/fiscal/documentos/route.ts
+++ b/apps/web/src/app/api/fiscal/documentos/route.ts
@@ -1,0 +1,322 @@
+import { NextResponse } from "next/server";
+import { supabaseRouteClient } from "@/lib/supabaseServer";
+import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
+import {
+  type PostFiscalDocumentoInput,
+  postFiscalDocumentoSchema,
+} from "@/lib/schemas/fiscal-documento.schema";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+type JsonRecord = Record<string, unknown>;
+
+type FiscalSerieLookup = {
+  id: string;
+  empresa_id: string;
+  tipo_documento: string;
+  prefixo: string;
+  origem_documento: string;
+  ativa: boolean;
+  descontinuada_em: string | null;
+};
+
+const ALLOWED_FISCAL_ROLES = ["owner", "admin", "operator"] as const;
+
+function jsonError(status: number, code: string, message: string, details?: JsonRecord) {
+  return NextResponse.json(
+    {
+      ok: false,
+      error: {
+        code,
+        message,
+        details: details ?? null,
+      },
+    },
+    { status }
+  );
+}
+
+async function parseRequestBody(req: Request) {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}
+
+export async function POST(req: Request) {
+  const requestId = crypto.randomUUID();
+  const body = await parseRequestBody(req);
+  const parsed = postFiscalDocumentoSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return jsonError(400, "INVALID_PAYLOAD", "O corpo da requisição é inválido.", {
+      request_id: requestId,
+      field_errors: parsed.error.flatten().fieldErrors,
+      form_errors: parsed.error.flatten().formErrors,
+    });
+  }
+
+  try {
+    const supabase = await supabaseRouteClient<any>();
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return jsonError(401, "UNAUTHENTICATED", "Utilizador não autenticado.", {
+        request_id: requestId,
+      });
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase as any, user.id);
+    const authz = await requireFiscalAccess({
+      supabase,
+      userId: user.id,
+      empresaId: parsed.data.empresa_id,
+      escolaId,
+    });
+
+    if (!authz.ok) {
+      return jsonError(authz.status, authz.code, authz.message, {
+        request_id: requestId,
+        empresa_id: parsed.data.empresa_id,
+        escola_id: escolaId,
+      });
+    }
+
+    const semanticSeries = await resolveSerieSemantica({
+      supabase,
+      input: parsed.data,
+      escolaId,
+      requestId,
+    });
+
+    if (!semanticSeries.ok) {
+      return jsonError(
+        semanticSeries.status,
+        semanticSeries.code,
+        semanticSeries.message,
+        semanticSeries.details
+      );
+    }
+
+    const activeKey = await resolveChaveActiva({
+      supabase,
+      empresaId: parsed.data.empresa_id,
+      requestId,
+    });
+
+    if (!activeKey.ok) {
+      return jsonError(activeKey.status, activeKey.code, activeKey.message, activeKey.details);
+    }
+
+    return jsonError(
+      501,
+      "FISCAL_EMISSAO_ATOMICA_PENDENTE",
+      "A emissão fiscal permanece bloqueada até a introdução da RPC atómica que una reserva de número, assinatura e persistência sem risco de buracos na sequência.",
+      {
+        request_id: requestId,
+        empresa_id: parsed.data.empresa_id,
+        serie_id: semanticSeries.data.id,
+        tipo_documento: parsed.data.tipo_documento,
+        prefixo_serie: parsed.data.prefixo_serie,
+        origem_documento: parsed.data.origem_documento,
+        key_version: activeKey.data.key_version,
+      }
+    );
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro interno ao preparar emissão fiscal.";
+    return jsonError(500, "FISCAL_ROUTE_INTERNAL_ERROR", message, { request_id: requestId });
+  }
+}
+
+async function requireFiscalAccess({
+  supabase,
+  userId,
+  empresaId,
+  escolaId,
+}: {
+  supabase: any;
+  userId: string;
+  empresaId: string;
+  escolaId: string | null;
+}) {
+  const { data: membership, error } = await supabase
+    .from("fiscal_empresa_users")
+    .select("role")
+    .eq("empresa_id", empresaId)
+    .eq("user_id", userId)
+    .in("role", [...ALLOWED_FISCAL_ROLES])
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false as const,
+      status: 500,
+      code: "FISCAL_AUTH_CHECK_FAILED",
+      message: error.message || "Falha ao validar acesso fiscal.",
+    };
+  }
+
+  if (!membership) {
+    return {
+      ok: false as const,
+      status: 403,
+      code: "FORBIDDEN",
+      message: "Sem acesso fiscal à empresa informada.",
+    };
+  }
+
+  if (!escolaId) {
+    return { ok: true as const };
+  }
+
+  const { data: binding, error: bindingError } = await supabase
+    .from("fiscal_escola_bindings")
+    .select("id")
+    .eq("empresa_id", empresaId)
+    .eq("escola_id", escolaId)
+    .is("effective_to", null)
+    .limit(1)
+    .maybeSingle();
+
+  if (bindingError) {
+    return {
+      ok: false as const,
+      status: 500,
+      code: "FISCAL_BINDING_CHECK_FAILED",
+      message: bindingError.message || "Falha ao validar vínculo escola→empresa fiscal.",
+    };
+  }
+
+  if (!binding) {
+    return {
+      ok: false as const,
+      status: 403,
+      code: "FISCAL_ESCOLA_BINDING_NOT_FOUND",
+      message: "A escola actual do utilizador não está vinculada à empresa fiscal informada.",
+    };
+  }
+
+  return { ok: true as const };
+}
+
+async function resolveSerieSemantica({
+  supabase,
+  input,
+  escolaId,
+  requestId,
+}: {
+  supabase: any;
+  input: PostFiscalDocumentoInput;
+  escolaId: string | null;
+  requestId: string;
+}) {
+  const { data, error } = await supabase
+    .from("fiscal_series")
+    .select("id, empresa_id, tipo_documento, prefixo, origem_documento, ativa, descontinuada_em")
+    .eq("empresa_id", input.empresa_id)
+    .eq("tipo_documento", input.tipo_documento)
+    .eq("prefixo", input.prefixo_serie)
+    .eq("origem_documento", input.origem_documento)
+    .eq("ativa", true)
+    .is("descontinuada_em", null)
+    .limit(2);
+
+  if (error) {
+    return {
+      ok: false as const,
+      status: 500,
+      code: "SERIE_LOOKUP_FAILED",
+      message: error.message || "Falha ao resolver semanticamente a série fiscal.",
+      details: {
+        request_id: requestId,
+        escola_id: escolaId,
+        empresa_id: input.empresa_id,
+        tipo_documento: input.tipo_documento,
+        prefixo_serie: input.prefixo_serie,
+        origem_documento: input.origem_documento,
+      },
+    };
+  }
+
+  const rows = ((data ?? []) as FiscalSerieLookup[]);
+  if (rows.length === 0) {
+    return {
+      ok: false as const,
+      status: 404,
+      code: "SERIE_NAO_ENCONTRADA",
+      message: "Nenhuma série activa encontrada para a combinação semântica informada.",
+      details: {
+        request_id: requestId,
+        escola_id: escolaId,
+        empresa_id: input.empresa_id,
+        tipo_documento: input.tipo_documento,
+        prefixo_serie: input.prefixo_serie,
+        origem_documento: input.origem_documento,
+      },
+    };
+  }
+
+  if (rows.length > 1) {
+    return {
+      ok: false as const,
+      status: 409,
+      code: "SERIE_AMBIGUA",
+      message: "Mais de uma série activa corresponde ao contrato semântico informado.",
+      details: {
+        request_id: requestId,
+        escola_id: escolaId,
+        empresa_id: input.empresa_id,
+        tipo_documento: input.tipo_documento,
+        prefixo_serie: input.prefixo_serie,
+        origem_documento: input.origem_documento,
+      },
+    };
+  }
+
+  return { ok: true as const, data: rows[0] };
+}
+
+async function resolveChaveActiva({
+  supabase,
+  empresaId,
+  requestId,
+}: {
+  supabase: any;
+  empresaId: string;
+  requestId: string;
+}) {
+  const { data, error } = await supabase
+    .from("fiscal_chaves")
+    .select("key_version, status, private_key_ref")
+    .eq("empresa_id", empresaId)
+    .eq("status", "active")
+    .maybeSingle();
+
+  if (error) {
+    return {
+      ok: false as const,
+      status: 500,
+      code: "CHAVE_LOOKUP_FAILED",
+      message: error.message || "Falha ao localizar a chave fiscal activa.",
+      details: { request_id: requestId, empresa_id: empresaId },
+    };
+  }
+
+  if (!data) {
+    return {
+      ok: false as const,
+      status: 409,
+      code: "CHAVE_FISCAL_INDISPONIVEL",
+      message: "A empresa não possui chave fiscal activa para emissão.",
+      details: { request_id: requestId, empresa_id: empresaId },
+    };
+  }
+
+  return { ok: true as const, data };
+}

--- a/apps/web/src/lib/schemas/fiscal-documento.schema.ts
+++ b/apps/web/src/lib/schemas/fiscal-documento.schema.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+export const FISCAL_ORIGENS_DOCUMENTO = [
+  "interno",
+  "manual_recuperado",
+  "integrado",
+  "formacao",
+  "contingencia",
+] as const;
+
+export const FISCAL_TIPOS_DOCUMENTO = ["FR", "FT", "NC", "ND", "RC"] as const;
+
+export const fiscalDocumentoItemSchema = z.object({
+  descricao: z.string().trim().min(1).max(500),
+  quantidade: z.coerce.number().positive(),
+  preco_unit: z.coerce.number().min(0),
+  taxa_iva: z.coerce.number().min(0).max(100),
+});
+
+export const fiscalDocumentoClienteSchema = z.object({
+  id: z.string().uuid().optional(),
+  nome: z.string().trim().min(1).max(255),
+  nif: z
+    .string()
+    .trim()
+    .regex(/^\d{9,20}$/)
+    .optional(),
+});
+
+export const postFiscalDocumentoSchema = z
+  .object({
+    empresa_id: z.string().uuid(),
+    tipo_documento: z.enum(FISCAL_TIPOS_DOCUMENTO),
+    prefixo_serie: z.string().trim().min(1).max(50),
+    origem_documento: z.enum(FISCAL_ORIGENS_DOCUMENTO).default("interno"),
+    cliente: fiscalDocumentoClienteSchema,
+    documento_origem_id: z.string().uuid().nullable().optional(),
+    rectifica_documento_id: z.string().uuid().nullable().optional(),
+    invoice_date: z.string().date(),
+    moeda: z.string().trim().length(3).transform((value) => value.toUpperCase()),
+    taxa_cambio_aoa: z.coerce.number().positive().nullable().optional(),
+    itens: z.array(fiscalDocumentoItemSchema).min(1).max(500),
+    metadata: z.record(z.string(), z.unknown()).optional(),
+  })
+  .superRefine((data, ctx) => {
+    const moeda = data.moeda.toUpperCase();
+
+    if (moeda !== "AOA" && !data.taxa_cambio_aoa) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["taxa_cambio_aoa"],
+        message: "taxa_cambio_aoa é obrigatória quando moeda != 'AOA'",
+      });
+    }
+
+    if (moeda === "AOA" && data.taxa_cambio_aoa != null) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["taxa_cambio_aoa"],
+        message: "taxa_cambio_aoa deve ser nula quando moeda = 'AOA'",
+      });
+    }
+
+    if (data.tipo_documento === "NC" && !data.rectifica_documento_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["rectifica_documento_id"],
+        message: "rectifica_documento_id é obrigatório para nota de crédito",
+      });
+    }
+  });
+
+export type PostFiscalDocumentoInput = z.infer<typeof postFiscalDocumentoSchema>;

--- a/docs/api/fiscal-documentos.md
+++ b/docs/api/fiscal-documentos.md
@@ -1,0 +1,182 @@
+# API — Fiscal / Documentos
+
+## Endpoint
+
+`POST /api/fiscal/documentos`
+
+## Objetivo
+
+Preparar a emissão fiscal no padrão híbrido do KLASSE:
+
+- contrato público semântico na API;
+- resolução interna de `serie_id`;
+- guarda de acesso fiscal por `empresa_id`;
+- bloqueio explícito da emissão até existir uma RPC atómica que evite buracos na sequência.
+
+## Contrato público
+
+### Request
+
+```json
+{
+  "empresa_id": "uuid",
+  "tipo_documento": "FR",
+  "prefixo_serie": "2026",
+  "origem_documento": "interno",
+  "cliente": {
+    "id": "uuid-opcional",
+    "nome": "Empresa X",
+    "nif": "5000000000"
+  },
+  "documento_origem_id": null,
+  "rectifica_documento_id": null,
+  "invoice_date": "2026-03-19",
+  "moeda": "AOA",
+  "taxa_cambio_aoa": null,
+  "itens": [
+    {
+      "descricao": "Mensalidade Março",
+      "quantidade": 1,
+      "preco_unit": 25000,
+      "taxa_iva": 14
+    }
+  ],
+  "metadata": {
+    "canal": "portal_financeiro"
+  }
+}
+```
+
+### Regras
+
+- `origem_documento` é opcional no cliente, mas no backend assume `interno` por default.
+- A API nunca expõe `serie_id` como argumento público.
+- A lookup semântica usa:
+  - `empresa_id`
+  - `tipo_documento`
+  - `prefixo_serie`
+  - `origem_documento`
+- A rota é sempre `no-store`.
+
+## Estado actual
+
+A rota foi criada em modo **guarded merge-ready**:
+
+- valida o request;
+- autentica o utilizador;
+- verifica membership fiscal;
+- confirma vínculo `escola -> empresa fiscal` quando existir contexto escolar;
+- resolve semanticamente a série activa;
+- verifica existência de chave fiscal activa;
+- responde `501 FISCAL_EMISSAO_ATOMICA_PENDENTE` até existir uma RPC atómica de emissão.
+
+## Porque a emissão está bloqueada
+
+Emitir directamente pela route, sem uma RPC transaccional única, abre o risco de:
+
+- reservar número e falhar antes de persistir o documento;
+- criar buracos indevidos na sequência fiscal;
+- quebrar o encadeamento entre reserva, assinatura e insert.
+
+Em fiscal, isso é inaceitável.
+
+## Respostas previstas
+
+### 201 Created
+
+Reservado para quando a RPC atómica existir.
+
+### 400 INVALID_PAYLOAD
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "INVALID_PAYLOAD",
+    "message": "O corpo da requisição é inválido."
+  }
+}
+```
+
+### 401 UNAUTHENTICATED
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "UNAUTHENTICATED",
+    "message": "Utilizador não autenticado."
+  }
+}
+```
+
+### 403 FORBIDDEN
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "FORBIDDEN",
+    "message": "Sem acesso fiscal à empresa informada."
+  }
+}
+```
+
+### 404 SERIE_NAO_ENCONTRADA
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "SERIE_NAO_ENCONTRADA",
+    "message": "Nenhuma série activa encontrada para a combinação semântica informada."
+  }
+}
+```
+
+### 409 SERIE_AMBIGUA
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "SERIE_AMBIGUA",
+    "message": "Mais de uma série activa corresponde ao contrato semântico informado."
+  }
+}
+```
+
+### 409 CHAVE_FISCAL_INDISPONIVEL
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "CHAVE_FISCAL_INDISPONIVEL",
+    "message": "A empresa não possui chave fiscal activa para emissão."
+  }
+}
+```
+
+### 501 FISCAL_EMISSAO_ATOMICA_PENDENTE
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "FISCAL_EMISSAO_ATOMICA_PENDENTE",
+    "message": "A emissão fiscal permanece bloqueada até a introdução da RPC atómica que una reserva de número, assinatura e persistência sem risco de buracos na sequência."
+  }
+}
+```
+
+## Próximo passo obrigatório
+
+Criar uma RPC/fluxo atómico de emissão fiscal que una, na mesma operação lógica:
+
+1. reserva do número;
+2. cálculo do encadeamento;
+3. assinatura server-side/KMS;
+4. insert de `fiscal_documentos`;
+5. insert de `fiscal_documento_itens`;
+6. insert de `fiscal_documentos_eventos`.

--- a/supabase/migrations/20260319000000_create_fiscal_foundation.sql
+++ b/supabase/migrations/20260319000000_create_fiscal_foundation.sql
@@ -1,0 +1,805 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.fiscal_empresas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  nome text NOT NULL,
+  nif text NOT NULL,
+  endereco text,
+  certificado_agt_numero text,
+  status text NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'suspended', 'retired')),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT fiscal_empresas_nif_digits_chk CHECK (nif ~ '^[0-9]{9,20}$')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_fiscal_empresas_nif
+  ON public.fiscal_empresas (nif);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_empresa_users (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL,
+  role text NOT NULL CHECK (role IN ('owner', 'admin', 'operator', 'auditor')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (empresa_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_empresa_users_user
+  ON public.fiscal_empresa_users (user_id, empresa_id);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_escola_bindings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE CASCADE,
+  is_primary boolean NOT NULL DEFAULT false,
+  effective_from date NOT NULL DEFAULT current_date,
+  effective_to date,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT fiscal_escola_bindings_date_chk CHECK (effective_to IS NULL OR effective_to >= effective_from)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_fiscal_escola_bindings_range
+  ON public.fiscal_escola_bindings (escola_id, empresa_id, effective_from);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_fiscal_escola_bindings_primary_active
+  ON public.fiscal_escola_bindings (escola_id)
+  WHERE is_primary = true AND effective_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.fiscal_series (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE CASCADE,
+  tipo_documento text NOT NULL,
+  prefixo text NOT NULL,
+  origem_documento text NOT NULL CHECK (origem_documento IN ('interno', 'manual_recuperado', 'integrado', 'formacao', 'contingencia')),
+  ultimo_numero bigint NOT NULL DEFAULT 0,
+  ativa boolean NOT NULL DEFAULT true,
+  descontinuada_em timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (empresa_id, tipo_documento, prefixo, origem_documento),
+  CONSTRAINT fiscal_series_numero_chk CHECK (ultimo_numero >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_series_empresa_tipo
+  ON public.fiscal_series (empresa_id, tipo_documento, ativa);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_chaves (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE CASCADE,
+  key_version integer NOT NULL,
+  algorithm text NOT NULL DEFAULT 'RSA' CHECK (algorithm = 'RSA'),
+  public_key_pem text NOT NULL,
+  private_key_ref text,
+  key_fingerprint text NOT NULL,
+  status text NOT NULL CHECK (status IN ('pending', 'active', 'retired')),
+  activated_at timestamptz,
+  retired_at timestamptz,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (empresa_id, key_version),
+  CONSTRAINT fiscal_chaves_version_chk CHECK (key_version > 0),
+  CONSTRAINT fiscal_chaves_retired_chk CHECK (retired_at IS NULL OR status = 'retired')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_fiscal_chaves_active_per_empresa
+  ON public.fiscal_chaves (empresa_id)
+  WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS public.fiscal_documentos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE RESTRICT,
+  serie_id uuid NOT NULL REFERENCES public.fiscal_series(id) ON DELETE RESTRICT,
+  tipo_documento text NOT NULL,
+  numero bigint NOT NULL,
+  numero_formatado text NOT NULL,
+  cliente_id uuid,
+  cliente_nome text NOT NULL,
+  cliente_nif text,
+  invoice_date date NOT NULL,
+  system_entry timestamptz NOT NULL DEFAULT now(),
+  moeda text NOT NULL DEFAULT 'AOA',
+  taxa_cambio_aoa numeric(18,8),
+  total_bruto_aoa numeric(18,4) NOT NULL,
+  total_impostos_aoa numeric(18,4) NOT NULL,
+  total_liquido_aoa numeric(18,4) NOT NULL,
+  hash_anterior text,
+  assinatura_base64 text NOT NULL,
+  hash_control text NOT NULL,
+  canonical_string text,
+  key_version integer NOT NULL,
+  status text NOT NULL CHECK (status IN ('emitido', 'rectificado', 'anulado')),
+  documento_origem_id uuid,
+  rectifica_documento_id uuid REFERENCES public.fiscal_documentos(id) ON DELETE RESTRICT,
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  pdf_storage_path text,
+  xml_storage_path text,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (serie_id, numero),
+  UNIQUE (empresa_id, numero_formatado),
+  CONSTRAINT fiscal_documentos_totals_chk CHECK (
+    total_bruto_aoa >= 0
+    AND total_impostos_aoa >= 0
+    AND total_liquido_aoa >= 0
+  ),
+  CONSTRAINT fiscal_documentos_moeda_chk CHECK (char_length(moeda) = 3),
+  CONSTRAINT fiscal_documentos_cliente_nif_chk CHECK (cliente_nif IS NULL OR cliente_nif ~ '^[0-9]{9,20}$'),
+  CONSTRAINT fiscal_documentos_fk_key_version
+    FOREIGN KEY (empresa_id, key_version)
+    REFERENCES public.fiscal_chaves (empresa_id, key_version)
+    ON DELETE RESTRICT
+);
+
+ALTER TABLE public.fiscal_documentos
+  ADD CONSTRAINT fiscal_documentos_documento_origem_fk
+  FOREIGN KEY (documento_origem_id)
+  REFERENCES public.fiscal_documentos(id)
+  ON DELETE RESTRICT;
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_documentos_empresa_created
+  ON public.fiscal_documentos (empresa_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_documentos_empresa_status
+  ON public.fiscal_documentos (empresa_id, status, invoice_date DESC);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_documento_itens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE RESTRICT,
+  documento_id uuid NOT NULL REFERENCES public.fiscal_documentos(id) ON DELETE CASCADE,
+  linha_no integer NOT NULL,
+  descricao text NOT NULL,
+  quantidade numeric(18,4) NOT NULL,
+  preco_unit numeric(18,4) NOT NULL,
+  taxa_iva numeric(5,2) NOT NULL,
+  total_liquido_aoa numeric(18,4) NOT NULL,
+  total_impostos_aoa numeric(18,4) NOT NULL,
+  total_bruto_aoa numeric(18,4) NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (documento_id, linha_no),
+  CONSTRAINT fiscal_documento_itens_line_chk CHECK (linha_no > 0),
+  CONSTRAINT fiscal_documento_itens_values_chk CHECK (
+    quantidade > 0
+    AND preco_unit >= 0
+    AND taxa_iva >= 0
+    AND total_liquido_aoa >= 0
+    AND total_impostos_aoa >= 0
+    AND total_bruto_aoa >= 0
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_documento_itens_documento
+  ON public.fiscal_documento_itens (documento_id, linha_no);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_documentos_eventos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE RESTRICT,
+  documento_id uuid NOT NULL REFERENCES public.fiscal_documentos(id) ON DELETE CASCADE,
+  tipo_evento text NOT NULL CHECK (tipo_evento IN (
+    'EMITIDO',
+    'RECTIFICADO',
+    'ANULADO',
+    'PDF_GERADO',
+    'REIMPRESSO',
+    'SAFT_EXPORTADO',
+    'SUBMETIDO',
+    'CHAVE_ACTIVADA'
+  )),
+  payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_documentos_eventos_documento
+  ON public.fiscal_documentos_eventos (documento_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.fiscal_saft_exports (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  empresa_id uuid NOT NULL REFERENCES public.fiscal_empresas(id) ON DELETE CASCADE,
+  periodo_inicio date NOT NULL,
+  periodo_fim date NOT NULL,
+  arquivo_storage_path text NOT NULL,
+  checksum_sha256 text NOT NULL,
+  xsd_version text NOT NULL,
+  status text NOT NULL DEFAULT 'generated' CHECK (status IN ('generated', 'validated', 'failed', 'submitted')),
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (empresa_id, periodo_inicio, periodo_fim),
+  CONSTRAINT fiscal_saft_exports_period_chk CHECK (periodo_fim >= periodo_inicio)
+);
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_saft_exports_empresa_periodo
+  ON public.fiscal_saft_exports (empresa_id, periodo_inicio DESC, periodo_fim DESC);
+
+CREATE OR REPLACE FUNCTION public.fiscal_touch_updated_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_fiscal_empresas_updated_at ON public.fiscal_empresas;
+CREATE TRIGGER trg_fiscal_empresas_updated_at
+BEFORE UPDATE ON public.fiscal_empresas
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_fiscal_escola_bindings_updated_at ON public.fiscal_escola_bindings;
+CREATE TRIGGER trg_fiscal_escola_bindings_updated_at
+BEFORE UPDATE ON public.fiscal_escola_bindings
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_fiscal_series_updated_at ON public.fiscal_series;
+CREATE TRIGGER trg_fiscal_series_updated_at
+BEFORE UPDATE ON public.fiscal_series
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_touch_updated_at();
+
+DROP TRIGGER IF EXISTS trg_fiscal_chaves_updated_at ON public.fiscal_chaves;
+CREATE TRIGGER trg_fiscal_chaves_updated_at
+BEFORE UPDATE ON public.fiscal_chaves
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_touch_updated_at();
+
+CREATE OR REPLACE FUNCTION public.current_tenant_empresa_id()
+RETURNS uuid
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_claims jsonb := '{}'::jsonb;
+  v_empresa uuid := null;
+  v_uid uuid := public.safe_auth_uid();
+BEGIN
+  BEGIN
+    v_claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN others THEN
+    v_claims := '{}'::jsonb;
+  END;
+
+  IF (v_claims ? 'empresa_id') THEN
+    v_empresa := nullif(v_claims->>'empresa_id', '')::uuid;
+    IF v_empresa IS NOT NULL THEN
+      RETURN v_empresa;
+    END IF;
+  END IF;
+
+  IF (v_claims ? 'app_metadata') AND ((v_claims->'app_metadata') ? 'empresa_id') THEN
+    v_empresa := nullif((v_claims->'app_metadata')->>'empresa_id', '')::uuid;
+    IF v_empresa IS NOT NULL THEN
+      RETURN v_empresa;
+    END IF;
+  END IF;
+
+  IF v_uid IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT feu.empresa_id
+    INTO v_empresa
+  FROM public.fiscal_empresa_users feu
+  WHERE feu.user_id = v_uid
+  ORDER BY feu.created_at ASC
+  LIMIT 1;
+
+  RETURN v_empresa;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.user_has_role_in_empresa(
+  p_empresa_id uuid,
+  p_roles text[]
+)
+RETURNS boolean
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid uuid := public.safe_auth_uid();
+BEGIN
+  IF public.check_super_admin_role() THEN
+    RETURN true;
+  END IF;
+
+  IF v_uid IS NULL OR p_empresa_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  RETURN EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = p_empresa_id
+      AND feu.user_id = v_uid
+      AND feu.role = ANY (p_roles)
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fiscal_reservar_numero_serie(p_serie_id uuid)
+RETURNS TABLE (
+  numero bigint,
+  numero_formatado text
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_uid uuid := public.safe_auth_uid();
+  v_serie public.fiscal_series%ROWTYPE;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'AUTH: utilizador não autenticado';
+  END IF;
+
+  SELECT *
+    INTO v_serie
+  FROM public.fiscal_series
+  WHERE id = p_serie_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'DATA: série não encontrada';
+  END IF;
+
+  IF NOT public.user_has_role_in_empresa(v_serie.empresa_id, ARRAY['owner','admin','operator']) THEN
+    RAISE EXCEPTION 'AUTH: permissão negada para reservar número da série';
+  END IF;
+
+  IF NOT v_serie.ativa THEN
+    RAISE EXCEPTION 'STATE: série inativa';
+  END IF;
+
+  IF v_serie.descontinuada_em IS NOT NULL THEN
+    RAISE EXCEPTION 'STATE: série descontinuada';
+  END IF;
+
+  UPDATE public.fiscal_series
+     SET ultimo_numero = ultimo_numero + 1,
+         updated_at = now()
+   WHERE id = p_serie_id
+   RETURNING ultimo_numero INTO numero;
+
+  numero_formatado := v_serie.prefixo || '-' || lpad(numero::text, 6, '0');
+  RETURN NEXT;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fiscal_validate_document_consistency()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_serie_empresa_id uuid;
+BEGIN
+  SELECT empresa_id
+    INTO v_serie_empresa_id
+  FROM public.fiscal_series
+  WHERE id = NEW.serie_id;
+
+  IF v_serie_empresa_id IS NULL THEN
+    RAISE EXCEPTION 'DATA: série fiscal inválida';
+  END IF;
+
+  IF v_serie_empresa_id IS DISTINCT FROM NEW.empresa_id THEN
+    RAISE EXCEPTION 'TENANT: empresa do documento divergente da empresa da série';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fiscal_validate_item_consistency()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_documento_empresa_id uuid;
+BEGIN
+  SELECT empresa_id
+    INTO v_documento_empresa_id
+  FROM public.fiscal_documentos
+  WHERE id = NEW.documento_id;
+
+  IF v_documento_empresa_id IS NULL THEN
+    RAISE EXCEPTION 'DATA: documento fiscal inválido';
+  END IF;
+
+  IF v_documento_empresa_id IS DISTINCT FROM NEW.empresa_id THEN
+    RAISE EXCEPTION 'TENANT: empresa do item divergente da empresa do documento';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fiscal_validate_event_consistency()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public'
+AS $$
+DECLARE
+  v_documento_empresa_id uuid;
+BEGIN
+  SELECT empresa_id
+    INTO v_documento_empresa_id
+  FROM public.fiscal_documentos
+  WHERE id = NEW.documento_id;
+
+  IF v_documento_empresa_id IS NULL THEN
+    RAISE EXCEPTION 'DATA: documento fiscal inválido';
+  END IF;
+
+  IF v_documento_empresa_id IS DISTINCT FROM NEW.empresa_id THEN
+    RAISE EXCEPTION 'TENANT: empresa do evento divergente da empresa do documento';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fiscal_prevent_update_emitido()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.status IN ('emitido', 'rectificado', 'anulado') THEN
+    RAISE EXCEPTION 'IMMUTABILITY: documento fiscal fechado não pode ser alterado';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_fiscal_documentos_consistency ON public.fiscal_documentos;
+CREATE TRIGGER trg_fiscal_documentos_consistency
+BEFORE INSERT OR UPDATE ON public.fiscal_documentos
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_validate_document_consistency();
+
+DROP TRIGGER IF EXISTS trg_fiscal_documentos_no_update ON public.fiscal_documentos;
+CREATE TRIGGER trg_fiscal_documentos_no_update
+BEFORE UPDATE ON public.fiscal_documentos
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_prevent_update_emitido();
+
+DROP TRIGGER IF EXISTS trg_fiscal_documento_itens_consistency ON public.fiscal_documento_itens;
+CREATE TRIGGER trg_fiscal_documento_itens_consistency
+BEFORE INSERT OR UPDATE ON public.fiscal_documento_itens
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_validate_item_consistency();
+
+DROP TRIGGER IF EXISTS trg_fiscal_documentos_eventos_consistency ON public.fiscal_documentos_eventos;
+CREATE TRIGGER trg_fiscal_documentos_eventos_consistency
+BEFORE INSERT OR UPDATE ON public.fiscal_documentos_eventos
+FOR EACH ROW
+EXECUTE FUNCTION public.fiscal_validate_event_consistency();
+
+ALTER TABLE public.fiscal_empresas ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_empresas FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_empresa_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_empresa_users FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_escola_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_escola_bindings FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_series ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_series FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_chaves ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_chaves FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documentos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documentos FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documento_itens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documento_itens FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documentos_eventos ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_documentos_eventos FORCE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_saft_exports ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.fiscal_saft_exports FORCE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS fiscal_empresas_select ON public.fiscal_empresas;
+CREATE POLICY fiscal_empresas_select
+ON public.fiscal_empresas
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_empresas.id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_empresas_mutation ON public.fiscal_empresas;
+CREATE POLICY fiscal_empresas_mutation
+ON public.fiscal_empresas
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(id, ARRAY['owner','admin'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(id, ARRAY['owner','admin'])
+);
+
+DROP POLICY IF EXISTS fiscal_empresa_users_select ON public.fiscal_empresa_users;
+CREATE POLICY fiscal_empresa_users_select
+ON public.fiscal_empresa_users
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_empresa_users.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_empresa_users_mutation ON public.fiscal_empresa_users;
+CREATE POLICY fiscal_empresa_users_mutation
+ON public.fiscal_empresa_users
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+);
+
+DROP POLICY IF EXISTS fiscal_escola_bindings_select ON public.fiscal_escola_bindings;
+CREATE POLICY fiscal_escola_bindings_select
+ON public.fiscal_escola_bindings
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_escola_bindings.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_escola_bindings_mutation ON public.fiscal_escola_bindings;
+CREATE POLICY fiscal_escola_bindings_mutation
+ON public.fiscal_escola_bindings
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+);
+
+DROP POLICY IF EXISTS fiscal_series_select ON public.fiscal_series;
+CREATE POLICY fiscal_series_select
+ON public.fiscal_series
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_series.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_series_mutation ON public.fiscal_series;
+CREATE POLICY fiscal_series_mutation
+ON public.fiscal_series
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+);
+
+DROP POLICY IF EXISTS fiscal_chaves_select ON public.fiscal_chaves;
+CREATE POLICY fiscal_chaves_select
+ON public.fiscal_chaves
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_chaves.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_chaves_mutation ON public.fiscal_chaves;
+CREATE POLICY fiscal_chaves_mutation
+ON public.fiscal_chaves
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_select ON public.fiscal_documentos;
+CREATE POLICY fiscal_documentos_select
+ON public.fiscal_documentos
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_documentos.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_insert ON public.fiscal_documentos;
+CREATE POLICY fiscal_documentos_insert
+ON public.fiscal_documentos
+FOR INSERT
+TO authenticated
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_update ON public.fiscal_documentos;
+CREATE POLICY fiscal_documentos_update
+ON public.fiscal_documentos
+FOR UPDATE
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin'])
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_delete ON public.fiscal_documentos;
+CREATE POLICY fiscal_documentos_delete
+ON public.fiscal_documentos
+FOR DELETE
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner'])
+);
+
+DROP POLICY IF EXISTS fiscal_documento_itens_select ON public.fiscal_documento_itens;
+CREATE POLICY fiscal_documento_itens_select
+ON public.fiscal_documento_itens
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_documento_itens.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_documento_itens_mutation ON public.fiscal_documento_itens;
+CREATE POLICY fiscal_documento_itens_mutation
+ON public.fiscal_documento_itens
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_eventos_select ON public.fiscal_documentos_eventos;
+CREATE POLICY fiscal_documentos_eventos_select
+ON public.fiscal_documentos_eventos
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_documentos_eventos.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_documentos_eventos_mutation ON public.fiscal_documentos_eventos;
+CREATE POLICY fiscal_documentos_eventos_mutation
+ON public.fiscal_documentos_eventos
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+);
+
+DROP POLICY IF EXISTS fiscal_saft_exports_select ON public.fiscal_saft_exports;
+CREATE POLICY fiscal_saft_exports_select
+ON public.fiscal_saft_exports
+FOR SELECT
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR EXISTS (
+    SELECT 1
+    FROM public.fiscal_empresa_users feu
+    WHERE feu.empresa_id = fiscal_saft_exports.empresa_id
+      AND feu.user_id = public.safe_auth_uid()
+  )
+);
+
+DROP POLICY IF EXISTS fiscal_saft_exports_mutation ON public.fiscal_saft_exports;
+CREATE POLICY fiscal_saft_exports_mutation
+ON public.fiscal_saft_exports
+FOR ALL
+TO authenticated
+USING (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+)
+WITH CHECK (
+  public.check_super_admin_role()
+  OR public.user_has_role_in_empresa(empresa_id, ARRAY['owner','admin','operator'])
+);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_empresas TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_empresa_users TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_escola_bindings TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_series TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_chaves TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_documentos TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_documento_itens TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_documentos_eventos TO authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.fiscal_saft_exports TO authenticated;
+GRANT EXECUTE ON FUNCTION public.current_tenant_empresa_id() TO authenticated;
+GRANT EXECUTE ON FUNCTION public.user_has_role_in_empresa(uuid, text[]) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.fiscal_reservar_numero_serie(uuid) TO authenticated;
+
+COMMIT;

--- a/supabase/migrations/20260319010000_fiscal_series_semantic_lookup_index.sql
+++ b/supabase/migrations/20260319010000_fiscal_series_semantic_lookup_index.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_fiscal_series_semantic_lookup_active
+  ON public.fiscal_series (empresa_id, tipo_documento, prefixo, origem_documento)
+  WHERE ativa = true AND descontinuada_em IS NULL;
+
+COMMIT;


### PR DESCRIPTION
### Motivation

- Introduce a separate fiscal bounded context backed by explicit `empresa_id` tenant separation and avoid reusing the legacy `documentos_emitidos` as the fiscal ledger. 
- Provide the minimal data foundation to support series, key versioning, transactional number reservation, append-only events and SAF-T exports required for Fiscal v3 compliance. 
- Enforce strong tenant isolation, immutability and consistency checks at the database layer to reduce regulatory and migration risk. 

### Description

- Add a new migration `supabase/migrations/20260319000000_create_fiscal_foundation.sql` that creates fiscal tables: `fiscal_empresas`, `fiscal_empresa_users`, `fiscal_escola_bindings`, `fiscal_series`, `fiscal_chaves`, `fiscal_documentos`, `fiscal_documento_itens`, `fiscal_documentos_eventos` and `fiscal_saft_exports`. 
- Implement triggers, guardrail functions and constraints including `fiscal_touch_updated_at()`, `fiscal_validate_*` triggers, `fiscal_prevent_update_emitido()` and transactional number reservation via `fiscal_reservar_numero_serie()`. 
- Add tenant & permission helpers `current_tenant_empresa_id()` and `user_has_role_in_empresa(...)`, and enable strong RLS policies and grants for all new tables and functions. 
- Add documentation and rollout artifacts under `agents/outputs`: an inventory report `RELATORIO_INVENTARIO_MODULO_FISCAL_2026-03-19.md`, a phase plan `KLASSE_FISCAL_PHASE0_PHASE1_2026-03-19.md`, and apply-diff metadata files for the run. 

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbd40de4b8832693997efa11237bcb)