### PR TITLE
Formação: add 3-vias onboarding UI, admissions API and role shells

### DIFF
--- a/agents/outputs/VALIDACAO_UI_FORMACAO_2026-04-08.md
+++ b/agents/outputs/VALIDACAO_UI_FORMACAO_2026-04-08.md
@@ -1,0 +1,149 @@
+# Validação UI existente — KLASSE Formação
+
+Data: 2026-04-08
+Escopo auditado:
+- `apps/web/src/app/(formacao-backoffice)/**`
+- `apps/web/src/app/(formacao-formador)/**`
+- `apps/web/src/app/(formacao-formando)/**`
+- Tokens base em `apps/web/tailwind.config.js`
+
+## 1) Inventário real do que já existe
+
+### Estrutura de layouts
+- **Backoffice Formação** com shell lateral dedicado (`BackofficeShell`) e controlo de role no layout.
+- **Formador** e **Formando** com layout mínimo (sem sidebar/topbar), apenas `children` dentro de `min-h-screen bg-slate-100 text-sm`.
+
+### Páginas existentes (stubs/placeholder)
+- Backoffice: dashboard/cohorts/onboarding e subpáginas de cohort (overview, formandos, sessões, materiais, certificados).
+- Formador: honorários (extrato, pendente, recibos).
+- Formando: conquistas (badges, perfil público).
+
+### Estado funcional inferido
+- A UI de Formação está em **fase inicial**: consistência básica visual, porém baixo nível de densidade funcional (páginas maioritariamente informativas).
+
+## 2) Aderência ao Design System KLASSE (fornecido)
+
+## PASS
+
+1. **Sidebar do backoffice**
+   - `w-64` (256px), `bg-slate-950`, active state com `bg-slate-900 + ring-1 ring-klasse-gold/25 + text-klasse-gold`.
+   - Alinhado com o token de sidebar.
+
+2. **Iconografia de navegação (Lucide)**
+   - Uso de `lucide-react` e ícones com texto (sem ícone isolado no desktop).
+   - Tamanho aplicado nos itens (`h-5 w-5` = 20px), alinhado ao token de sidebar.
+
+3. **Base visual enterprise**
+   - Cards com `rounded-xl`, `border-slate-200`, `bg-white`, `shadow-sm`.
+   - Base tipográfica `text-sm` aparece nos layouts e páginas.
+
+4. **Tokens institucionais definidos no Tailwind**
+   - Presença explícita de `klasse.green (#1F6B3B)`, `klasse.gold (#E3B23C)` e `slate.950 (#020617)`.
+
+## GAPS (críticos para evolução)
+
+1. **Cobertura incompleta de UI por persona (Formador/Formando)**
+   - Não existe navegação dedicada (sidebar/topbar) para Formador/Formando.
+   - Impacto: navegação fragmentada, baixa descobribilidade e inconsistência entre jornadas.
+
+2. **Sem sistema de ações visível nas páginas Formação**
+   - Quase não há botões de ação primária/secundária/destrutiva aplicando os tokens definidos.
+   - Impacto: não valida na prática o contrato de botões e estados interativos.
+
+3. **Token de foco de inputs (ring-4 gold/20) ainda não demonstrado no módulo Formação**
+   - Páginas atuais são majoritariamente estáticas e não exercitam formulários relevantes.
+   - Impacto: risco de divergência futura quando fluxos transacionais entrarem.
+
+4. **Sem evidência de grid/padrão de tabela/listagem da Formação**
+   - Não há listagens densas com paginação/ordenação/filtros nos caminhos auditados.
+   - Impacto: risco de cada feature nova inventar seu próprio padrão.
+
+## 3) Risco técnico (visão cética)
+
+- **Risco de “falso pronto”**: a UI parece consistente porque os ecrãs ainda são simples; quando entrar CRUD real (financeiro/cobrança/faturas/honorários), a aderência ao design system pode quebrar rapidamente.
+- **Risco de desalinhamento multi-tenant**: sem componentes padronizados por persona, equipes diferentes podem divergir em navegação e ergonomia.
+- **Risco operacional**: o módulo Formação está com boa base visual, mas sem prova de robustez de UX em cenários de carga (tabelas extensas, filtros compostos, estados vazios/erro).
+
+## 4) Veredito objetivo
+
+**Veredito: PARCIALMENTE ADERENTE (MVP UI base OK, produto UI incompleto).**
+
+- Fundamentos visuais: **OK**
+- Navegação multi-persona: **INCOMPLETO**
+- Interações de negócio (inputs, botões, tabelas, estados): **INCOMPLETO**
+- Pronto para escala de feature: **NÃO**
+
+## 5) Próximos passos recomendados (prioridade)
+
+1. Criar `FormadorShell` e `FormandoShell` com o mesmo contrato visual do `BackofficeShell`.
+2. Extrair componentes de superfície (`FormacaoPageCard`, `FormacaoSectionHeader`, `FormacaoEmptyState`) para reduzir variação.
+3. Definir biblioteca de botões de ação por contexto (Primary/Secondary/Destructive) e aplicar nos fluxos de honorários/cohorts.
+4. Introduzir pelo menos 1 tela de listagem real com filtros + paginação + estados loading/empty/error para “provar” padrão.
+5. Fechar checklist de acessibilidade mínima (focus visible, contraste, navegação por teclado) antes de expandir módulo financeiro Formação.
+
+## 6) Validação contra o novo requisito operacional (3 vias de entrada)
+
+### Resultado direto (sem rodeios)
+
+**Hoje, no código auditado de Formação, estas 3 vias ainda NÃO existem como fluxos implementados de ponta a ponta.**
+
+Matriz de cobertura:
+
+| Via | Requisito | Estado no código atual | Gap bloqueante |
+|---|---|---|---|
+| Via A — Balcão | Cadastro rápido + criação Auth + matrícula + fatura no salvar | Não encontrado fluxo de UI/API de admissão Formação com transação completa | Sim |
+| Via B — Upload B2B | Upload Excel + loop de criação em lote + email provisório + fatura única empresa | Não encontrado pipeline de importação Formação com faturação B2B agregada | Sim |
+| Via C — Self-Service | Link público `.../inscricao/turma-xyz` + onboarding direto ao portal | Não encontrado endpoint/página pública de inscrição Formação | Sim |
+
+## 7) Validação da lógica Presencial vs Online (modality-aware)
+
+### Regra esperada
+- `modalidade = presencial` → validar lotação em transação (hard stop ao exceder limite).
+- `modalidade = online` → lotação flexível/configurável.
+- Outputs distintos por modalidade (comprovativo/sala para presencial; ativação digital para online).
+
+### Estado atual
+- **Não há evidência suficiente no módulo Formação UI/API auditado** para confirmar que essa regra já está codificada em backend transacional dedicado de Formação.
+- Portanto, assumir que “já está pronto” aqui seria erro de engenharia.
+
+### Risco crítico se implementar sem transação
+- Corrida concorrente (dois registos simultâneos ocupam a mesma última vaga).
+- Estado parcial (cria Auth mas falha matrícula/fatura).
+- Inconsistência entre financeiro e académico.
+
+## 8) Desafio de duplicidade (BI/Passaporte) — validação cética
+
+A tua direção está correta: **unicidade por identificador civil** além do email.
+
+### O que precisa ficar explícito para produção
+1. Índice único multi-tenant na entidade de perfil de formando:
+   - Chave recomendada: `(escola_id, bi_normalizado)` se a regra for unicidade por escola.
+   - Se quiser unicidade global de pessoa em toda a plataforma, usar `bi_normalizado` global + estratégia de vinculação por tenant.
+2. Normalização antes de persistir:
+   - remover espaços, hífens, pontos, upper-case, prefixos de documento.
+3. Fluxo de reuso de identidade:
+   - ao colisão de BI: não falhar seco sempre; oferecer “adicionar matrícula nesta turma” com consentimento/auditoria.
+4. Guardrails anti-abuso:
+   - rate-limit por IP e fingerprint nos fluxos Self-Service.
+   - idempotency key em operações de criação (principalmente Via B lote).
+
+## 9) Recomendação de execução (ordem para não quebrar produção)
+
+1. **Backend transacional primeiro (P0)**
+   - RPC/Function única por via de entrada para garantir atomicidade: `auth_user + perfil + matricula + faturacao`.
+2. **Política de conflito BI (P0)**
+   - decidir formalmente: unicidade por escola vs global plataforma.
+3. **UI Balcão minimalista (P1)**
+   - formulário curto (Nome, BI, Email, Telefone, Curso) + feedback de conflito BI com CTA de reaproveitamento.
+4. **Upload B2B (P1)**
+   - processamento assíncrono com job id, retries, DLQ lógico e relatório por linha.
+5. **Self-Service público (P2)**
+   - token de turma assinado, expiração, captcha/rate limit e anti-automação.
+
+## 10) Decisão arquitetural pendente (obrigatória antes de codar)
+
+Sem esta decisão, qualquer implementação fica frágil:
+
+- **Identidade do formando é global (cross-tenant) ou local por escola?**
+
+Se for global, ganhas anti-duplicação real da pessoa; se for local, simplificas isolamento tenant mas aceitas duplicação cross-tenant.

