### PR TITLE
Add 'Formação' domain: UI, auth/permissions, plan gates, APIs and DB migrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -652,3 +652,36 @@ ENGINEERING_AGENTS_CONTRACT.md
 Se violar qualquer regra CRITICAL → FAIL imediato.
 Se violar qualquer regra sem excepção documentada → FAIL.
 Se REGRESSION detectada → FAIL imediato, independente de severidade.
+
+---
+
+## Aditamento Operacional — Formação (Ticket 5)
+
+### Taxonomia de rotas críticas (Formação)
+
+As seguintes rotas devem ser tratadas como **operacionais/financeiras sensíveis**:
+
+- `/api/formacao/financeiro/**`
+- `/api/formacao/cobrancas/**`
+- `/api/formacao/faturas/**`
+- `/api/formacao/honorarios/**`
+- `/api/secretaria/documentos/**` quando envolver emissão oficial com valor legal
+
+### Política de cache mandatória
+
+Para qualquer rota acima (ou equivalente em `/financeiro/**`):
+
+- Em API Route: `export const dynamic = 'force-dynamic'`
+- Em fetch de UI cliente/servidor: `cache: 'no-store'`
+- `revalidate > 0` é proibido para payload financeiro transacional
+
+### MVs obrigatórias para dashboards Formação
+
+- `internal.mv_formacao_cohorts_lotacao` → wrapper `public.vw_formacao_cohorts_lotacao`
+- `internal.mv_formacao_inadimplencia_resumo` → wrapper `public.vw_formacao_inadimplencia_resumo`
+- `internal.mv_formacao_margem_por_edicao` → wrapper `public.vw_formacao_margem_por_edicao`
+
+Cada MV deve ter:
+- `CREATE UNIQUE INDEX`
+- função `refresh_mv_*` com `REFRESH MATERIALIZED VIEW CONCURRENTLY`
+- agendamento `cron.schedule(...)`

--- a/agents/outputs/FORMACAO_TAXONOMY_CACHE_POLICY_2026-04-07.md
+++ b/agents/outputs/FORMACAO_TAXONOMY_CACHE_POLICY_2026-04-07.md
@@ -1,0 +1,63 @@
+# Formação — Taxonomia de Rotas, Cache e Observabilidade (Ticket 5)
+
+timestamp: 2026-04-07T00:00:00Z
+
+## 1) Rotas Formação classificadas
+
+### Financeiro transacional (no-store obrigatório)
+- `/api/formacao/financeiro/**`
+- `/api/formacao/cobrancas/**`
+- `/api/formacao/faturas/**`
+- `/api/formacao/honorarios/**`
+- `/api/financeiro/**`
+
+### Operações secretaria com valor legal (no-store obrigatório)
+- `/api/secretaria/documentos/**` (certificados, pautas oficiais, comprovativos)
+
+## 2) Política de cache mandatória
+
+Para rotas acima:
+- API route deve definir `export const dynamic = 'force-dynamic'`
+- Requests do frontend devem usar `cache: 'no-store'`
+- Evitar `revalidate > 0` para payload financeiro, pagamentos, recibos, extratos.
+
+## 3) MVs para dashboards de formação
+
+## MVs criadas
+- `internal.mv_formacao_cohorts_lotacao`
+- `internal.mv_formacao_inadimplencia_resumo`
+- `internal.mv_formacao_margem_por_edicao`
+
+## Wrappers públicos
+- `public.vw_formacao_cohorts_lotacao`
+- `public.vw_formacao_inadimplencia_resumo`
+- `public.vw_formacao_margem_por_edicao`
+
+## Refresh
+- `public.refresh_mv_formacao_cohorts_lotacao()` + cron a cada 5 minutos
+- `public.refresh_mv_formacao_inadimplencia_resumo()` + cron a cada 2 minutos
+- `public.refresh_mv_formacao_margem_por_edicao()` + cron a cada 10 minutos
+
+Todos os refresh usam `REFRESH MATERIALIZED VIEW CONCURRENTLY`.
+
+## 4) Observabilidade recomendada
+
+- Logar duração de endpoints de `/api/financeiro/**` e `/api/formacao/financeiro/**`
+- Alertar quando refresh de MV exceder 30s
+- Alertar quando percentual de erros 5xx em endpoints financeiros > 1% por 5 minutos
+- Adicionar tracing por `escola_id` para auditoria de latência tenant a tenant
+
+## 5) Checklist de hard rules para agentes
+
+- [ ] Sem query direta pesada em dashboard se MV equivalente existir
+- [ ] Sem `force-cache` em rotas financeiras
+- [ ] Sem `revalidate > 0` em pagamentos/recibos
+- [ ] Cada MV tem UNIQUE INDEX
+- [ ] Cada MV tem refresh function + cron
+
+## 6) Decisão de escalabilidade multi-tenant (recomendação)
+
+- Estratégia preferida: **schema partilhado** com isolamento por `tenant_id` + `tenant_type`.
+- `tenant_type` recomendado: `escola_k12 | centro_formacao`.
+- Razão: evita duplicação de infraestrutura, facilita billing unificado e casos híbridos (escola + formação).
+- Requisito: todas as tabelas novas devem manter `escola_id` (ou `tenant_id` consolidado) e políticas RLS estritas por tenant.

--- a/apps/web/src/app/(formacao-backoffice)/BackofficeShell.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/BackofficeShell.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { ComponentType, ReactNode } from 'react'
+import { BarChart3, BookOpen, LayoutDashboard, Settings, Shield, Wallet, UsersRound } from 'lucide-react'
+import { hasPermission, type Papel, type Permission } from '@/lib/permissions'
+
+type NavItem = {
+  href: string
+  label: string
+  icon: ComponentType<{ className?: string }>
+  perms: Permission[]
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { href: '/formacao/admin/dashboard', label: 'Dashboard', icon: LayoutDashboard, perms: ['visualizar_relatorios_globais'] },
+  { href: '/formacao/cohorts', label: 'Turmas', icon: UsersRound, perms: ['gerir_cohorts'] },
+  { href: '/formacao/secretaria/catalogo-cursos', label: 'Académico', icon: BookOpen, perms: ['gerir_cohorts'] },
+  { href: '/formacao/financeiro/dashboard', label: 'Financeiro', icon: Wallet, perms: ['visualizar_fluxo_caixa'] },
+  { href: '/formacao/admin/relatorios-kpi', label: 'Relatórios', icon: BarChart3, perms: ['visualizar_relatorios_globais'] },
+  { href: '/formacao/admin/configuracoes', label: 'Configurações', icon: Settings, perms: ['configurar_escola'] },
+  { href: '/formacao/admin/equipa', label: 'Utilizadores', icon: Shield, perms: ['editar_usuario'] },
+]
+
+export function BackofficeShell({
+  children,
+  papel,
+}: {
+  children: ReactNode
+  papel: Papel | null
+}) {
+  const pathname = usePathname() ?? ''
+  const allowedItems = NAV_ITEMS.filter((item) => item.perms.some((perm) => hasPermission(papel, perm)))
+
+  return (
+    <div className="min-h-screen bg-slate-100 text-sm">
+      <div className="flex min-h-screen">
+        <aside className="w-64 bg-slate-950 p-4">
+          <div className="mb-6 px-3 text-base font-semibold text-white">KLASSE Formação</div>
+          <nav className="space-y-1">
+            {allowedItems.map((item) => {
+              const Icon = item.icon
+              const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`flex items-center gap-2 rounded-xl px-3 py-2 ${
+                    active
+                      ? 'bg-slate-900 text-klasse-gold ring-1 ring-klasse-gold/25'
+                      : 'text-slate-400 hover:text-klasse-gold'
+                  }`}
+                >
+                  <Icon className="h-5 w-5" />
+                  <span>{item.label}</span>
+                </Link>
+              )
+            })}
+          </nav>
+        </aside>
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/page.tsx
@@ -1,0 +1,10 @@
+export default function FormacaoAdminOnboardingPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Onboarding do Centro</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Wizard inicial para dados legais, branding, primeiro curso e configuração operacional.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/certificados/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/certificados/page.tsx
@@ -1,0 +1,10 @@
+export default function CohortCertificadosPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Certificados</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Emissão em massa e conferência de certificados com validação por QR Code.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/formandos/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/formandos/page.tsx
@@ -1,0 +1,10 @@
+export default function CohortFormandosPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Formandos</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Gestão individual de presença, avaliação e estado de pagamento por formando.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/materiais/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/materiais/page.tsx
@@ -1,0 +1,10 @@
+export default function CohortMateriaisPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Materiais</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Repositório da edição para PDFs, links e conteúdos de suporte da turma.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/overview/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/overview/page.tsx
@@ -1,0 +1,10 @@
+export default function CohortOverviewPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Cohort Overview</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Estado da edição: vagas, inscritos, receita e margem (fonte: MVs de formação).
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/sessoes/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/[cohort_id]/sessoes/page.tsx
@@ -1,0 +1,10 @@
+export default function CohortSessoesPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Sessões</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Calendário operacional da edição com atribuição de formadores por sessão.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/cohorts/page.tsx
@@ -1,0 +1,10 @@
+export default function FormacaoCohortsPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Cohorts</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Listagem operacional das edições de formação e acesso rápido aos módulos da turma.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-backoffice)/layout.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/layout.tsx
@@ -1,0 +1,52 @@
+import { redirect } from 'next/navigation'
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+import type { ReactNode } from 'react'
+import { BackofficeShell } from './BackofficeShell'
+import { normalizePapel, type Papel } from '@/lib/permissions'
+import { getFormacaoContext } from '@/lib/auth/formacaoAccess'
+
+const ALLOWED_BACKOFFICE_ROLES = new Set([
+  'formacao_admin',
+  'formacao_secretaria',
+  'formacao_financeiro',
+])
+
+export default async function FormacaoBackofficeLayout({ children }: { children: ReactNode }) {
+  const context = await getFormacaoContext()
+  if (!context?.role) redirect('/login')
+  if (String(context.modeloEnsino ?? '').toLowerCase() !== 'formacao') redirect('/login')
+  if (!ALLOWED_BACKOFFICE_ROLES.has(context.role)) redirect('/login')
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !key || !context.escolaId) redirect('/login')
+
+  const cookieStore = await cookies()
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll() {
+        // no-op (server component)
+      },
+    },
+  })
+
+  const { data: userRes } = await supabase.auth.getUser()
+  const user = userRes?.user
+  if (!user) redirect('/login')
+
+  const { data: vinculo } = await supabase
+    .from('escola_users')
+    .select('papel, role')
+    .eq('user_id', user.id)
+    .eq('escola_id', context.escolaId)
+    .limit(1)
+    .maybeSingle()
+
+  const papel = normalizePapel((vinculo?.papel ?? vinculo?.role ?? context.role) as string) as Papel | null
+
+  return <BackofficeShell papel={papel}>{children}</BackofficeShell>
+}

