### PR TITLE
chore(web): upgrade inngest to ^3.54.0 to address vulnerable version warning

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^2.29.3",
-    "inngest": "^3.52.3",
+    "inngest": "^3.54.0",
     "lucide-react": "^0.562.0",
     "next": "15.5.7",
     "pdf-lib": "^1.17.1",


### PR DESCRIPTION
### Motivation
- Address Vercel's deployment warning about a vulnerable `inngest` version by requiring `^3.54.0` which includes the patched release.

### Description
- Updated `apps/web/package.json` to change the `inngest` dependency from `^3.52.3` to `^3.54.0` and committed the change (short ref `a893c1a`); no runtime code paths were modified and the lockfile was not regenerated in this environment.

### Testing
- Ran `pnpm install --lockfile-only` (failed with `ERR_PNPM_FETCH_403` due to registry/auth restrictions in this environment).
- Ran `pnpm -C apps/web run build` (prebuild reached `db:types` then failed with `ERR_PNPM_FETCH_403` fetching packages); failures are environment registry/auth related, not caused by the dependency version bump.
- No further automated tests could be executed because the environment could not fetch required packages to refresh the lockfile or complete the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb928961f48326aca6c733e1d5e555)