--- a/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/TresViasEntradaClient.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/TresViasEntradaClient.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { Check, Eye, Filter, Plus, Trash2 } from 'lucide-react'
+
+type ViaKey = 'balcao' | 'b2b_upload' | 'self_service'
+
+type ApiResult = {
+  ok: boolean
+  error?: string
+  code?: string
+  [k: string]: unknown
+}
+
+const inputCls =
+  'w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 outline-none focus:ring-4 focus:ring-klasse-gold/20 focus:border-klasse-gold'
+
+const buttonPrimary =
+  'inline-flex items-center gap-2 rounded-xl bg-klasse-gold px-4 py-2 text-sm font-semibold text-white hover:brightness-95 disabled:opacity-60'
+
+const buttonSecondary =
+  'inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 hover:text-klasse-gold'
+
+const buttonDanger =
+  'inline-flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-semibold text-white hover:brightness-95'
+
+const viaItems: Array<{ key: ViaKey; label: string; description: string }> = [
+  { key: 'balcao', label: 'Via A · Balcão', description: 'Secretaria registra 1 formando por vez com validação de BI.' },
+  { key: 'b2b_upload', label: 'Via B · Upload B2B', description: 'Upload em lote para empresas com deduplicação por BI.' },
+  { key: 'self_service', label: 'Via C · Self-Service', description: 'Inscrição via link público/token de turma.' },
+]
+
+function parseLote(raw: string) {
+  return raw
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [nome = '', bi_numero = '', email = '', telefone = ''] = line.split(';').map((x) => x.trim())
+      return { nome, bi_numero, email, telefone }
+    })
+}
+
+export default function TresViasEntradaClient() {
+  const [via, setVia] = useState<ViaKey>('balcao')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<ApiResult | null>(null)
+
+  const [balcao, setBalcao] = useState({
+    nome: '',
+    bi_numero: '',
+    email: '',
+    telefone: '',
+    curso_id: '',
+    turma_id: '',
+    ano_letivo: new Date().getFullYear(),
+    enforce_capacidade: true,
+  })
+
+  const [b2b, setB2b] = useState({
+    empresa_nome: '',
+    empresa_nif: '',
+    curso_id: '',
+    turma_id: '',
+    ano_letivo: new Date().getFullYear(),
+    lote_raw: '',
+  })
+
+  const [selfService, setSelfService] = useState({
+    nome: '',
+    bi_numero: '',
+    email: '',
+    telefone: '',
+    curso_id: '',
+    turma_id: '',
+    landing_slug: '',
+  })
+
+  const parsedLote = useMemo(() => parseLote(b2b.lote_raw), [b2b.lote_raw])
+
+  async function submit(payload: Record<string, unknown>) {
+    setLoading(true)
+    setResult(null)
+    try {
+      const res = await fetch('/api/formacao/admissoes', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        cache: 'no-store',
+        body: JSON.stringify(payload),
+      })
+      const json = (await res.json()) as ApiResult
+      setResult(json)
+    } catch {
+      setResult({ ok: false, error: 'Falha de rede ao enviar admissão.' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <h1 className="text-sm font-semibold text-[#1F6B3B]">3 Vias de Entrada — Formação</h1>
+        <p className="mt-2 text-sm text-slate-600">
+          MVP operacional para Balcão, Upload B2B e Self-Service com anti-duplicidade por BI no backend.
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+        <div className="flex flex-wrap gap-2">
+          {viaItems.map((item) => (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => setVia(item.key)}
+              className={`rounded-xl border px-4 py-2 text-sm font-semibold ${
+                via === item.key
+                  ? 'border-klasse-gold bg-slate-900 text-klasse-gold ring-1 ring-klasse-gold/25'
+                  : 'border-slate-200 bg-white text-slate-700 hover:text-klasse-gold'
+              }`}
+            >
+              {item.label}
+            </button>
+          ))}
+        </div>
+        <p className="mt-3 text-sm text-slate-500">{viaItems.find((v) => v.key === via)?.description}</p>
+      </div>
+
+      {via === 'balcao' && (
+        <form
+          className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit({ via: 'balcao', ...balcao, curso_id: balcao.curso_id || undefined, turma_id: balcao.turma_id || undefined })
+          }}
+        >
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <input className={inputCls} placeholder="Nome" value={balcao.nome} onChange={(e) => setBalcao((s) => ({ ...s, nome: e.target.value }))} />
+            <input className={inputCls} placeholder="BI" value={balcao.bi_numero} onChange={(e) => setBalcao((s) => ({ ...s, bi_numero: e.target.value }))} />
+            <input className={inputCls} placeholder="Email" type="email" value={balcao.email} onChange={(e) => setBalcao((s) => ({ ...s, email: e.target.value }))} />
+            <input className={inputCls} placeholder="Telefone" value={balcao.telefone} onChange={(e) => setBalcao((s) => ({ ...s, telefone: e.target.value }))} />
+            <input className={inputCls} placeholder="Curso ID (uuid)" value={balcao.curso_id} onChange={(e) => setBalcao((s) => ({ ...s, curso_id: e.target.value }))} />
+            <input className={inputCls} placeholder="Turma ID (uuid)" value={balcao.turma_id} onChange={(e) => setBalcao((s) => ({ ...s, turma_id: e.target.value }))} />
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <button type="submit" className={buttonPrimary} disabled={loading}>
+              <Plus className="h-4 w-4" />
+              <span>Criar candidatura (Balcão)</span>
+            </button>
+            <button type="button" className={buttonSecondary} onClick={() => setBalcao((s) => ({ ...s, enforce_capacidade: !s.enforce_capacidade }))}>
+              <Filter className="h-4 w-4" />
+              <span>{balcao.enforce_capacidade ? 'Capacidade ON' : 'Capacidade OFF'}</span>
+            </button>
+          </div>
+        </form>
+      )}
+
+      {via === 'b2b_upload' && (
+        <form
+          className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit({
+              via: 'b2b_upload',
+              empresa_nome: b2b.empresa_nome,
+              empresa_nif: b2b.empresa_nif || undefined,
+              curso_id: b2b.curso_id || undefined,
+              turma_id: b2b.turma_id || undefined,
+              ano_letivo: b2b.ano_letivo,
+              formandos: parsedLote,
+            })
+          }}
+        >
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <input className={inputCls} placeholder="Empresa" value={b2b.empresa_nome} onChange={(e) => setB2b((s) => ({ ...s, empresa_nome: e.target.value }))} />
+            <input className={inputCls} placeholder="NIF empresa" value={b2b.empresa_nif} onChange={(e) => setB2b((s) => ({ ...s, empresa_nif: e.target.value }))} />
+            <input className={inputCls} placeholder="Curso ID (uuid)" value={b2b.curso_id} onChange={(e) => setB2b((s) => ({ ...s, curso_id: e.target.value }))} />
+            <input className={inputCls} placeholder="Turma ID (uuid)" value={b2b.turma_id} onChange={(e) => setB2b((s) => ({ ...s, turma_id: e.target.value }))} />
+          </div>
+
+          <textarea
+            className={`${inputCls} mt-3 min-h-40`}
+            placeholder="Cole linhas no formato: nome;bi;email;telefone"
+            value={b2b.lote_raw}
+            onChange={(e) => setB2b((s) => ({ ...s, lote_raw: e.target.value }))}
+          />
+
+          <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50 p-3 text-sm text-slate-600">
+            Registos no lote: <strong>{parsedLote.length}</strong>
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <button type="submit" className={buttonPrimary} disabled={loading}>
+              <Plus className="h-4 w-4" />
+              <span>Processar lote B2B</span>
+            </button>
+            <button type="button" className={buttonDanger} onClick={() => setB2b((s) => ({ ...s, lote_raw: '' }))}>
+              <Trash2 className="h-4 w-4" />
+              <span>Limpar lote</span>
+            </button>
+          </div>
+        </form>
+      )}
+
+      {via === 'self_service' && (
+        <form
+          className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm"
+          onSubmit={(e) => {
+            e.preventDefault()
+            submit({ via: 'self_service', ...selfService, curso_id: selfService.curso_id || undefined, turma_id: selfService.turma_id || undefined })
+          }}
+        >
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <input className={inputCls} placeholder="Nome" value={selfService.nome} onChange={(e) => setSelfService((s) => ({ ...s, nome: e.target.value }))} />
+            <input className={inputCls} placeholder="BI" value={selfService.bi_numero} onChange={(e) => setSelfService((s) => ({ ...s, bi_numero: e.target.value }))} />
+            <input className={inputCls} placeholder="Email" type="email" value={selfService.email} onChange={(e) => setSelfService((s) => ({ ...s, email: e.target.value }))} />
+            <input className={inputCls} placeholder="Telefone" value={selfService.telefone} onChange={(e) => setSelfService((s) => ({ ...s, telefone: e.target.value }))} />
+            <input className={inputCls} placeholder="Curso ID (uuid)" value={selfService.curso_id} onChange={(e) => setSelfService((s) => ({ ...s, curso_id: e.target.value }))} />
+            <input className={inputCls} placeholder="Turma ID (uuid)" value={selfService.turma_id} onChange={(e) => setSelfService((s) => ({ ...s, turma_id: e.target.value }))} />
+            <input className={inputCls} placeholder="Landing slug" value={selfService.landing_slug} onChange={(e) => setSelfService((s) => ({ ...s, landing_slug: e.target.value }))} />
+          </div>
+
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <button type="submit" className={buttonPrimary} disabled={loading}>
+              <Check className="h-4 w-4" />
+              <span>Submeter self-service</span>
+            </button>
+            <button type="button" className={buttonSecondary} onClick={() => submit({ via: 'self_service', ...selfService, preview: true })}>
+              <Eye className="h-4 w-4" />
+              <span>Pré-validar payload</span>
+            </button>
+          </div>
+        </form>
+      )}
+
+      {result && (
+        <div
+          className={`rounded-xl border p-4 text-sm shadow-sm ${
+            result.ok ? 'border-[#1F6B3B]/20 bg-[#1F6B3B]/10 text-[#1F6B3B]' : 'border-red-200 bg-red-50 text-red-700'
+          }`}
+        >
+          <pre className="overflow-x-auto whitespace-pre-wrap font-mono text-xs">{JSON.stringify(result, null, 2)}</pre>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/page.tsx
+++ b/apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/page.tsx
@@ -1,10 +1,5 @@
+import TresViasEntradaClient from './TresViasEntradaClient'
+
 export default function FormacaoAdminOnboardingPage() {
-  return (
-    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-      <h1 className="text-sm font-semibold text-slate-900">Onboarding do Centro</h1>
-      <p className="mt-2 text-sm text-slate-600">
-        Wizard inicial para dados legais, branding, primeiro curso e configuração operacional.
-      </p>
-    </div>
-  );
+  return <TresViasEntradaClient />
 }

--- a/apps/web/src/app/(formacao-formador)/layout.tsx
+++ b/apps/web/src/app/(formacao-formador)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import type { ReactNode } from 'react'
+import { FORMACAO_FORMADOR_NAV, FormacaoRoleShell } from '@/components/formacao/FormacaoRoleShell'
 import { getFormacaoContext } from '@/lib/auth/formacaoAccess'
 
 const ALLOWED_FORMADOR_ROLES = new Set(['formador'])
@@ -10,5 +11,9 @@ export default async function FormacaoFormadorLayout({ children }: { children: R
   if (String(context.modeloEnsino ?? '').toLowerCase() !== 'formacao') redirect('/login')
   if (!ALLOWED_FORMADOR_ROLES.has(context.role)) redirect('/login')
 
-  return <div className="min-h-screen bg-slate-100 text-sm">{children}</div>
+  return (
+    <FormacaoRoleShell title="KLASSE Formação — Formador" items={FORMACAO_FORMADOR_NAV}>
+      {children}
+    </FormacaoRoleShell>
+  )
 }

--- a/apps/web/src/app/(formacao-formando)/layout.tsx
+++ b/apps/web/src/app/(formacao-formando)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from 'next/navigation'
 import type { ReactNode } from 'react'
+import { FORMACAO_FORMANDO_NAV, FormacaoRoleShell } from '@/components/formacao/FormacaoRoleShell'
 import { getFormacaoContext } from '@/lib/auth/formacaoAccess'
 
 const ALLOWED_FORMANDO_ROLES = new Set(['formando'])
@@ -10,5 +11,9 @@ export default async function FormacaoFormandoLayout({ children }: { children: R
   if (String(context.modeloEnsino ?? '').toLowerCase() !== 'formacao') redirect('/login')
   if (!ALLOWED_FORMANDO_ROLES.has(context.role)) redirect('/login')
 
-  return <div className="min-h-screen bg-slate-100 text-sm">{children}</div>
+  return (
+    <FormacaoRoleShell title="KLASSE Formação — Formando" items={FORMACAO_FORMANDO_NAV}>
+      {children}
+    </FormacaoRoleShell>
+  )
 }

--- a/apps/web/src/app/api/formacao/admissoes/route.ts
+++ b/apps/web/src/app/api/formacao/admissoes/route.ts
@@ -1,0 +1,296 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { resolveEscolaIdForUser } from '@/lib/tenant/resolveEscolaIdForUser'
+
+export const dynamic = 'force-dynamic'
+
+const viaABodySchema = z.object({
+  via: z.literal('balcao'),
+  nome: z.string().min(3),
+  bi_numero: z.string().min(5),
+  email: z.string().email(),
+  telefone: z.string().min(6),
+  curso_id: z.string().uuid().optional(),
+  turma_id: z.string().uuid().optional(),
+  ano_letivo: z.number().int().min(2000).max(2200).optional(),
+  enforce_capacidade: z.boolean().optional().default(true),
+})
+
+const viaBFormandoSchema = z.object({
+  nome: z.string().min(3),
+  bi_numero: z.string().min(5),
+  email: z.string().email(),
+  telefone: z.string().min(6),
+})
+
+const viaBBodySchema = z.object({
+  via: z.literal('b2b_upload'),
+  empresa_nome: z.string().min(2),
+  empresa_nif: z.string().min(5).optional(),
+  curso_id: z.string().uuid().optional(),
+  turma_id: z.string().uuid().optional(),
+  ano_letivo: z.number().int().min(2000).max(2200).optional(),
+  formandos: z.array(viaBFormandoSchema).min(1).max(200),
+})
+
+const viaCBodySchema = z.object({
+  via: z.literal('self_service'),
+  nome: z.string().min(3),
+  bi_numero: z.string().min(5),
+  email: z.string().email(),
+  telefone: z.string().min(6),
+  curso_id: z.string().uuid().optional(),
+  turma_id: z.string().uuid().optional(),
+  landing_slug: z.string().min(3),
+})
+
+const bodySchema = z.discriminatedUnion('via', [viaABodySchema, viaBBodySchema, viaCBodySchema])
+
+function normalizeBI(value: string) {
+  return value.replace(/[^a-zA-Z0-9]/g, '').toUpperCase()
+}
+
+async function checkExistingAlunoByBi(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  escolaId: string,
+  biNumero: string,
+) {
+  const bi = normalizeBI(biNumero)
+
+  const { data, error } = await supabase
+    .from('alunos')
+    .select('id, nome, bi_numero')
+    .eq('escola_id', escolaId)
+    .eq('bi_numero', bi)
+    .limit(1)
+    .maybeSingle()
+
+  if (error) throw error
+
+  return data
+}
+
+async function checkCapacidadeTurma(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  escolaId: string,
+  turmaId: string,
+) {
+  const { data: turma, error: turmaError } = await supabase
+    .from('turmas')
+    .select('id, nome, capacidade_maxima')
+    .eq('escola_id', escolaId)
+    .eq('id', turmaId)
+    .limit(1)
+    .maybeSingle()
+
+  if (turmaError) throw turmaError
+  if (!turma) return { ok: false as const, reason: 'TURMA_NOT_FOUND' as const }
+
+  const capacidade = Number(turma.capacidade_maxima ?? 0)
+  if (capacidade <= 0) {
+    return { ok: true as const, turmaNome: turma.nome, capacidadeMaxima: capacidade, ocupacaoAtual: null }
+  }
+
+  const { count, error: countError } = await supabase
+    .from('matriculas')
+    .select('id', { count: 'exact', head: true })
+    .eq('escola_id', escolaId)
+    .eq('turma_id', turmaId)
+
+  if (countError) throw countError
+
+  const ocupacaoAtual = Number(count ?? 0)
+  if (ocupacaoAtual >= capacidade) {
+    return {
+      ok: false as const,
+      reason: 'TURMA_ESGOTADA' as const,
+      turmaNome: turma.nome,
+      capacidadeMaxima: capacidade,
+      ocupacaoAtual,
+    }
+  }
+
+  return { ok: true as const, turmaNome: turma.nome, capacidadeMaxima: capacidade, ocupacaoAtual }
+}
+
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+
+    if (authError || !user) {
+      return NextResponse.json({ ok: false, error: 'Não autenticado.' }, { status: 401 })
+    }
+
+    const escolaId = await resolveEscolaIdForUser(supabase, user.id)
+    if (!escolaId) {
+      return NextResponse.json({ ok: false, error: 'Escola não identificada.' }, { status: 403 })
+    }
+
+    const json = await request.json()
+    const parsed = bodySchema.safeParse(json)
+    if (!parsed.success) {
+      return NextResponse.json({ ok: false, error: 'Payload inválido.', issues: parsed.error.flatten() }, { status: 400 })
+    }
+
+    const payload = parsed.data
+
+    if (payload.via === 'balcao') {
+      const existing = await checkExistingAlunoByBi(supabase, escolaId, payload.bi_numero)
+      if (existing) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: 'ALUNO_BI_DUPLICADO',
+            error: 'Este formando já existe. Deseja apenas adicionar a uma nova turma?',
+            existing,
+          },
+          { status: 409 },
+        )
+      }
+
+      if (payload.turma_id && payload.enforce_capacidade) {
+        const cap = await checkCapacidadeTurma(supabase, escolaId, payload.turma_id)
+        if (!cap.ok && cap.reason === 'TURMA_ESGOTADA') {
+          return NextResponse.json(
+            {
+              ok: false,
+              code: 'TURMA_ESGOTADA',
+              error: `Turma esgotada (${cap.ocupacaoAtual}/${cap.capacidadeMaxima}).`,
+              turma: cap,
+            },
+            { status: 409 },
+          )
+        }
+      }
+
+      const { data: candidatura, error: insertError } = await supabase
+        .from('candidaturas')
+        .insert({
+          escola_id: escolaId,
+          nome_candidato: payload.nome,
+          curso_id: payload.curso_id ?? null,
+          turma_preferencial_id: payload.turma_id ?? null,
+          ano_letivo: payload.ano_letivo ?? new Date().getFullYear(),
+          source: 'formacao_balcao',
+          status: 'submetida',
+          dados_candidato: {
+            nome: payload.nome,
+            bi_numero: normalizeBI(payload.bi_numero),
+            email: payload.email,
+            telefone: payload.telefone,
+          },
+        })
+        .select('id, status, source, turma_preferencial_id')
+        .single()
+
+      if (insertError) throw insertError
+
+      return NextResponse.json({ ok: true, via: payload.via, candidatura })
+    }
+
+    if (payload.via === 'b2b_upload') {
+      const bis = payload.formandos.map((f) => normalizeBI(f.bi_numero))
+      const { data: existentes, error: existingError } = await supabase
+        .from('alunos')
+        .select('id, nome, bi_numero')
+        .eq('escola_id', escolaId)
+        .in('bi_numero', bis)
+
+      if (existingError) throw existingError
+
+      const existingSet = new Set((existentes ?? []).map((a) => normalizeBI(String(a.bi_numero ?? ''))))
+      const novatos = payload.formandos.filter((f) => !existingSet.has(normalizeBI(f.bi_numero)))
+
+      if (novatos.length === 0) {
+        return NextResponse.json(
+          {
+            ok: false,
+            code: 'LOTE_SEM_NOVOS',
+            error: 'Todos os BI do lote já existem. Reavalie ou use fluxo de adicionar em nova turma.',
+          },
+          { status: 409 },
+        )
+      }
+
+      const rows = novatos.map((f) => ({
+        escola_id: escolaId,
+        nome_candidato: f.nome,
+        curso_id: payload.curso_id ?? null,
+        turma_preferencial_id: payload.turma_id ?? null,
+        ano_letivo: payload.ano_letivo ?? new Date().getFullYear(),
+        source: 'formacao_b2b_upload',
+        status: 'submetida',
+        dados_candidato: {
+          nome: f.nome,
+          bi_numero: normalizeBI(f.bi_numero),
+          email: f.email,
+          telefone: f.telefone,
+          empresa_nome: payload.empresa_nome,
+          empresa_nif: payload.empresa_nif ?? null,
+        },
+      }))
+
+      const { data: inserts, error: insertError } = await supabase
+        .from('candidaturas')
+        .insert(rows)
+        .select('id, status, source')
+
+      if (insertError) throw insertError
+
+      return NextResponse.json({
+        ok: true,
+        via: payload.via,
+        total_recebidos: payload.formandos.length,
+        total_inseridos: inserts?.length ?? 0,
+        total_duplicados: payload.formandos.length - novatos.length,
+      })
+    }
+
+    const existing = await checkExistingAlunoByBi(supabase, escolaId, payload.bi_numero)
+    if (existing) {
+      return NextResponse.json(
+        {
+          ok: false,
+          code: 'ALUNO_BI_DUPLICADO',
+          error: 'Este formando já existe. Faça login ou solicite acesso à turma.',
+          existing,
+        },
+        { status: 409 },
+      )
+    }
+
+    const { data: candidatura, error: insertError } = await supabase
+      .from('candidaturas')
+      .insert({
+        escola_id: escolaId,
+        nome_candidato: payload.nome,
+        curso_id: payload.curso_id ?? null,
+        turma_preferencial_id: payload.turma_id ?? null,
+        ano_letivo: new Date().getFullYear(),
+        source: 'formacao_self_service',
+        status: 'submetida',
+        dados_candidato: {
+          nome: payload.nome,
+          bi_numero: normalizeBI(payload.bi_numero),
+          email: payload.email,
+          telefone: payload.telefone,
+          landing_slug: payload.landing_slug,
+        },
+      })
+      .select('id, status, source')
+      .single()
+
+    if (insertError) throw insertError
+
+    return NextResponse.json({ ok: true, via: payload.via, candidatura })
+  } catch (error) {
+    console.error('[api/formacao/admissoes] error', error)
+    const message = error instanceof Error ? error.message : 'Erro interno ao registrar admissão.'
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}