--- a/apps/web/src/app/(formacao-formador)/formacao/honorarios/extrato/page.tsx
+++ b/apps/web/src/app/(formacao-formador)/formacao/honorarios/extrato/page.tsx
@@ -1,0 +1,8 @@
+export default function HonorariosExtratoPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Honorários — Extrato</h1>
+      <p className="mt-2 text-sm text-slate-600">Histórico imutável dos pagamentos já liquidados ao formador.</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-formador)/formacao/honorarios/pendente/page.tsx
+++ b/apps/web/src/app/(formacao-formador)/formacao/honorarios/pendente/page.tsx
@@ -1,0 +1,8 @@
+export default function HonorariosPendentePage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Honorários — Pendente</h1>
+      <p className="mt-2 text-sm text-slate-600">Valores aprovados e ainda não pagos para liquidação.</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-formador)/formacao/honorarios/recibos/page.tsx
+++ b/apps/web/src/app/(formacao-formador)/formacao/honorarios/recibos/page.tsx
@@ -1,0 +1,8 @@
+export default function HonorariosRecibosPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Honorários — Recibos</h1>
+      <p className="mt-2 text-sm text-slate-600">Download de recibos para suporte fiscal e declarações AGT.</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-formador)/layout.tsx
+++ b/apps/web/src/app/(formacao-formador)/layout.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { getFormacaoContext } from '@/lib/auth/formacaoAccess'
+
+const ALLOWED_FORMADOR_ROLES = new Set(['formador'])
+
+export default async function FormacaoFormadorLayout({ children }: { children: ReactNode }) {
+  const context = await getFormacaoContext()
+  if (!context?.role) redirect('/login')
+  if (String(context.modeloEnsino ?? '').toLowerCase() !== 'formacao') redirect('/login')
+  if (!ALLOWED_FORMADOR_ROLES.has(context.role)) redirect('/login')
+
+  return <div className="min-h-screen bg-slate-100 text-sm">{children}</div>
+}

--- a/apps/web/src/app/(formacao-formando)/formacao/conquistas/badges/page.tsx
+++ b/apps/web/src/app/(formacao-formando)/formacao/conquistas/badges/page.tsx
@@ -1,0 +1,8 @@
+export default function ConquistasBadgesPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Conquistas — Badges</h1>
+      <p className="mt-2 text-sm text-slate-600">Micro-credenciais por módulos concluídos (roadmap do formando).</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-formando)/formacao/conquistas/perfil-publico/page.tsx
+++ b/apps/web/src/app/(formacao-formando)/formacao/conquistas/perfil-publico/page.tsx
@@ -1,0 +1,10 @@
+export default function ConquistasPerfilPublicoPage() {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h1 className="text-sm font-semibold text-slate-900">Conquistas — Perfil Público</h1>
+      <p className="mt-2 text-sm text-slate-600">
+        Gestão da URL partilhável de validação de conquistas e certificados.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(formacao-formando)/layout.tsx
+++ b/apps/web/src/app/(formacao-formando)/layout.tsx
@@ -1,0 +1,14 @@
+import { redirect } from 'next/navigation'
+import type { ReactNode } from 'react'
+import { getFormacaoContext } from '@/lib/auth/formacaoAccess'
+
+const ALLOWED_FORMANDO_ROLES = new Set(['formando'])
+
+export default async function FormacaoFormandoLayout({ children }: { children: ReactNode }) {
+  const context = await getFormacaoContext()
+  if (!context?.role) redirect('/login')
+  if (String(context.modeloEnsino ?? '').toLowerCase() !== 'formacao') redirect('/login')
+  if (!ALLOWED_FORMANDO_ROLES.has(context.role)) redirect('/login')
+
+  return <div className="min-h-screen bg-slate-100 text-sm">{children}</div>
+}

--- a/apps/web/src/app/(guards)/RequireAluno.tsx
+++ b/apps/web/src/app/(guards)/RequireAluno.tsx
@@ -30,7 +30,7 @@ export default function RequireAluno({ children }: { children: React.ReactNode }
 
       const hasAluno = (vinculos || []).some((v: Tables<'escola_users'>) => {
         const papel = v.papel ?? v.role ?? null;
-        return papel === "aluno";
+        return papel === "aluno" || papel === "formando";
       });
 
       if (error || !hasAluno) {

--- a/apps/web/src/app/(guards)/RequireSecretaria.tsx
+++ b/apps/web/src/app/(guards)/RequireSecretaria.tsx
@@ -35,7 +35,16 @@ export default function RequireSecretaria({
       const { data: vinculos, error } = await vinculoQuery.limit(10);
       const hasSecretaria = (vinculos || []).some((v: Tables<'escola_users'>) => {
         const papel = v.papel ?? v.role ?? null;
-        return papel === "secretaria" || papel === "admin" || papel === "secretaria_financeiro" || papel === "admin_financeiro" || papel === "financeiro";
+        return (
+          papel === "secretaria" ||
+          papel === "admin" ||
+          papel === "secretaria_financeiro" ||
+          papel === "admin_financeiro" ||
+          papel === "financeiro" ||
+          papel === "formacao_admin" ||
+          papel === "formacao_secretaria" ||
+          papel === "formacao_financeiro"
+        );
       });
       if (error || !hasSecretaria) { router.replace("/"); return; }
 

--- a/apps/web/src/app/api/formacao/certificados/[id]/verify/route.ts
+++ b/apps/web/src/app/api/formacao/certificados/[id]/verify/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import type { Database } from "~types/supabase";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const fetchCache = "force-no-store";
+
+function badRequest(msg: string) {
+  return NextResponse.json({ ok: false, error: msg }, { status: 400 });
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  const publicId = (params.id ?? "").trim();
+  const hash = (req.nextUrl.searchParams.get("hash") ?? "").trim();
+
+  if (!publicId) return badRequest("missing certificado id");
+  if (!hash) return badRequest("missing hash");
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !anonKey) {
+    return NextResponse.json({ ok: false, error: "server misconfigured" }, { status: 500 });
+  }
+
+  const supabase = createClient<Database>(supabaseUrl, anonKey, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const { data, error } = await supabase.rpc("public_get_documento_by_token", {
+    p_public_id: publicId,
+    p_hash: hash,
+  });
+
+  if (error) {
+    return NextResponse.json({ ok: false, valid: false, error: "not found" }, { status: 404 });
+  }
+
+  const row = Array.isArray(data) ? data[0] : null;
+  if (!row || row.tipo !== "certificado") {
+    return NextResponse.json({ ok: false, valid: false, error: "not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(
+    {
+      ok: true,
+      valid: true,
+      tipo: row.tipo,
+      emitted_at: row.emitted_at ?? null,
+      payload: row.payload ?? {},
+    },
+    { status: 200 }
+  );
+}

--- a/apps/web/src/app/api/secretaria/documentos-oficiais/lote/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos-oficiais/lote/route.ts
@@ -5,6 +5,8 @@ import { supabaseServerTyped } from "@/lib/supabaseServer"
 import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser"
 import { authorizeTurmasManage } from "@/lib/escola/disciplinas"
 import { inngest } from "@/inngest/client"
+import { requireFeature } from "@/lib/plan/requireFeature"
+import { HttpError } from "@/lib/errors"
 
 export const dynamic = "force-dynamic"
 export const revalidate = 0
@@ -67,6 +69,10 @@ export async function POST(req: Request) {
     const parsed = Body.safeParse(await req.json().catch(() => ({})))
     if (!parsed.success) {
       return NextResponse.json({ ok: false, error: "Dados inválidos" }, { status: 400 })
+    }
+
+    if (parsed.data.tipo === "certificado") {
+      await requireFeature("doc_qr_code")
     }
 
     const escolaId = await resolveEscolaIdForUser(supabase as any, user.id)
@@ -164,6 +170,17 @@ export async function POST(req: Request) {
 
     return NextResponse.json({ ok: true, job_id: job.id }, { status: 202 })
   } catch (e) {
+    if (e instanceof HttpError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: e.message,
+          error_code: e.code,
+          upgrade_required: e.status === 403 && e.code === "PLAN_FEATURE_REQUIRED",
+        },
+        { status: e.status }
+      )
+    }
     const message = e instanceof Error ? e.message : String(e)
     return NextResponse.json({ ok: false, error: message }, { status: 500 })
   }

--- a/apps/web/src/app/api/secretaria/documentos/certificado/batch/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos/certificado/batch/route.ts
@@ -3,6 +3,8 @@ import { z } from 'zod'
 import { supabaseServerTyped } from '@/lib/supabaseServer'
 import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
 import { requireRoleInSchool } from '@/lib/authz'
+import { requireFeature } from '@/lib/plan/requireFeature'
+import { HttpError } from '@/lib/errors'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,75 +14,93 @@ const BodySchema = z.object({
 })
 
 export async function POST(request: Request) {
-  const supabase = await supabaseServerTyped<any>()
-  const { data: auth } = await supabase.auth.getUser()
-  const user = auth?.user
-  if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
+  try {
+    const supabase = await supabaseServerTyped<any>()
+    const { data: auth } = await supabase.auth.getUser()
+    const user = auth?.user
+    if (!user) return NextResponse.json({ ok: false, error: 'Não autenticado' }, { status: 401 })
 
-  const parsed = BodySchema.safeParse(await request.json().catch(() => null))
-  if (!parsed.success) {
-    return NextResponse.json({ ok: false, error: parsed.error.flatten() }, { status: 400 })
-  }
+    await requireFeature('doc_qr_code')
 
-  const { turma_id, alunos_ids } = parsed.data
+    const parsed = BodySchema.safeParse(await request.json().catch(() => null))
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: parsed.error.flatten() }, { status: 400 })
+    }
 
-  const { data: turma, error: turmaError } = await supabase
-    .from('turmas')
-    .select('id, escola_id, ano_letivo')
-    .eq('id', turma_id)
-    .single()
+    const { turma_id, alunos_ids } = parsed.data
 
-  if (turmaError || !turma?.escola_id) {
-    return NextResponse.json({ ok: false, error: 'Turma não encontrada' }, { status: 404 })
-  }
+    const { data: turma, error: turmaError } = await supabase
+      .from('turmas')
+      .select('id, escola_id, ano_letivo')
+      .eq('id', turma_id)
+      .single()
 
-  const escolaId = turma.escola_id as string
-  const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId)
-  if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
-    return NextResponse.json({ ok: false, error: 'Escola inválida' }, { status: 403 })
-  }
+    if (turmaError || !turma?.escola_id) {
+      return NextResponse.json({ ok: false, error: 'Turma não encontrada' }, { status: 404 })
+    }
 
-  const { error: authError } = await requireRoleInSchool({
-    supabase,
-    escolaId,
-    roles: ['secretaria', 'admin', 'admin_escola', 'staff_admin'],
-  })
-  if (authError) return authError
+    const escolaId = turma.escola_id as string
+    const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId)
+    if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
+      return NextResponse.json({ ok: false, error: 'Escola inválida' }, { status: 403 })
+    }
 
-  let query = supabase
-    .from('matriculas')
-    .select('id, aluno_id')
-    .eq('escola_id', escolaId)
-    .eq('turma_id', turma_id)
-    .in('status', ['concluido', 'reprovado'])
-
-  if (alunos_ids && alunos_ids.length > 0) {
-    query = query.in('aluno_id', alunos_ids)
-  }
-
-  const { data: matriculas, error: matError } = await query
-  if (matError) return NextResponse.json({ ok: false, error: matError.message }, { status: 400 })
-
-  const snapshots: any[] = []
-  for (const m of matriculas || []) {
-    const { data: docRes, error: emitError } = await supabase.rpc('emitir_documento_final', {
-      p_escola_id: escolaId,
-      p_aluno_id: m.aluno_id,
-      p_ano_letivo: Number(turma.ano_letivo),
-      p_tipo_documento: 'certificado',
+    const { error: authError } = await requireRoleInSchool({
+      supabase,
+      escolaId,
+      roles: ['secretaria', 'admin', 'admin_escola', 'staff_admin'],
     })
-    if (emitError || !docRes?.docId) continue
+    if (authError) return authError
 
-    const { data: row } = await supabase
-      .from('documentos_emitidos')
-      .select('dados_snapshot, hash_validacao')
-      .eq('id', docRes.docId)
+    let query = supabase
+      .from('matriculas')
+      .select('id, aluno_id')
       .eq('escola_id', escolaId)
-      .maybeSingle()
+      .eq('turma_id', turma_id)
+      .in('status', ['concluido', 'reprovado'])
 
-    const snapshot = (row?.dados_snapshot || {}) as Record<string, any>
-    snapshots.push({ ...snapshot, hash_validacao: row?.hash_validacao ?? snapshot.hash_validacao ?? null })
+    if (alunos_ids && alunos_ids.length > 0) {
+      query = query.in('aluno_id', alunos_ids)
+    }
+
+    const { data: matriculas, error: matError } = await query
+    if (matError) return NextResponse.json({ ok: false, error: matError.message }, { status: 400 })
+
+    const snapshots: any[] = []
+    for (const m of matriculas || []) {
+      const { data: docRes, error: emitError } = await supabase.rpc('emitir_documento_final', {
+        p_escola_id: escolaId,
+        p_aluno_id: m.aluno_id,
+        p_ano_letivo: Number(turma.ano_letivo),
+        p_tipo_documento: 'certificado',
+      })
+      if (emitError || !docRes?.docId) continue
+
+      const { data: row } = await supabase
+        .from('documentos_emitidos')
+        .select('dados_snapshot, hash_validacao')
+        .eq('id', docRes.docId)
+        .eq('escola_id', escolaId)
+        .maybeSingle()
+
+      const snapshot = (row?.dados_snapshot || {}) as Record<string, any>
+      snapshots.push({ ...snapshot, hash_validacao: row?.hash_validacao ?? snapshot.hash_validacao ?? null })
+    }
+
+    return NextResponse.json({ ok: true, snapshots })
+  } catch (err) {
+    if (err instanceof HttpError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: err.message,
+          error_code: err.code,
+          upgrade_required: err.status === 403 && err.code === 'PLAN_FEATURE_REQUIRED',
+        },
+        { status: err.status }
+      )
+    }
+    const message = err instanceof Error ? err.message : String(err)
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
   }
-
-  return NextResponse.json({ ok: true, snapshots })
 }

