### PR TITLE
Introduce ReciboPagamentoCompacto and refactor printable receipt views

### DIFF
--- a/apps/web/src/app/secretaria/documentos/[docId]/recibo/print/page.tsx
+++ b/apps/web/src/app/secretaria/documentos/[docId]/recibo/print/page.tsx
@@ -1,17 +1,16 @@
-import QRCode from "react-qr-code";
 import PrintTrigger from "@/app/secretaria/documentos/_print/PrintTrigger";
 import { getDocumentoEmitido } from "@/app/secretaria/documentos/_print/getDocumento";
 import styles from "@/app/secretaria/documentos/_print/print.module.css";
+import ReciboPagamentoCompacto from "@/components/financeiro/ReciboPagamentoCompacto";
 import { getRequestOrigin, normalizeValidationBaseUrl } from "@/lib/serverUrl";
 
 export const dynamic = "force-dynamic";
 
-const formatMoney = (value: number) =>
-  new Intl.NumberFormat("pt-AO", {
-    style: "currency",
-    currency: "AOA",
-    minimumFractionDigits: 2,
-  }).format(value || 0);
+const getSnapshotString = (value: unknown, fallback = "—") => {
+  if (typeof value === "string" && value.trim()) return value;
+  if (typeof value === "number") return String(value);
+  return fallback;
+};
 
 export default async function ReciboPrintPage({
   params,
@@ -28,120 +27,49 @@ export default async function ReciboPrintPage({
     return <div className="p-8">Documento inválido para esta página.</div>;
   }
 
-  const snapshot = (doc.dados_snapshot || {}) as Record<string, any>;
+  const snapshot = (doc.dados_snapshot || {}) as Record<string, unknown>;
   const baseUrl = normalizeValidationBaseUrl(
     process.env.NEXT_PUBLIC_VALIDATION_BASE_URL ?? validationBaseUrl ?? (await getRequestOrigin())
   );
   const hash = typeof snapshot.hash_validacao === "string" ? snapshot.hash_validacao : "";
   const urlValidacao = hash ? `${String(baseUrl).replace(/\/$/, "")}/documentos/${doc.public_id}?hash=${hash}` : null;
 
-  const referencia = snapshot.referencia || "Mensalidade";
-  const valorPago = Number(snapshot.valor_pago || 0);
+  const referencia = getSnapshotString(snapshot.referencia, "Mensalidade");
+  const valorPago = Number(snapshot.valor_pago ?? 0);
   const dataPagamento = snapshot.data_pagamento
     ? new Date(String(snapshot.data_pagamento)).toLocaleDateString("pt-PT")
     : "—";
-  const metodo = snapshot.metodo || "—";
+  const metodo = getSnapshotString(snapshot.metodo);
   const numero = snapshot.numero_sequencial ? String(snapshot.numero_sequencial).padStart(6, "0") : null;
+  const emitidoEm = new Date(String(doc.created_at)).toLocaleString("pt-PT");
 
-  // Novos campos enriquecidos
-  const alunoNome = snapshot.aluno_nome || "—";
-  const alunoBi = snapshot.aluno_bi || "—";
-  const turmaNome = snapshot.turma_nome || "—";
-  const classeNome = snapshot.classe_nome || "—";
-  const cursoNome = snapshot.curso_nome || "";
+  const alunoNome = getSnapshotString(snapshot.aluno_nome);
+  const alunoBi = getSnapshotString(snapshot.aluno_bi);
+  const turmaNome = getSnapshotString(snapshot.turma_nome);
+  const classeNome = getSnapshotString(snapshot.classe_nome);
+  const cursoNome = getSnapshotString(snapshot.curso_nome, "");
 
   return (
-    <div className={`min-h-screen ${styles.printRoot} font-serif text-slate-900`}>
+    <div className={`min-h-screen ${styles.printRoot} text-slate-900`}>
       <PrintTrigger />
-      <div className={`${styles.sheet} shadow-lg`}>
-        <div className="space-y-8">
-          <header className="text-center space-y-2 border-b border-slate-200 pb-6">
-            <div className="flex justify-center">
-              <img
-                src={logoUrl ?? "/insignia_med.png"}
-                alt="Insígnia da República de Angola"
-                className="h-20 w-20 max-h-20 max-w-20 object-contain"
-              />
-            </div>
-            <p className="text-xs uppercase tracking-[0.2em] text-slate-500 font-bold">{escolaNome}</p>
-            <h1 className="text-2xl font-bold uppercase tracking-tight">Recibo de Pagamento</h1>
-            <div className="flex justify-center gap-4 text-[10px] text-slate-500 font-sans">
-              <p>Emitido em: {new Date(String(doc.created_at)).toLocaleString("pt-PT")}</p>
-              {numero ? <p>Nº de Série: {numero}</p> : null}
-            </div>
-          </header>
-
-          <section className="space-y-4">
-            <h2 className="text-xs font-bold uppercase tracking-widest text-slate-400 border-b border-slate-100 pb-1">Identificação do Aluno</h2>
-            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
-              <div className="col-span-2">
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Nome Completo</p>
-                <p className="font-semibold text-base">{alunoNome}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">NIF / BI</p>
-                <p className="font-medium">{alunoBi}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Classe / Curso</p>
-                <p className="font-medium">{classeNome}{cursoNome ? ` - ${cursoNome}` : ""}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Turma</p>
-                <p className="font-medium">{turmaNome}</p>
-              </div>
-            </div>
-          </section>
-
-          <section className="space-y-4">
-            <h2 className="text-xs font-bold uppercase tracking-widest text-slate-400 border-b border-slate-100 pb-1">Dados do Pagamento</h2>
-            <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm">
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Referência</p>
-                <p className="font-semibold">{String(referencia)}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Data de Pagamento</p>
-                <p className="font-semibold">{dataPagamento}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Método</p>
-                <p className="font-medium">{String(metodo)}</p>
-              </div>
-              <div>
-                <p className="text-[10px] uppercase text-slate-400 font-sans font-bold">Valor Pago</p>
-                <p className="font-bold text-lg">{formatMoney(valorPago)}</p>
-              </div>
-            </div>
-          </section>
-
-          <div className="pt-8 grid grid-cols-2 gap-12">
-            <section className="space-y-2">
-              <p className="text-[9px] uppercase text-slate-400 font-bold">Autenticação Digital</p>
-              {urlValidacao ? (
-                <div className="flex items-center gap-4">
-                  <QRCode value={urlValidacao} size={72} />
-                  <div className="space-y-1">
-                    <p className="text-[8px] text-slate-500 leading-tight max-w-[150px]">
-                      Valide este recibo no portal oficial através do QR Code.
-                    </p>
-                    <p className="text-[8px] font-mono text-slate-400 truncate max-w-[150px]">
-                      ID: {doc.public_id}
-                    </p>
-                  </div>
-                </div>
-              ) : (
-                <p className="text-[10px] text-slate-500">Validação indisponível.</p>
-              )}
-            </section>
-
-            <section className="flex flex-col justify-end items-center text-center space-y-2">
-              <div className="w-full border-b border-slate-300 pb-1" />
-              <p className="text-[10px] uppercase font-bold text-slate-600">A Secretaria</p>
-              <p className="text-[8px] text-slate-400 italic">Documento processado por computador</p>
-            </section>
-          </div>
-        </div>
+      <div className={`${styles.sheet} ${styles.receiptCompactSheet} shadow-lg`}>
+        <ReciboPagamentoCompacto
+          escolaNome={escolaNome}
+          alunoNome={alunoNome}
+          alunoBi={alunoBi}
+          classeNome={classeNome}
+          cursoNome={cursoNome}
+          turmaNome={turmaNome}
+          referencia={referencia}
+          metodo={metodo}
+          valorPago={valorPago}
+          dataPagamento={dataPagamento}
+          numero={numero}
+          publicId={doc.public_id}
+          urlValidacao={urlValidacao}
+          logoUrl={logoUrl}
+          emitidoEm={emitidoEm}
+        />
       </div>
     </div>
   );

--- a/apps/web/src/app/secretaria/documentos/_print/print.module.css
+++ b/apps/web/src/app/secretaria/documentos/_print/print.module.css
@@ -13,29 +13,37 @@
   box-sizing: border-box;
 }
 
+.receiptCompactSheet {
+  min-height: auto;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+
 @media print {
   @page {
     size: A4;
-    margin: 0;
+    margin: 8mm;
   }
 
   .printRoot {
+    min-height: auto !important;
     background: white !important;
   }
 
   .sheet {
     margin: 0;
     box-shadow: none;
-    padding: 12mm;
-    width: 210mm;
-    height: 297mm;
-    max-height: 297mm;
+    padding: 0;
+    width: 100%;
+    min-height: auto;
     break-inside: avoid;
     page-break-inside: avoid;
     box-sizing: border-box;
   }
 
-  .printRoot {
-    background: white !important;
+  .receiptCompactSheet {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    overflow: hidden;
   }
 }

--- a/apps/web/src/components/financeiro/ReciboImprimivel.tsx
+++ b/apps/web/src/components/financeiro/ReciboImprimivel.tsx
@@ -1,14 +1,9 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import QRCode from "react-qr-code";
 import { Eye } from "lucide-react";
 import { useToast } from "@/components/feedback/FeedbackSystem";
-
-const formatKz = (valor: number) =>
-  new Intl.NumberFormat("pt-AO", { style: "currency", currency: "AOA" }).format(
-    valor || 0
-  );
+import ReciboPagamentoCompacto from "@/components/financeiro/ReciboPagamentoCompacto";
 
 type ReciboImprimivelProps = {
   escolaNome: string;
@@ -16,6 +11,16 @@ type ReciboImprimivelProps = {
   valor: number;
   data: string;
   urlValidacao: string | null;
+  alunoBi?: string;
+  classeNome?: string;
+  cursoNome?: string;
+  turmaNome?: string;
+  referencia?: string;
+  metodo?: string;
+  numero?: string | null;
+  publicId?: string;
+  logoUrl?: string | null;
+  emitidoEm?: string | null;
 };
 
 type ReciboPayload = {
@@ -29,6 +34,16 @@ export function ReciboImprimivel({
   valor,
   data,
   urlValidacao,
+  alunoBi = "—",
+  classeNome = "—",
+  cursoNome = "",
+  turmaNome = "—",
+  referencia = "Mensalidade",
+  metodo = "—",
+  numero = null,
+  publicId = "—",
+  logoUrl = null,
+  emitidoEm = null,
 }: ReciboImprimivelProps) {
   const dataFormatada = useMemo(() => {
     if (!data) return "—";
@@ -38,57 +53,25 @@ export function ReciboImprimivel({
   }, [data]);
 
   return (
-    <div className="hidden print:block print:p-10">
-      <div className="w-[210mm] min-h-[297mm] bg-white text-slate-900 text-sm">
-        <div className="flex items-start justify-between">
-          <div>
-            <p className="text-xs uppercase tracking-widest text-slate-400">Recibo</p>
-            <h1 className="text-2xl font-semibold text-slate-900">{escolaNome}</h1>
-            <p className="mt-1 text-slate-500">Comprovativo oficial de pagamento</p>
-          </div>
-          <div className="flex flex-col items-center gap-2 text-xs text-slate-500">
-            {urlValidacao ? (
-              <QRCode value={urlValidacao} size={96} className="h-24 w-24" />
-            ) : (
-              <div className="h-24 w-24 rounded-xl border border-dashed border-slate-200 flex items-center justify-center text-[11px] text-slate-400">
-                QR indisponível
-              </div>
-            )}
-            <span>Validar Autenticidade</span>
-          </div>
-        </div>
-
-        <div className="mt-10 grid grid-cols-2 gap-6">
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-wider text-slate-400">Aluno</p>
-            <p className="text-lg font-semibold text-slate-900">{alunoNome}</p>
-          </div>
-          <div className="space-y-2">
-            <p className="text-xs uppercase tracking-wider text-slate-400">Data</p>
-            <p className="text-lg font-semibold text-slate-900">{dataFormatada}</p>
-          </div>
-        </div>
-
-        <div className="mt-8 rounded-xl border border-slate-200 bg-slate-50 p-6">
-          <p className="text-xs uppercase tracking-wider text-slate-400">Valor Recebido</p>
-          <p className="mt-2 text-3xl font-semibold text-klasse-gold">
-            {formatKz(valor)}
-          </p>
-        </div>
-
-        <div className="mt-12 space-y-2 text-slate-500">
-          <p>
-            Confirmamos o recebimento do valor acima referente à mensalidade do aluno.
-          </p>
-          <p className="text-xs">
-            Este recibo possui autenticidade verificada via QR Code.
-          </p>
-        </div>
-
-        <div className="mt-16 flex items-center justify-between text-xs text-slate-400">
-          <span>Emitido eletronicamente pela secretaria.</span>
-          {urlValidacao ? <span>{urlValidacao}</span> : <span>URL não configurada</span>}
-        </div>
+    <div className="hidden print:block">
+      <div className="w-full max-w-none bg-white text-slate-900">
+        <ReciboPagamentoCompacto
+          escolaNome={escolaNome}
+          alunoNome={alunoNome}
+          alunoBi={alunoBi}
+          classeNome={classeNome}
+          cursoNome={cursoNome}
+          turmaNome={turmaNome}
+          referencia={referencia}
+          metodo={metodo}
+          valorPago={valor}
+          dataPagamento={dataFormatada}
+          numero={numero}
+          publicId={publicId}
+          urlValidacao={urlValidacao}
+          logoUrl={logoUrl}
+          emitidoEm={emitidoEm ?? dataFormatada}
+        />
       </div>
     </div>
   );
@@ -140,7 +123,7 @@ export function ReciboPrintButton({
         url_validacao: json.url_validacao ?? null,
       });
       setPrintRequested(true);
-    } catch (err) {
+    } catch (_err) {
       error("Erro na emissão", "Não conseguimos gerar o recibo para impressão no momento. Por favor, tente novamente.");
     } finally {
       setLoading(false);
@@ -166,6 +149,7 @@ export function ReciboPrintButton({
           valor={valor}
           data={dataPagamento}
           urlValidacao={recibo.url_validacao}
+          publicId={recibo.doc_id}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/financeiro/ReciboPagamentoCompacto.tsx
+++ b/apps/web/src/components/financeiro/ReciboPagamentoCompacto.tsx
@@ -1,0 +1,157 @@
+import QRCode from "react-qr-code";
+
+export type ReciboPagamentoCompactoProps = {
+  escolaNome: string;
+  alunoNome: string;
+  alunoBi: string;
+  classeNome: string;
+  cursoNome: string;
+  turmaNome: string;
+  referencia: string;
+  metodo: string;
+  valorPago: number;
+  dataPagamento: string;
+  numero: string | null;
+  publicId: string;
+  urlValidacao: string | null;
+  logoUrl: string | null;
+  emitidoEm?: string | null;
+};
+
+type CompactFieldProps = {
+  label: string;
+  value: string;
+  clamp?: "one" | "two";
+  className?: string;
+};
+
+const formatMoney = (value: number) =>
+  new Intl.NumberFormat("pt-AO", {
+    style: "currency",
+    currency: "AOA",
+    minimumFractionDigits: 2,
+  }).format(value || 0);
+
+function CompactField({ label, value, clamp = "one", className = "" }: CompactFieldProps) {
+  const clampClass = clamp === "two" ? "line-clamp-2" : "truncate";
+
+  return (
+    <div className={`min-w-0 space-y-1 ${className}`}>
+      <p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`${clampClass} text-xs font-semibold leading-snug text-slate-900`} title={value}>
+        {value || "—"}
+      </p>
+    </div>
+  );
+}
+
+export default function ReciboPagamentoCompacto({
+  escolaNome,
+  alunoNome,
+  alunoBi,
+  classeNome,
+  cursoNome,
+  turmaNome,
+  referencia,
+  metodo,
+  valorPago,
+  dataPagamento,
+  numero,
+  publicId,
+  urlValidacao,
+  logoUrl,
+  emitidoEm,
+}: ReciboPagamentoCompactoProps) {
+  const classeCurso = `${classeNome}${cursoNome ? ` - ${cursoNome}` : ""}`;
+  const emissao = emitidoEm || "—";
+
+  return (
+    <div className="space-y-3 bg-white font-sans text-slate-900">
+      <header className="grid grid-cols-[auto_1fr_auto] items-start gap-3 border-b border-slate-200 pb-3">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={logoUrl ?? "/insignia_med.png"}
+          alt="Insígnia da República de Angola"
+          className="h-12 w-12 shrink-0 object-contain"
+        />
+
+        <div className="min-w-0 space-y-1">
+          <p className="line-clamp-2 text-[10px] font-bold uppercase leading-snug tracking-[0.14em] text-slate-500" title={escolaNome}>
+            {escolaNome}
+          </p>
+          <h1 className="text-lg font-bold uppercase tracking-tight text-slate-900">Recibo de Pagamento</h1>
+        </div>
+
+        <div className="min-w-[92px] max-w-[150px] space-y-1 text-right text-[10px] leading-tight text-slate-500">
+          <p className="font-bold uppercase tracking-wide text-slate-400">Nº / Emitido</p>
+          <p className="truncate font-semibold text-slate-900" title={numero || "Sem número"}>
+            {numero ? `Nº ${numero}` : "Sem número"}
+          </p>
+          <p className="line-clamp-1 font-medium text-slate-600" title={emissao}>
+            {emissao}
+          </p>
+        </div>
+      </header>
+
+      <section className="rounded-xl border border-slate-200 bg-white">
+        <div className="grid grid-cols-3 gap-3 border-b border-slate-200 p-3">
+          <CompactField label="Aluno" value={alunoNome} clamp="two" className="col-span-3 sm:col-span-1" />
+          <CompactField label="Classe / Curso" value={classeCurso} />
+          <CompactField label="Turma" value={turmaNome} />
+          <CompactField label="NIF / BI" value={alunoBi} />
+          <CompactField label="Referência" value={referencia} />
+          <CompactField label="Método" value={metodo} />
+        </div>
+
+        <div className="grid grid-cols-[1fr_auto] items-center gap-3 border-b border-slate-200 p-3">
+          <div className="min-w-0">
+            <p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Valor Pago</p>
+            <p className="truncate text-xl font-bold leading-tight text-klasse-gold" title={formatMoney(valorPago)}>
+              {formatMoney(valorPago)}
+            </p>
+          </div>
+          <div className="min-w-[120px] text-right">
+            <p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Data Pagamento</p>
+            <p className="truncate text-xs font-semibold text-slate-900" title={dataPagamento}>
+              {dataPagamento}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4 p-3">
+          <section className="min-w-0 space-y-2">
+            <p className="text-[9px] font-bold uppercase tracking-wide text-slate-500">Validação</p>
+            {urlValidacao ? (
+              <div className="flex min-w-0 items-center gap-3">
+                <QRCode value={urlValidacao} size={60} />
+                <div className="min-w-0 space-y-1">
+                  <p className="line-clamp-2 max-w-[170px] text-[8px] leading-tight text-slate-500">
+                    Valide este recibo no portal oficial através do QR Code.
+                  </p>
+                  <p className="max-w-[170px] truncate font-mono text-[8px] text-slate-500" title={publicId}>
+                    ID: {publicId || "—"}
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="flex min-w-0 items-center gap-3">
+                <div className="flex h-[60px] w-[60px] shrink-0 items-center justify-center rounded-xl border border-dashed border-slate-200 text-center text-[8px] text-slate-500">
+                  QR indisponível
+                </div>
+                <p className="max-w-[170px] truncate font-mono text-[8px] text-slate-500" title={publicId}>
+                  ID: {publicId || "—"}
+                </p>
+              </div>
+            )}
+          </section>
+
+          <section className="flex min-w-0 flex-col justify-end text-center">
+            <div className="border-b border-slate-200 pb-1" />
+            <p className="mt-2 text-[10px] font-bold uppercase text-slate-900">A Secretaria</p>
+            <p className="line-clamp-1 text-[8px] italic text-slate-500">Documento processado por computador</p>
+          </section>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Replace duplicated, large receipt markup with a reusable compact component to standardize printed receipts and reduce duplication. 
- Improve snapshot value handling and typing to avoid runtime issues when rendering document snapshots.

### Description
- Add a new reusable component `ReciboPagamentoCompacto` to render a compact, print-friendly payment receipt and include QR validation, IDs and styling.  
- Refactor `apps/web/src/app/secretaria/documentos/[docId]/recibo/print/page.tsx` to use `ReciboPagamentoCompacto`, introduce `getSnapshotString` for safer snapshot reads, and tighten snapshot typing.  
- Update `ReciboImprimivel` to render the compact component for the print view and pass additional metadata (`publicId`, `emitidoEm`, `alunoBi`, `classeNome`, `cursoNome`, `turmaNome`, `referencia`, `metodo`, `numero`, `logoUrl`).  
- Adjust print styles in `print.module.css` to support the compact sheet layout and improve print margins and overflow handling.

### Testing
- Ran TypeScript type checking, the web build, and the existing test suite against the modified files; all checks passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0af25be5b0832682c41aa0e1c9726a)