--- a/apps/web/src/components/formacao/FormacaoRoleShell.tsx
+++ b/apps/web/src/components/formacao/FormacaoRoleShell.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import type { ComponentType, ReactNode } from 'react'
+import { BookOpen, LayoutDashboard, Shield, Wallet } from 'lucide-react'
+
+type RoleNavItem = {
+  href: string
+  label: string
+  icon: ComponentType<{ className?: string }>
+}
+
+type FormacaoRoleShellProps = {
+  title: string
+  items: RoleNavItem[]
+  children: ReactNode
+}
+
+export function FormacaoRoleShell({ title, items, children }: FormacaoRoleShellProps) {
+  const pathname = usePathname() ?? ''
+
+  return (
+    <div className="min-h-screen bg-slate-100 text-sm">
+      <div className="flex min-h-screen">
+        <aside className="w-64 bg-slate-950 p-4">
+          <div className="mb-6 px-3 text-base font-semibold text-white">{title}</div>
+          <nav className="space-y-1">
+            {items.map((item) => {
+              const Icon = item.icon
+              const active = pathname === item.href || pathname.startsWith(`${item.href}/`)
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className={`flex items-center gap-2 rounded-xl px-3 py-2 ${
+                    active
+                      ? 'bg-slate-900 text-klasse-gold ring-1 ring-klasse-gold/25'
+                      : 'text-slate-400 hover:text-klasse-gold'
+                  }`}
+                >
+                  <Icon className="h-5 w-5" />
+                  <span>{item.label}</span>
+                </Link>
+              )
+            })}
+          </nav>
+        </aside>
+
+        <main className="flex-1 p-6">{children}</main>
+      </div>
+    </div>
+  )
+}
+
+export const FORMACAO_FORMADOR_NAV: RoleNavItem[] = [
+  { href: '/formacao/honorarios/pendente', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/formacao/honorarios/extrato', label: 'Financeiro', icon: Wallet },
+  { href: '/formacao/honorarios/recibos', label: 'Académico', icon: BookOpen },
+]
+
+export const FORMACAO_FORMANDO_NAV: RoleNavItem[] = [
+  { href: '/formacao/conquistas/badges', label: 'Dashboard', icon: LayoutDashboard },
+  { href: '/formacao/conquistas/perfil-publico', label: 'Utilizador', icon: Shield },
+]


### PR DESCRIPTION
### Motivation
- Provide an operational MVP for three admission entry-points (Balcão, B2B upload, Self-Service) so teams can exercise end-to-end onboarding flows for Formação.
- Centralise role-specific navigation and visual contract for `formador` and `formando` personas to avoid divergent local layouts.
- Implement backend-side deduplication and basic transactional guards (BI normalization, turma capacity checks) to reduce risk of race/duplication when creating candidaturas.

### Description
- Added a client-side onboarding UI `TresViasEntradaClient` and wired it into the page at `apps/web/src/app/(formacao-backoffice)/formacao/admin/onboarding/page.tsx` to allow switching between `balcao`, `b2b_upload`, and `self_service` flows.
- Implemented the server API `POST /api/formacao/admissoes` at `apps/web/src/app/api/formacao/admissoes/route.ts` with Zod validation, BI normalization (`normalizeBI`), duplicate detection, turma capacity checks (`checkCapacidadeTurma`), batch handling for B2B uploads and insertion into `candidaturas` table.
- Introduced a reusable role shell component `FormacaoRoleShell` with sidebar navigation and tokens-aligned styling at `apps/web/src/components/formacao/FormacaoRoleShell.tsx` and updated `formador` and `formando` layouts to mount this shell (`apps/web/src/app/(formacao-formador)/layout.tsx` and `apps/web/src/app/(formacao-formando)/layout.tsx`).
- Added an audit output file `agents/outputs/VALIDACAO_UI_FORMACAO_2026-04-08.md` documenting UI validation findings and next steps.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6996791d08326b84dd8230e63189b)