--- a/apps/web/src/app/api/secretaria/documentos/emitir/route.ts
+++ b/apps/web/src/app/api/secretaria/documentos/emitir/route.ts
@@ -7,6 +7,8 @@ import { requireRoleInSchool } from "@/lib/authz";
 import type { Database } from "~types/supabase";
 import { recordAuditServer } from "@/lib/audit";
 import { dispatchAlunoNotificacao } from "@/lib/notificacoes/dispatchAlunoNotificacao";
+import { requireFeature } from "@/lib/plan/requireFeature";
+import { HttpError } from "@/lib/errors";
 
 const payloadSchema = z.object({
   alunoId: z.string().uuid(),
@@ -55,6 +57,11 @@ export async function POST(request: Request) {
     }
 
     const { alunoId, escolaId, tipoDocumento, ano_letivo } = parsed.data;
+
+    if (tipoDocumento === "certificado") {
+      await requireFeature("doc_qr_code");
+    }
+
     const resolvedEscolaId = await resolveEscolaIdForUser(supabase as any, user.id, escolaId);
 
     if (!resolvedEscolaId || resolvedEscolaId !== escolaId) {
@@ -210,6 +217,17 @@ export async function POST(request: Request) {
       tipo: tipoDocumento,
     });
   } catch (err) {
+    if (err instanceof HttpError) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: err.message,
+          error_code: err.code,
+          upgrade_required: err.status === 403 && err.code === "PLAN_FEATURE_REQUIRED",
+        },
+        { status: err.status }
+      );
+    }
     const message = err instanceof Error ? err.message : String(err);
     return NextResponse.json({ ok: false, error: message }, { status: 500 });
   }

--- a/apps/web/src/app/financeiro/cobrancas/page.tsx
+++ b/apps/web/src/app/financeiro/cobrancas/page.tsx
@@ -61,7 +61,7 @@ export default function SistemaCobrancas() {
   const fetchCampanhas = useCallback(async () => {
     setLoadingCampanhas(true);
     try {
-      const res = await fetch("/api/financeiro/cobrancas/campanhas");
+      const res = await fetch("/api/financeiro/cobrancas/campanhas", { cache: "no-store" });
       if (!res.ok) throw new Error("Falha ao buscar campanhas.");
       const json = await res.json();
       setCampanhas(Array.isArray(json) ? json : json.data ?? []);
@@ -76,7 +76,7 @@ export default function SistemaCobrancas() {
   const fetchTemplates = useCallback(async () => {
     setLoadingTemplates(true);
     try {
-      const res = await fetch("/api/financeiro/cobrancas/templates");
+      const res = await fetch("/api/financeiro/cobrancas/templates", { cache: "no-store" });
       if (!res.ok) throw new Error("Falha ao buscar templates.");
       const json = await res.json();
       setTemplates(Array.isArray(json) ? json : json.data ?? []);
@@ -127,6 +127,7 @@ export default function SistemaCobrancas() {
       const res = await fetch("/api/financeiro/cobrancas/campanhas/nova", {
         method: "POST",
         headers: { "content-type": "application/json" },
+        cache: "no-store",
         body: JSON.stringify(payload),
       });
       

--- a/apps/web/src/app/financeiro/conciliacao/page.tsx
+++ b/apps/web/src/app/financeiro/conciliacao/page.tsx
@@ -272,7 +272,7 @@ const ConciliacaoBancaria: React.FC = () => {
       // mantém compat com teu endpoint atual
       qs.set("status", filtroStatus);
 
-      const response = await fetch(`/api/financeiro/conciliacao/transacoes?${qs.toString()}`);
+      const response = await fetch(`/api/financeiro/conciliacao/transacoes?${qs.toString()}`, { cache: "no-store" });
       const result = await response.json();
 
       if (response.ok && result.ok && Array.isArray(result.transactions)) {
@@ -323,6 +323,7 @@ const ConciliacaoBancaria: React.FC = () => {
         const response = await fetch("/api/financeiro/conciliacao/upload", {
           method: "POST",
           body: formData,
+          cache: "no-store",
         });
         const result = await response.json();
 
@@ -387,6 +388,7 @@ const ConciliacaoBancaria: React.FC = () => {
       const response = await fetch("/api/financeiro/conciliacao/settle", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        cache: "no-store",
         body: JSON.stringify({
           transacao_id: transacaoId,
           aluno_id: alunoId,

--- a/apps/web/src/app/financeiro/turmas-alunos/page.tsx
+++ b/apps/web/src/app/financeiro/turmas-alunos/page.tsx
@@ -98,9 +98,9 @@ const TurmasAlunosFinanceiro: React.FC = () => {
       try {
         // Mock fetch calls - substituir por chamadas reais
         const [turmasRes, alunosRes, mensalidadesRes] = await Promise.all([
-          fetch('/api/financeiro/turmas'),
-          fetch('/api/financeiro/alunos'),
-          fetch('/api/financeiro/mensalidades')
+          fetch('/api/financeiro/turmas', { cache: 'no-store' }),
+          fetch('/api/financeiro/alunos', { cache: 'no-store' }),
+          fetch('/api/financeiro/mensalidades', { cache: 'no-store' })
         ]);
         
         const [turmas, alunos, mensalidades] = await Promise.all([

--- a/apps/web/src/config/plans.ts
+++ b/apps/web/src/config/plans.ts
@@ -14,6 +14,7 @@ export type FeatureKey =
   | "sec_upload_docs"
   | "sec_matricula_online"
   | "doc_qr_code"
+  | "relatorio_avancado"
   | "app_whatsapp_auto"
   | "suporte_prioritario";
 
@@ -29,6 +30,7 @@ export const PLAN_FEATURES: Record<PlanTier, Record<FeatureKey, boolean>> = {
     sec_upload_docs: false,
     sec_matricula_online: false,
     doc_qr_code: false,
+    relatorio_avancado: false,
     app_whatsapp_auto: false,
     suporte_prioritario: false,
   },
@@ -37,6 +39,7 @@ export const PLAN_FEATURES: Record<PlanTier, Record<FeatureKey, boolean>> = {
     sec_upload_docs: true,
     sec_matricula_online: false,
     doc_qr_code: false,
+    relatorio_avancado: false,
     app_whatsapp_auto: false,
     suporte_prioritario: false,
   },
@@ -45,8 +48,8 @@ export const PLAN_FEATURES: Record<PlanTier, Record<FeatureKey, boolean>> = {
     sec_upload_docs: true,
     sec_matricula_online: true,
     doc_qr_code: true,
+    relatorio_avancado: true,
     app_whatsapp_auto: true,
     suporte_prioritario: true,
   },
 };
-

--- a/apps/web/src/lib/auth/formacaoAccess.ts
+++ b/apps/web/src/lib/auth/formacaoAccess.ts
@@ -1,0 +1,39 @@
+import { createServerClient } from '@supabase/ssr'
+import { cookies } from 'next/headers'
+
+export type FormacaoContext = {
+  role: string | null
+  modeloEnsino: string | null
+  escolaId: string | null
+}
+
+export async function getFormacaoContext(): Promise<FormacaoContext | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  if (!url || !key) return null
+
+  const cookieStore = await cookies()
+  const supabase = createServerClient(url, key, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll()
+      },
+      setAll() {
+        // read-only on server components
+      },
+    },
+  })
+
+  const { data } = await supabase.auth.getUser()
+  const user = data?.user
+  if (!user) return null
+
+  const appMetadata = (user.app_metadata ?? {}) as Record<string, unknown>
+  const userMetadata = (user.user_metadata ?? {}) as Record<string, unknown>
+
+  return {
+    role: (appMetadata.role ?? userMetadata.role ?? null) as string | null,
+    modeloEnsino: (appMetadata.modelo_ensino ?? userMetadata.modelo_ensino ?? null) as string | null,
+    escolaId: (appMetadata.escola_id ?? userMetadata.escola_id ?? null) as string | null,
+  }
+}

--- a/apps/web/src/lib/authz.ts
+++ b/apps/web/src/lib/authz.ts
@@ -10,7 +10,12 @@ export type Role =
   | "admin_financeiro"
   | "secretaria_financeiro"
   | "admin_escola"
-  | "staff_admin";
+  | "staff_admin"
+  | "formacao_admin"
+  | "formacao_secretaria"
+  | "formacao_financeiro"
+  | "formador"
+  | "formando";
 
 interface RequireRoleInSchoolParams {
   supabase: SupabaseClient;

--- a/apps/web/src/lib/permissions.ts
+++ b/apps/web/src/lib/permissions.ts
@@ -12,6 +12,11 @@ export type Papel =
   | 'professor'
   | 'admin_escola'
   | 'encarregado'
+  | 'formacao_admin'
+  | 'formacao_secretaria'
+  | 'formacao_financeiro'
+  | 'formador'
+  | 'formando'
 
 // Enumerate known permissions to get type-safety across the app
 export type Permission =
@@ -47,6 +52,17 @@ export type Permission =
   | 'visualizar_situacao_financeira'
   | 'baixar_documentos'
   | 'enviar_mensagem'
+  | 'gerir_cohorts'
+  | 'emitir_certificados'
+  | 'gerir_faturas_b2b'
+  | 'gerir_honorarios'
+  | 'lancar_avaliacoes_formacao'
+  | 'registar_presencas_formacao'
+  | 'consultar_turmas_formador'
+  | 'consultar_honorarios'
+  | 'consultar_progresso_formando'
+  | 'consultar_pagamentos_formando'
+  | 'comprar_cursos'
 
 // Global role enum as used in profiles/app_metadata
 export type GlobalRole =
@@ -61,6 +77,11 @@ export type GlobalRole =
   | 'admin_escola'
   | 'staff_admin'
   | 'encarregado'
+  | 'formacao_admin'
+  | 'formacao_secretaria'
+  | 'formacao_financeiro'
+  | 'formador'
+  | 'formando'
   | 'global_admin'
   | 'guest'
 
@@ -82,6 +103,11 @@ export function normalizePapel(papel: Papel | string | null | undefined): Papel 
     professor: 'professor',
     aluno: 'aluno',
     encarregado: 'encarregado',
+    formacao_admin: 'formacao_admin',
+    formacao_secretaria: 'formacao_secretaria',
+    formacao_financeiro: 'formacao_financeiro',
+    formador: 'formador',
+    formando: 'formando',
   }
 
   const key = papel.trim().toLowerCase()
@@ -109,6 +135,15 @@ const ALUNO_PERMISSIONS = new Set<Permission>([
   'visualizar_situacao_financeira',
   'baixar_documentos',
   'enviar_mensagem',
+])
+
+const FORMANDO_PERMISSIONS = new Set<Permission>([
+  'consultar_calendario',
+  'consultar_horarios',
+  'consultar_progresso_formando',
+  'consultar_pagamentos_formando',
+  'baixar_documentos',
+  'comprar_cursos',
 ])
 
 // Mapping derived directly from the provided matrix.
@@ -188,6 +223,52 @@ const ROLE_PERMISSIONS: Record<Papel, ReadonlySet<Permission>> = {
 
   aluno: ALUNO_PERMISSIONS,
   encarregado: ALUNO_PERMISSIONS,
+  formando: FORMANDO_PERMISSIONS,
+
+  formacao_admin: new Set<Permission>([
+    'criar_usuario',
+    'editar_usuario',
+    'remover_usuario',
+    'configurar_escola',
+    'visualizar_relatorios_globais',
+    'visualizar_financeiro',
+    'visualizar_academico',
+    'gerir_cohorts',
+    'emitir_certificados',
+    'gerir_faturas_b2b',
+    'gerir_honorarios',
+  ]),
+
+  formacao_secretaria: new Set<Permission>([
+    'criar_matricula',
+    'editar_matricula',
+    'gerenciar_turmas',
+    'emitir_documentos',
+    'emitir_certificados',
+    'gerir_cohorts',
+    'enviar_comunicado',
+  ]),
+
+  formacao_financeiro: new Set<Permission>([
+    'criar_cobranca',
+    'editar_cobranca',
+    'registrar_pagamento',
+    'emitir_recibo',
+    'emitir_nota_fiscal',
+    'visualizar_fluxo_caixa',
+    'exportar_relatorios_contabeis',
+    'gerir_faturas_b2b',
+    'gerir_honorarios',
+  ]),
+
+  formador: new Set<Permission>([
+    'lançar_notas',
+    'registrar_frequencia',
+    'lancar_avaliacoes_formacao',
+    'registar_presencas_formacao',
+    'consultar_turmas_formador',
+    'consultar_honorarios',
+  ]),
 }
 
 export function getPermissionsForRole(papel: Papel | string | null | undefined): ReadonlySet<Permission> {
@@ -214,6 +295,8 @@ export function temAcessoFinanceiro(role: GlobalRole | string | null | undefined
     'financeiro',
     'secretaria_financeiro',
     'admin_financeiro',
+    'formacao_financeiro',
+    'formacao_admin',
     'admin',
     'super_admin',
     'global_admin',
@@ -225,6 +308,8 @@ export function temAcessoSecretaria(role: GlobalRole | string | null | undefined
     'secretaria',
     'secretaria_financeiro',
     'admin_financeiro',
+    'formacao_secretaria',
+    'formacao_admin',
     'admin',
     'super_admin',
     'global_admin',
@@ -253,6 +338,16 @@ export function mapPapelToGlobalRole(papel: Papel | string | null | undefined): 
       return 'aluno'
     case 'encarregado':
       return 'encarregado'
+    case 'formacao_admin':
+      return 'formacao_admin'
+    case 'formacao_secretaria':
+      return 'formacao_secretaria'
+    case 'formacao_financeiro':
+      return 'formacao_financeiro'
+    case 'formador':
+      return 'formador'
+    case 'formando':
+      return 'formando'
     default:
       return 'guest'
   }

--- a/apps/web/src/lib/plan/featureMatrix.ts
+++ b/apps/web/src/lib/plan/featureMatrix.ts
@@ -1,0 +1,71 @@
+import {
+  PLAN_FEATURES,
+  PLAN_NAMES,
+  parsePlanTier,
+  type FeatureKey,
+  type PlanTier,
+} from "@/config/plans";
+
+export type FeatureGateConfig = {
+  feature: FeatureKey;
+  minPlan: PlanTier;
+  errorCode: "PLAN_FEATURE_REQUIRED";
+  upgradeCta: string;
+};
+
+export const FEATURE_GATE_MATRIX: Record<FeatureKey, FeatureGateConfig> = {
+  fin_recibo_pdf: {
+    feature: "fin_recibo_pdf",
+    minPlan: "essencial",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_fin_recibo_pdf",
+  },
+  sec_upload_docs: {
+    feature: "sec_upload_docs",
+    minPlan: "profissional",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_sec_upload_docs",
+  },
+  sec_matricula_online: {
+    feature: "sec_matricula_online",
+    minPlan: "premium",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_sec_matricula_online",
+  },
+  doc_qr_code: {
+    feature: "doc_qr_code",
+    minPlan: "premium",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_doc_qr_code",
+  },
+  relatorio_avancado: {
+    feature: "relatorio_avancado",
+    minPlan: "premium",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_relatorio_avancado",
+  },
+  app_whatsapp_auto: {
+    feature: "app_whatsapp_auto",
+    minPlan: "premium",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_app_whatsapp_auto",
+  },
+  suporte_prioritario: {
+    feature: "suporte_prioritario",
+    minPlan: "premium",
+    errorCode: "PLAN_FEATURE_REQUIRED",
+    upgradeCta: "upgrade_suporte_prioritario",
+  },
+};
+
+export function isFeatureAllowed(plan: string | null | undefined, feature: FeatureKey): boolean {
+  const tier = parsePlanTier(plan);
+  return Boolean(PLAN_FEATURES[tier]?.[feature]);
+}
+
+export function getFeatureDeniedMessage(plan: string | null | undefined, feature: FeatureKey): string {
+  const tier = parsePlanTier(plan);
+  const planName = PLAN_NAMES[tier];
+  const neededPlan = PLAN_NAMES[FEATURE_GATE_MATRIX[feature].minPlan];
+  return `Funcionalidade '${feature}' indisponível no plano ${planName}. Faça upgrade para ${neededPlan}.`;
+}

--- a/apps/web/src/lib/plan/requireFeature.ts
+++ b/apps/web/src/lib/plan/requireFeature.ts
@@ -3,6 +3,7 @@ import type { FeatureKey } from "@/config/plans";
 import { HttpError } from "@/lib/errors";
 import { resolveEscolaIdForUser } from "@/lib/tenant/resolveEscolaIdForUser";
 import type { Database } from "~types/supabase";
+import { getFeatureDeniedMessage, isFeatureAllowed } from "@/lib/plan/featureMatrix";
 
 type DBWithFeature = Database & {
   public: Omit<Database["public"], "Tables" | "Functions"> & {
@@ -11,18 +12,13 @@ type DBWithFeature = Database & {
         Row: Database["public"]["Tables"]["escolas"]["Row"] & { plano_atual?: string | null };
       };
     };
-    Functions: Database["public"]["Functions"] & {
-      escola_has_feature: {
-        Args: { p_escola_id: string; p_feature: FeatureKey };
-        Returns: boolean;
-      };
-    };
+    Functions: Database["public"]["Functions"];
   };
 };
 
 type RequireFeatureResult = {
   escolaId: string;
-  plano: string | null;
+  plano: string;
   userId: string;
 };
 
@@ -46,24 +42,25 @@ export async function requireFeature(feature: FeatureKey): Promise<RequireFeatur
     throw new HttpError(403, "NO_SCHOOL", "Usuário sem escola associada.");
   }
 
-  if (feature !== "fin_recibo_pdf") {
-    const { data: allowed, error: rpcError } = await supabase.rpc("escola_has_feature", {
-      p_escola_id: escolaId,
-      p_feature: feature,
-    });
+  const { data: escola, error: schoolError } = await supabase
+    .from("escolas")
+    .select("plano_atual")
+    .eq("id", escolaId)
+    .maybeSingle();
 
-    if (rpcError) {
-      throw new HttpError(500, "FEATURE_CHECK_FAILED", "Falha ao validar plano.");
-    }
+  if (schoolError) {
+    throw new HttpError(500, "FEATURE_CHECK_FAILED", "Falha ao validar plano.");
+  }
 
-    if (!allowed) {
-      throw new HttpError(403, "FORBIDDEN", "Seu plano não inclui esta funcionalidade.");
-    }
+  const plano = String(escola?.plano_atual ?? "essencial").toLowerCase();
+
+  if (!isFeatureAllowed(plano, feature)) {
+    throw new HttpError(403, "PLAN_FEATURE_REQUIRED", getFeatureDeniedMessage(plano, feature));
   }
 
   return {
     escolaId,
-    plano: null,
+    plano,
     userId: user.id,
   };
 }

--- a/apps/web/src/lib/roles.ts
+++ b/apps/web/src/lib/roles.ts
@@ -10,6 +10,11 @@ export const PAPEIS_ESCOLA_VALIDOS = [
   'admin_financeiro',
   'professor',
   'aluno',
+  'formacao_admin',
+  'formacao_secretaria',
+  'formacao_financeiro',
+  'formador',
+  'formando',
 ] as const
 
 export type PapelEscola = (typeof PAPEIS_ESCOLA_VALIDOS)[number]

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -5,6 +5,13 @@ import { createServerClient } from '@supabase/ssr';
 import { isEscolaUuid } from '@/lib/tenant/escolaSlug';
 import { resolveEscolaParam } from '@/lib/tenant/resolveEscolaParam';
 
+type ModeloEnsino = 'k12' | 'formacao';
+type AuthContext = {
+  role: string | null;
+  escolaId: string | null;
+  modeloEnsino: ModeloEnsino | null;
+};
+
 // Simulação de Rate Limiting simples em memória (Edge Runtime)
 // Nota: Em produção real, o Edge Runtime pode resetar a memória entre instâncias.
 // Para 100 escolas, o ideal é usar Upstash Redis ou similar.
@@ -124,58 +131,165 @@ function finalizeResponse(request: NextRequest, response: NextResponse, allowedO
 const PORTAL_RULES: Array<{ prefix: string; roles: string[] }> = [
   {
     prefix: '/admin',
-    roles: ['admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin'],
+    roles: ['admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin', 'formacao_admin'],
   },
   {
     prefix: '/secretaria',
-    roles: ['secretaria', 'secretaria_financeiro', 'admin_financeiro', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin'],
+    roles: ['secretaria', 'secretaria_financeiro', 'admin_financeiro', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin', 'formacao_secretaria', 'formacao_admin'],
   },
   {
     prefix: '/financeiro',
-    roles: ['financeiro', 'secretaria_financeiro', 'admin_financeiro', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin'],
+    roles: ['financeiro', 'secretaria_financeiro', 'admin_financeiro', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin', 'formacao_financeiro', 'formacao_admin'],
   },
   {
     prefix: '/professor',
-    roles: ['professor', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin'],
+    roles: ['professor', 'admin', 'admin_escola', 'staff_admin', 'super_admin', 'global_admin', 'formador'],
   },
   {
     prefix: '/aluno',
-    roles: ['aluno', 'encarregado'],
+    roles: ['aluno', 'encarregado', 'formando'],
+  },
+  {
+    prefix: '/agenda',
+    roles: ['formador'],
+  },
+  {
+    prefix: '/minhas-turmas',
+    roles: ['formador'],
+  },
+  {
+    prefix: '/honorarios',
+    roles: ['formador'],
+  },
+  {
+    prefix: '/dashboard',
+    roles: ['formando'],
+  },
+  {
+    prefix: '/meus-cursos',
+    roles: ['formando'],
+  },
+  {
+    prefix: '/pagamentos',
+    roles: ['formando'],
+  },
+  {
+    prefix: '/loja-cursos',
+    roles: ['formando'],
+  },
+  {
+    prefix: '/conquistas',
+    roles: ['formando'],
+  },
+  {
+    prefix: '/formacao',
+    roles: ['formacao_admin', 'formacao_secretaria', 'formacao_financeiro', 'formador', 'formando'],
   },
 ];
 
-async function resolveUserRole(request: NextRequest, response: NextResponse) {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !key) return null;
-
-  const supabase = createServerClient(url, key, {
-    cookies: {
-      getAll() {
-        return request.cookies.getAll();
-      },
-      setAll(cookiesToSet) {
-        cookiesToSet.forEach(({ name, value, options }) => response.cookies.set(name, value, options));
-      },
-    },
-  });
-
-  const { data: userRes } = await supabase.auth.getUser();
-  const user = userRes?.user;
-  if (!user) return null;
-
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('user_id', user.id)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-
-  return profile?.role ?? null;
+function normalizeModeloEnsino(value: unknown): ModeloEnsino | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'k12') return 'k12';
+  if (normalized === 'formacao') return 'formacao';
+  return null;
 }
 
-async function resolveUserTenant(request: NextRequest, response: NextResponse) {
+function decodeJwtPayload(token: string): Record<string, unknown> | null {
+  const segments = token.split('.');
+  if (segments.length < 2) return null;
+  try {
+    const base64 = segments[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+    const json = atob(padded);
+    const parsed = JSON.parse(json) as Record<string, unknown>;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function extractAccessTokenFromCookies(request: NextRequest): string | null {
+  const authCookie = request.cookies
+    .getAll()
+    .find((cookie) => cookie.name.includes('auth-token') && cookie.name.startsWith('sb-'));
+  if (!authCookie?.value) return null;
+
+  try {
+    const decoded = decodeURIComponent(authCookie.value);
+    const parsed = JSON.parse(decoded) as unknown;
+    if (Array.isArray(parsed) && typeof parsed[0] === 'string') return parsed[0];
+  } catch {
+    // ignore cookie parse issues and fallback below
+  }
+
+  return authCookie.value;
+}
+
+function extractJwtAuthContext(request: NextRequest): AuthContext | null {
+  const bearer = request.headers.get('authorization');
+  const accessToken = bearer?.startsWith('Bearer ')
+    ? bearer.slice('Bearer '.length).trim()
+    : extractAccessTokenFromCookies(request);
+
+  if (!accessToken) return null;
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload) return null;
+
+  const appMetadata = (payload.app_metadata ?? {}) as Record<string, unknown>;
+  const userMetadata = (payload.user_metadata ?? {}) as Record<string, unknown>;
+
+  const role = (appMetadata.role ?? userMetadata.role ?? null) as string | null;
+  const escolaId = (appMetadata.escola_id ?? userMetadata.escola_id ?? null) as string | null;
+  const modeloEnsino = normalizeModeloEnsino(appMetadata.modelo_ensino ?? userMetadata.modelo_ensino);
+
+  return { role, escolaId, modeloEnsino };
+}
+
+function getLandingPathByContext(ctx: AuthContext): string {
+  if (ctx.modeloEnsino === 'formacao') {
+    if (ctx.role === 'formador') return '/agenda';
+    if (ctx.role === 'formando') return '/dashboard';
+    if (ctx.role === 'formacao_financeiro') return '/financeiro/dashboard';
+    if (ctx.role === 'formacao_secretaria') return '/secretaria/catalogo-cursos';
+    return '/admin/dashboard';
+  }
+
+  if (ctx.role === 'professor') return '/professor';
+  if (ctx.role === 'aluno' || ctx.role === 'encarregado') return '/aluno';
+  if (ctx.role === 'financeiro') return '/financeiro';
+  if (ctx.role === 'secretaria') return '/secretaria';
+  return '/admin';
+}
+
+function pathRequiresK12Model(pathname: string): boolean {
+  return (
+    pathname.startsWith('/professor') ||
+    pathname.startsWith('/aluno') ||
+    pathname.startsWith('/secretaria') ||
+    pathname.startsWith('/financeiro')
+  );
+}
+
+function pathRequiresFormacaoModel(pathname: string): boolean {
+  return (
+    pathname.startsWith('/formacao') ||
+    pathname.startsWith('/agenda') ||
+    pathname.startsWith('/minhas-turmas') ||
+    pathname.startsWith('/honorarios') ||
+    pathname.startsWith('/meus-cursos') ||
+    pathname.startsWith('/pagamentos') ||
+    pathname.startsWith('/loja-cursos') ||
+    pathname.startsWith('/conquistas')
+  );
+}
+
+async function resolveAuthContext(request: NextRequest, response: NextResponse): Promise<AuthContext | null> {
+  const jwtContext = extractJwtAuthContext(request);
+  if (jwtContext?.role) {
+    return jwtContext;
+  }
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
   if (!url || !key) return null;
@@ -195,17 +309,16 @@ async function resolveUserTenant(request: NextRequest, response: NextResponse) {
   const user = userRes?.user;
   if (!user) return null;
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role, escola_id, current_escola_id')
-    .eq('user_id', user.id)
-    .order('created_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  const appMetadata = (user.app_metadata ?? {}) as Record<string, unknown>;
+  const userMetadata = (user.user_metadata ?? {}) as Record<string, unknown>;
+  const role = (appMetadata.role ?? userMetadata.role ?? null) as string | null;
+  const escolaId = (appMetadata.escola_id ?? userMetadata.escola_id ?? null) as string | null;
+  const modeloEnsino = normalizeModeloEnsino(appMetadata.modelo_ensino ?? userMetadata.modelo_ensino);
 
   return {
-    role: profile?.role ?? null,
-    escolaId: profile?.current_escola_id ?? profile?.escola_id ?? null,
+    role,
+    escolaId,
+    modeloEnsino,
   };
 }
 
@@ -351,7 +464,7 @@ export async function middleware(request: NextRequest) {
     if (escolaParam !== 'suspensa') {
       const resolved = await resolveEscolaSlugMapping(request, response, escolaParam);
       if (resolved) {
-        const tenant = await resolveUserTenant(request, response);
+        const tenant = await resolveAuthContext(request, response);
         if (!tenant) {
           return finalizeResponse(request, createForbiddenResponse(response, isApi), allowedOrigin);
         }
@@ -385,16 +498,29 @@ export async function middleware(request: NextRequest) {
   const portalRule = PORTAL_RULES.find((rule) => pathname.startsWith(rule.prefix));
   if (!portalRule) return finalizeResponse(request, response, allowedOrigin);
 
-  const role = await resolveUserRole(request, response);
-  if (!role) {
+  const authContext = await resolveAuthContext(request, response);
+  if (!authContext?.role) {
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = '/login';
     return finalizeResponse(request, NextResponse.redirect(loginUrl), allowedOrigin);
   }
 
-  if (!portalRule.roles.includes(String(role))) {
+  const modeloEnsino = authContext.modeloEnsino ?? 'k12';
+  if (modeloEnsino === 'formacao' && pathRequiresK12Model(pathname)) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = getLandingPathByContext(authContext);
+    return finalizeResponse(request, NextResponse.redirect(redirectUrl), allowedOrigin);
+  }
+
+  if (modeloEnsino === 'k12' && pathRequiresFormacaoModel(pathname)) {
+    const redirectUrl = request.nextUrl.clone();
+    redirectUrl.pathname = getLandingPathByContext(authContext);
+    return finalizeResponse(request, NextResponse.redirect(redirectUrl), allowedOrigin);
+  }
+
+  if (!portalRule.roles.includes(String(authContext.role))) {
     const deniedUrl = request.nextUrl.clone();
-    deniedUrl.pathname = '/login';
+    deniedUrl.pathname = getLandingPathByContext(authContext);
     return finalizeResponse(request, NextResponse.redirect(deniedUrl), allowedOrigin);
   }
 
@@ -411,6 +537,15 @@ export const config = {
     '/financeiro/:path*',
     '/professor/:path*',
     '/aluno/:path*',
+    '/agenda/:path*',
+    '/minhas-turmas/:path*',
+    '/honorarios/:path*',
+    '/dashboard/:path*',
+    '/meus-cursos/:path*',
+    '/pagamentos/:path*',
+    '/loja-cursos/:path*',
+    '/conquistas/:path*',
+    '/formacao/:path*',
     '/api/escolas/create/:path*',
     '/api/auth/login/:path*',
     '/api/alunos/ativar-acesso/:path*',

--- a/supabase/migrations/20260407130000_formacao_schema_rls_foundation.sql
+++ b/supabase/migrations/20260407130000_formacao_schema_rls_foundation.sql
@@ -1,0 +1,445 @@
+-- Ticket 3 — Base de Dados Formação (schema + RLS + views de abstração)
+
+-- =========================
+-- Helpers de autorização
+-- =========================
+CREATE OR REPLACE FUNCTION public.can_access_formacao_backoffice(p_escola_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT public.user_has_role_in_school(
+    p_escola_id,
+    ARRAY[
+      'formacao_admin',
+      'formacao_secretaria',
+      'formacao_financeiro',
+      'admin',
+      'admin_escola',
+      'staff_admin',
+      'super_admin',
+      'global_admin'
+    ]
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_access_formacao_cohort_as_formador(
+  p_escola_id uuid,
+  p_cohort_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    public.user_has_role_in_school(p_escola_id, ARRAY['formador'])
+    AND EXISTS (
+      SELECT 1
+      FROM public.formacao_cohort_formadores fcf
+      WHERE fcf.escola_id = p_escola_id
+        AND fcf.cohort_id = p_cohort_id
+        AND fcf.formador_user_id = auth.uid()
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_access_formacao_fatura_as_formando(
+  p_escola_id uuid,
+  p_formando_user_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    public.user_has_role_in_school(p_escola_id, ARRAY['formando'])
+    AND p_formando_user_id = auth.uid();
+$$;
+
+GRANT EXECUTE ON FUNCTION public.can_access_formacao_backoffice(uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_access_formacao_cohort_as_formador(uuid, uuid) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.can_access_formacao_fatura_as_formando(uuid, uuid) TO authenticated;
+
+-- =========================
+-- Cohorts (edições)
+-- =========================
+CREATE TABLE IF NOT EXISTS public.formacao_cohorts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  codigo text NOT NULL,
+  nome text NOT NULL,
+  curso_nome text NOT NULL,
+  carga_horaria_total integer NOT NULL CHECK (carga_horaria_total > 0),
+  vagas integer NOT NULL CHECK (vagas > 0),
+  data_inicio date NOT NULL,
+  data_fim date NOT NULL,
+  status text NOT NULL DEFAULT 'planeada' CHECK (status IN ('planeada', 'em_andamento', 'concluida', 'cancelada')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT formacao_cohorts_data_range_ck CHECK (data_fim >= data_inicio),
+  CONSTRAINT formacao_cohorts_codigo_unique UNIQUE (escola_id, codigo)
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_cohorts_escola_id
+  ON public.formacao_cohorts(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_cohorts_escola_status
+  ON public.formacao_cohorts(escola_id, status);
+
+CREATE TABLE IF NOT EXISTS public.formacao_cohort_formadores (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  cohort_id uuid NOT NULL REFERENCES public.formacao_cohorts(id) ON DELETE CASCADE,
+  formador_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  percentual_honorario numeric(5,2) NOT NULL DEFAULT 100.00 CHECK (percentual_honorario > 0 AND percentual_honorario <= 100),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT formacao_cohort_formadores_unique UNIQUE (escola_id, cohort_id, formador_user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_cohort_formadores_escola_id
+  ON public.formacao_cohort_formadores(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_cohort_formadores_user
+  ON public.formacao_cohort_formadores(escola_id, formador_user_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_cohort_formadores_cohort
+  ON public.formacao_cohort_formadores(escola_id, cohort_id);
+
+-- =========================
+-- Clientes B2B e faturação em lote
+-- =========================
+CREATE TABLE IF NOT EXISTS public.formacao_clientes_b2b (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  nome_fantasia text NOT NULL,
+  razao_social text,
+  nif text,
+  email_financeiro text,
+  telefone text,
+  status text NOT NULL DEFAULT 'ativo' CHECK (status IN ('ativo', 'inativo')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_clientes_b2b_escola_id
+  ON public.formacao_clientes_b2b(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_clientes_b2b_escola_status
+  ON public.formacao_clientes_b2b(escola_id, status);
+
+CREATE TABLE IF NOT EXISTS public.formacao_faturas_lote (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  cliente_b2b_id uuid NOT NULL REFERENCES public.formacao_clientes_b2b(id) ON DELETE RESTRICT,
+  cohort_id uuid REFERENCES public.formacao_cohorts(id) ON DELETE SET NULL,
+  referencia text NOT NULL,
+  emissao_em date NOT NULL DEFAULT current_date,
+  vencimento_em date NOT NULL,
+  moeda text NOT NULL DEFAULT 'AOA',
+  total_bruto numeric(14,2) NOT NULL DEFAULT 0,
+  total_desconto numeric(14,2) NOT NULL DEFAULT 0,
+  total_liquido numeric(14,2) GENERATED ALWAYS AS (total_bruto - total_desconto) STORED,
+  status text NOT NULL DEFAULT 'rascunho' CHECK (status IN ('rascunho', 'emitida', 'parcial', 'paga', 'cancelada')),
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT formacao_faturas_lote_ref_unique UNIQUE (escola_id, referencia),
+  CONSTRAINT formacao_faturas_lote_totais_ck CHECK (total_bruto >= 0 AND total_desconto >= 0 AND total_desconto <= total_bruto)
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_escola_id
+  ON public.formacao_faturas_lote(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_cliente
+  ON public.formacao_faturas_lote(escola_id, cliente_b2b_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_status
+  ON public.formacao_faturas_lote(escola_id, status, vencimento_em);
+
+CREATE TABLE IF NOT EXISTS public.formacao_faturas_lote_itens (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  fatura_lote_id uuid NOT NULL REFERENCES public.formacao_faturas_lote(id) ON DELETE CASCADE,
+  formando_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  descricao text NOT NULL,
+  quantidade numeric(12,2) NOT NULL DEFAULT 1 CHECK (quantidade > 0),
+  preco_unitario numeric(14,2) NOT NULL CHECK (preco_unitario >= 0),
+  desconto numeric(14,2) NOT NULL DEFAULT 0 CHECK (desconto >= 0),
+  valor_total numeric(14,2) GENERATED ALWAYS AS ((quantidade * preco_unitario) - desconto) STORED,
+  status_pagamento text NOT NULL DEFAULT 'pendente' CHECK (status_pagamento IN ('pendente', 'parcial', 'pago', 'cancelado')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT formacao_faturas_lote_itens_valor_ck CHECK (desconto <= (quantidade * preco_unitario))
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_itens_escola_id
+  ON public.formacao_faturas_lote_itens(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_itens_fatura
+  ON public.formacao_faturas_lote_itens(escola_id, fatura_lote_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_faturas_lote_itens_formando
+  ON public.formacao_faturas_lote_itens(escola_id, formando_user_id, status_pagamento);
+
+-- =========================
+-- Honorários dos formadores
+-- =========================
+CREATE TABLE IF NOT EXISTS public.formacao_honorarios_lancamentos (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  escola_id uuid NOT NULL REFERENCES public.escolas(id) ON DELETE CASCADE,
+  cohort_id uuid NOT NULL REFERENCES public.formacao_cohorts(id) ON DELETE RESTRICT,
+  formador_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  referencia text NOT NULL,
+  horas_ministradas numeric(10,2) NOT NULL CHECK (horas_ministradas >= 0),
+  valor_hora numeric(14,2) NOT NULL CHECK (valor_hora >= 0),
+  bonus numeric(14,2) NOT NULL DEFAULT 0 CHECK (bonus >= 0),
+  desconto numeric(14,2) NOT NULL DEFAULT 0 CHECK (desconto >= 0),
+  valor_bruto numeric(14,2) GENERATED ALWAYS AS (horas_ministradas * valor_hora) STORED,
+  valor_liquido numeric(14,2) GENERATED ALWAYS AS ((horas_ministradas * valor_hora) + bonus - desconto) STORED,
+  competencia date NOT NULL,
+  status text NOT NULL DEFAULT 'aberto' CHECK (status IN ('aberto', 'aprovado', 'pago', 'cancelado')),
+  created_by uuid REFERENCES auth.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT formacao_honorarios_lancamentos_ref_unique UNIQUE (escola_id, referencia),
+  CONSTRAINT formacao_honorarios_lancamentos_liquido_ck CHECK (((horas_ministradas * valor_hora) + bonus - desconto) >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS idx_formacao_honorarios_lancamentos_escola_id
+  ON public.formacao_honorarios_lancamentos(escola_id);
+CREATE INDEX IF NOT EXISTS idx_formacao_honorarios_lancamentos_formador
+  ON public.formacao_honorarios_lancamentos(escola_id, formador_user_id, competencia DESC);
+CREATE INDEX IF NOT EXISTS idx_formacao_honorarios_lancamentos_cohort
+  ON public.formacao_honorarios_lancamentos(escola_id, cohort_id);
+
+-- =========================
+-- RLS hard isolation
+-- =========================
+ALTER TABLE public.formacao_cohorts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.formacao_cohort_formadores ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.formacao_clientes_b2b ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.formacao_faturas_lote ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.formacao_faturas_lote_itens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.formacao_honorarios_lancamentos ENABLE ROW LEVEL SECURITY;
+
+-- Cohorts
+DROP POLICY IF EXISTS formacao_cohorts_select_policy ON public.formacao_cohorts;
+CREATE POLICY formacao_cohorts_select_policy
+  ON public.formacao_cohorts
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND (
+      public.can_access_formacao_backoffice(escola_id)
+      OR public.can_access_formacao_cohort_as_formador(escola_id, id)
+    )
+  );
+
+DROP POLICY IF EXISTS formacao_cohorts_mutation_policy ON public.formacao_cohorts;
+CREATE POLICY formacao_cohorts_mutation_policy
+  ON public.formacao_cohorts
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- Cohort x Formadores
+DROP POLICY IF EXISTS formacao_cohort_formadores_select_policy ON public.formacao_cohort_formadores;
+CREATE POLICY formacao_cohort_formadores_select_policy
+  ON public.formacao_cohort_formadores
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND (
+      public.can_access_formacao_backoffice(escola_id)
+      OR formador_user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS formacao_cohort_formadores_mutation_policy ON public.formacao_cohort_formadores;
+CREATE POLICY formacao_cohort_formadores_mutation_policy
+  ON public.formacao_cohort_formadores
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- Clientes B2B
+DROP POLICY IF EXISTS formacao_clientes_b2b_select_policy ON public.formacao_clientes_b2b;
+CREATE POLICY formacao_clientes_b2b_select_policy
+  ON public.formacao_clientes_b2b
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+DROP POLICY IF EXISTS formacao_clientes_b2b_mutation_policy ON public.formacao_clientes_b2b;
+CREATE POLICY formacao_clientes_b2b_mutation_policy
+  ON public.formacao_clientes_b2b
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- Faturas lote (cabeçalho): apenas backoffice
+DROP POLICY IF EXISTS formacao_faturas_lote_select_policy ON public.formacao_faturas_lote;
+CREATE POLICY formacao_faturas_lote_select_policy
+  ON public.formacao_faturas_lote
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+DROP POLICY IF EXISTS formacao_faturas_lote_mutation_policy ON public.formacao_faturas_lote;
+CREATE POLICY formacao_faturas_lote_mutation_policy
+  ON public.formacao_faturas_lote
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- Faturas lote itens: backoffice OU formando dono da linha
+DROP POLICY IF EXISTS formacao_faturas_lote_itens_select_policy ON public.formacao_faturas_lote_itens;
+CREATE POLICY formacao_faturas_lote_itens_select_policy
+  ON public.formacao_faturas_lote_itens
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND (
+      public.can_access_formacao_backoffice(escola_id)
+      OR public.can_access_formacao_fatura_as_formando(escola_id, formando_user_id)
+    )
+  );
+
+DROP POLICY IF EXISTS formacao_faturas_lote_itens_mutation_policy ON public.formacao_faturas_lote_itens;
+CREATE POLICY formacao_faturas_lote_itens_mutation_policy
+  ON public.formacao_faturas_lote_itens
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- Honorários: backoffice ou próprio formador (somente leitura)
+DROP POLICY IF EXISTS formacao_honorarios_select_policy ON public.formacao_honorarios_lancamentos;
+CREATE POLICY formacao_honorarios_select_policy
+  ON public.formacao_honorarios_lancamentos
+  FOR SELECT
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND (
+      public.can_access_formacao_backoffice(escola_id)
+      OR (
+        formador_user_id = auth.uid()
+        AND public.user_has_role_in_school(escola_id, ARRAY['formador'])
+      )
+    )
+  );
+
+DROP POLICY IF EXISTS formacao_honorarios_mutation_policy ON public.formacao_honorarios_lancamentos;
+CREATE POLICY formacao_honorarios_mutation_policy
+  ON public.formacao_honorarios_lancamentos
+  FOR ALL
+  USING (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  )
+  WITH CHECK (
+    escola_id = public.current_tenant_escola_id()
+    AND public.can_access_formacao_backoffice(escola_id)
+  );
+
+-- =========================
+-- Views de abstração para UI/API
+-- =========================
+CREATE OR REPLACE VIEW public.vw_formacao_cohorts_overview AS
+SELECT
+  c.id,
+  c.escola_id,
+  c.codigo,
+  c.nome,
+  c.curso_nome,
+  c.carga_horaria_total,
+  c.vagas,
+  c.data_inicio,
+  c.data_fim,
+  c.status,
+  COUNT(DISTINCT fcf.formador_user_id) AS total_formadores
+FROM public.formacao_cohorts c
+LEFT JOIN public.formacao_cohort_formadores fcf
+  ON fcf.escola_id = c.escola_id
+ AND fcf.cohort_id = c.id
+WHERE c.escola_id = public.current_tenant_escola_id()
+GROUP BY
+  c.id, c.escola_id, c.codigo, c.nome, c.curso_nome, c.carga_horaria_total,
+  c.vagas, c.data_inicio, c.data_fim, c.status;
+
+CREATE OR REPLACE VIEW public.vw_formacao_faturas_formando AS
+SELECT
+  i.id AS item_id,
+  i.escola_id,
+  i.formando_user_id,
+  i.fatura_lote_id,
+  f.referencia,
+  f.emissao_em,
+  f.vencimento_em,
+  f.status AS status_fatura,
+  i.status_pagamento,
+  i.descricao,
+  i.quantidade,
+  i.preco_unitario,
+  i.desconto,
+  i.valor_total
+FROM public.formacao_faturas_lote_itens i
+JOIN public.formacao_faturas_lote f
+  ON f.id = i.fatura_lote_id
+ AND f.escola_id = i.escola_id
+WHERE i.escola_id = public.current_tenant_escola_id();
+
+CREATE OR REPLACE VIEW public.vw_formacao_honorarios_formador AS
+SELECT
+  h.id,
+  h.escola_id,
+  h.formador_user_id,
+  h.cohort_id,
+  c.nome AS cohort_nome,
+  h.referencia,
+  h.competencia,
+  h.horas_ministradas,
+  h.valor_hora,
+  h.bonus,
+  h.desconto,
+  h.valor_bruto,
+  h.valor_liquido,
+  h.status
+FROM public.formacao_honorarios_lancamentos h
+LEFT JOIN public.formacao_cohorts c
+  ON c.id = h.cohort_id
+ AND c.escola_id = h.escola_id
+WHERE h.escola_id = public.current_tenant_escola_id();
+
+GRANT SELECT ON public.vw_formacao_cohorts_overview TO authenticated;
+GRANT SELECT ON public.vw_formacao_faturas_formando TO authenticated;
+GRANT SELECT ON public.vw_formacao_honorarios_formador TO authenticated;

--- a/supabase/migrations/20260407143000_formacao_financeiro_mvs.sql
+++ b/supabase/migrations/20260407143000_formacao_financeiro_mvs.sql
@@ -1,0 +1,171 @@
+-- Ticket 5 — Performance Financeira (Formação)
+-- MVs para dashboards pesados com refresh concorrente + cron.
+
+CREATE SCHEMA IF NOT EXISTS internal;
+
+DROP MATERIALIZED VIEW IF EXISTS internal.mv_formacao_cohorts_lotacao;
+CREATE MATERIALIZED VIEW internal.mv_formacao_cohorts_lotacao AS
+SELECT
+  c.escola_id,
+  c.id AS cohort_id,
+  c.nome AS cohort_nome,
+  c.vagas,
+  COUNT(i.id) FILTER (WHERE i.status_pagamento <> 'cancelado')::int AS inscritos_total,
+  COUNT(i.id) FILTER (WHERE i.status_pagamento = 'pago')::int AS inscritos_pagos,
+  ROUND(
+    (COUNT(i.id) FILTER (WHERE i.status_pagamento <> 'cancelado')::numeric / NULLIF(c.vagas::numeric, 0)) * 100,
+    2
+  ) AS lotacao_percentual
+FROM public.formacao_cohorts c
+LEFT JOIN public.formacao_faturas_lote f
+  ON f.escola_id = c.escola_id
+ AND f.cohort_id = c.id
+LEFT JOIN public.formacao_faturas_lote_itens i
+  ON i.escola_id = f.escola_id
+ AND i.fatura_lote_id = f.id
+GROUP BY c.escola_id, c.id, c.nome, c.vagas;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_formacao_cohorts_lotacao
+  ON internal.mv_formacao_cohorts_lotacao (escola_id, cohort_id);
+
+DROP MATERIALIZED VIEW IF EXISTS internal.mv_formacao_inadimplencia_resumo;
+CREATE MATERIALIZED VIEW internal.mv_formacao_inadimplencia_resumo AS
+WITH b2c AS (
+  SELECT
+    i.escola_id,
+    COUNT(*) FILTER (WHERE i.status_pagamento IN ('pendente', 'parcial'))::int AS titulos_em_aberto,
+    COALESCE(SUM(i.valor_total) FILTER (WHERE i.status_pagamento IN ('pendente', 'parcial')), 0)::numeric(14,2) AS valor_em_aberto
+  FROM public.formacao_faturas_lote_itens i
+  GROUP BY i.escola_id
+),
+b2b AS (
+  SELECT
+    f.escola_id,
+    COUNT(*) FILTER (WHERE f.status IN ('emitida', 'parcial'))::int AS faturas_em_aberto,
+    COALESCE(SUM(f.total_liquido) FILTER (WHERE f.status IN ('emitida', 'parcial')), 0)::numeric(14,2) AS valor_em_aberto
+  FROM public.formacao_faturas_lote f
+  GROUP BY f.escola_id
+)
+SELECT
+  COALESCE(b2c.escola_id, b2b.escola_id) AS escola_id,
+  COALESCE(b2c.titulos_em_aberto, 0) AS b2c_titulos_em_aberto,
+  COALESCE(b2c.valor_em_aberto, 0)::numeric(14,2) AS b2c_valor_em_aberto,
+  COALESCE(b2b.faturas_em_aberto, 0) AS b2b_faturas_em_aberto,
+  COALESCE(b2b.valor_em_aberto, 0)::numeric(14,2) AS b2b_valor_em_aberto,
+  (COALESCE(b2c.valor_em_aberto, 0) + COALESCE(b2b.valor_em_aberto, 0))::numeric(14,2) AS total_em_aberto
+FROM b2c
+FULL OUTER JOIN b2b
+  ON b2b.escola_id = b2c.escola_id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_formacao_inadimplencia_resumo
+  ON internal.mv_formacao_inadimplencia_resumo (escola_id);
+
+DROP MATERIALIZED VIEW IF EXISTS internal.mv_formacao_margem_por_edicao;
+CREATE MATERIALIZED VIEW internal.mv_formacao_margem_por_edicao AS
+WITH receita AS (
+  SELECT
+    f.escola_id,
+    f.cohort_id,
+    COALESCE(SUM(i.valor_total) FILTER (WHERE i.status_pagamento <> 'cancelado'), 0)::numeric(14,2) AS receita_total
+  FROM public.formacao_faturas_lote f
+  LEFT JOIN public.formacao_faturas_lote_itens i
+    ON i.escola_id = f.escola_id
+   AND i.fatura_lote_id = f.id
+  WHERE f.cohort_id IS NOT NULL
+  GROUP BY f.escola_id, f.cohort_id
+),
+custo AS (
+  SELECT
+    h.escola_id,
+    h.cohort_id,
+    COALESCE(SUM(h.valor_liquido) FILTER (WHERE h.status IN ('aprovado', 'pago')), 0)::numeric(14,2) AS custo_honorarios
+  FROM public.formacao_honorarios_lancamentos h
+  GROUP BY h.escola_id, h.cohort_id
+)
+SELECT
+  c.escola_id,
+  c.id AS cohort_id,
+  c.nome AS cohort_nome,
+  COALESCE(r.receita_total, 0)::numeric(14,2) AS receita_total,
+  COALESCE(ct.custo_honorarios, 0)::numeric(14,2) AS custo_honorarios,
+  (COALESCE(r.receita_total, 0) - COALESCE(ct.custo_honorarios, 0))::numeric(14,2) AS margem_bruta
+FROM public.formacao_cohorts c
+LEFT JOIN receita r
+  ON r.escola_id = c.escola_id
+ AND r.cohort_id = c.id
+LEFT JOIN custo ct
+  ON ct.escola_id = c.escola_id
+ AND ct.cohort_id = c.id;
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_mv_formacao_margem_por_edicao
+  ON internal.mv_formacao_margem_por_edicao (escola_id, cohort_id);
+
+CREATE OR REPLACE VIEW public.vw_formacao_cohorts_lotacao AS
+SELECT *
+FROM internal.mv_formacao_cohorts_lotacao
+WHERE escola_id = public.current_tenant_escola_id();
+
+CREATE OR REPLACE VIEW public.vw_formacao_inadimplencia_resumo AS
+SELECT *
+FROM internal.mv_formacao_inadimplencia_resumo
+WHERE escola_id = public.current_tenant_escola_id();
+
+CREATE OR REPLACE VIEW public.vw_formacao_margem_por_edicao AS
+SELECT *
+FROM internal.mv_formacao_margem_por_edicao
+WHERE escola_id = public.current_tenant_escola_id();
+
+GRANT SELECT ON public.vw_formacao_cohorts_lotacao TO authenticated;
+GRANT SELECT ON public.vw_formacao_inadimplencia_resumo TO authenticated;
+GRANT SELECT ON public.vw_formacao_margem_por_edicao TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.refresh_mv_formacao_cohorts_lotacao()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, internal
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_cohorts_lotacao;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_mv_formacao_inadimplencia_resumo()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, internal
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_inadimplencia_resumo;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_mv_formacao_margem_por_edicao()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, internal
+AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_margem_por_edicao;
+END;
+$$;
+
+SELECT cron.schedule(
+  'refresh_mv_formacao_cohorts_lotacao',
+  '*/5 * * * *',
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_cohorts_lotacao$$
+);
+
+SELECT cron.schedule(
+  'refresh_mv_formacao_inadimplencia_resumo',
+  '*/2 * * * *',
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_inadimplencia_resumo$$
+);
+
+SELECT cron.schedule(
+  'refresh_mv_formacao_margem_por_edicao',
+  '*/10 * * * *',
+  $$REFRESH MATERIALIZED VIEW CONCURRENTLY internal.mv_formacao_margem_por_edicao$$
+);


### PR DESCRIPTION
### Motivation

- Introduce a new "formação" (training) domain with dedicated backoffice, teacher and student portals and financial flows that require strict operational cache rules and plan gating. 
- Provide DB foundation (schema, RLS, MVs, refresh functions and cron) for heavy dashboards and multi-tenant isolation. 
- Enforce feature gating for QR-certified documents and expose upgrade-friendly errors for plan-limited features.

### Description

- Added frontend scaffolding for the formação area: layouts (`(formacao-backoffice)`, `(formacao-formador)`, `(formacao-formando)`), `BackofficeShell`, multiple placeholder pages for cohorts, onboarding, certificados, formandos, sessões, materiais, honorários and achievements, and updated guards to recognise new roles. 
- Expanded auth/permission model: added new roles/claims (`formacao_admin`, `formacao_secretaria`, `formacao_financeiro`, `formador`, `formando`) and new permissions, updated `permissions.ts`, `roles.ts`, and middleware to resolve JWT/app_metadata context and route landing/redirect logic for formacao vs k12 models. 
- Introduced plan/feature gating: new `plans` features, `featureMatrix`, `requireFeature` implementation and nicer error payloads (`PLAN_FEATURE_REQUIRED`) plus `HttpError` handling in API routes; API endpoints that issue/emit certificates or batch certificates now call `requireFeature('doc_qr_code')`. 
- Security and operational changes: `middleware.ts` now supports model-aware routing, portal rules for formação, improved auth-context extraction from JWT/cookies and expanded rate/route matchers; many financial APIs and client fetch calls set `cache: 'no-store'` / `dynamic = 'force-dynamic'` where appropriate. 
- New server APIs: certificate verification route (`/api/formacao/certificados/[id]/verify`) with no-cache settings and robust RPC call to validate tokens. 
- Database migrations: created formation schema and RLS foundation migration (`20260407130000_formacao_schema_rls_foundation.sql`) with helper auth functions, tables (cohorts, cohort_formadores, clientes_b2b, faturas_lote, honorarios), RLS policies and views; added performance MVs + refresh functions/cron for formation financial dashboards (`20260407143000_formacao_financeiro_mvs.sql`). 
- Documentation and agent outputs: updated `AGENTS.md` with cache/taxonomy rules for formação and added an agents output doc `FORMACAO_TAXONOMY_CACHE_POLICY_2026-04-07.md` describing routes, cache policy, MVs and observability checklist. 
- Misc: small UX/data-fetch changes to use `{ cache: 'no-store' }` for financial endpoints, added `getFormacaoContext` helper for server components.

### Testing

- Performed TypeScript/Next build (`pnpm -w -r build`) and static type checks; the project builds successfully. 
- Ran linters (`pnpm -w -r lint`) and unit test suite (`pnpm -w -r test`) as smoke checks; linters and tests passed in this branch. 
- Exercised a few API smoke paths locally (certificate verify and documentos emit/batch endpoints) to confirm plan-gate responses and error payloads include `error_code`/`upgrade_required` where applicable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d547d81b7483268ffd676810f144b1)