### PR TITLE
Fix school logo on receipt printouts

### DIFF
--- a/apps/web/src/app/api/escolas/[id]/nome/route.ts
+++ b/apps/web/src/app/api/escolas/[id]/nome/route.ts
@@ -13,6 +13,7 @@ type NomePayload = {
   nome?: string | null;
   plano?: string | null;
   status?: string | null;
+  logo_url?: string | null;
   error?: string;
 };
 
@@ -71,9 +72,9 @@ export async function GET(_req: NextRequest, context: { params: Promise<{ id: st
       (async () => {
         const queryStart = shouldLog ? performance.now() : 0;
         const { data, error } = await supabase
-          .from("vw_escola_info" as any)
-          .select("nome, plano_atual, status")
-          .eq("escola_id", targetEscolaId)
+          .from("escolas")
+          .select("nome, plano_atual, status, logo_url")
+          .eq("id", targetEscolaId)
           .maybeSingle();
         if (shouldLog) log('query', performance.now() - queryStart);
         if (error) {
@@ -85,6 +86,7 @@ export async function GET(_req: NextRequest, context: { params: Promise<{ id: st
           nome: row?.nome ?? null,
           plano: row?.plano_atual ? parsePlanTier(row.plano_atual) : null,
           status: row?.status ?? null,
+          logo_url: row?.logo_url ?? null,
         } satisfies NomePayload;
       })();
 

--- a/apps/web/src/app/escola/[id]/(portal)/financeiro/page.tsx
+++ b/apps/web/src/app/escola/[id]/(portal)/financeiro/page.tsx
@@ -155,6 +155,7 @@ export default async function FinanceiroDashboardPage({
   let alunoNome = "";
   let financeNotifications: Notification[] = [];
   let escolaNome = "Escola";
+  let escolaLogoUrl: string | null = null;
   let anoLetivo = new Date().getFullYear();
 
   if (aluno) {
@@ -186,7 +187,7 @@ export default async function FinanceiroDashboardPage({
         .maybeSingle(),
       supabase
         .from("escolas")
-        .select("nome")
+        .select("nome, logo_url")
         .eq("id", escolaId)
         .maybeSingle(),
       supabase
@@ -201,6 +202,7 @@ export default async function FinanceiroDashboardPage({
 
     if (anoAtivoRes.data?.ano) anoLetivo = Number(anoAtivoRes.data.ano);
     escolaNome = escolaRes.data?.nome ?? escolaNome;
+    escolaLogoUrl = escolaRes.data?.logo_url ?? null;
     financeNotifications = (notificationsRes.data as Notification[]) || [];
   }
 
@@ -457,6 +459,7 @@ export default async function FinanceiroDashboardPage({
                                   alunoNome={alunoNome}
                                   valor={mens.valor_pago_total ?? mens.valor_previsto ?? mens.valor ?? 0}
                                   dataPagamento={mens.data_pagamento_efetiva ?? new Date().toISOString()}
+                                  logoUrl={escolaLogoUrl}
                                 />
                                 <EstornarMensalidadeButton mensalidadeId={mens.id} />
                               </div>

--- a/apps/web/src/app/secretaria/documentos/_print/getDocumento.ts
+++ b/apps/web/src/app/secretaria/documentos/_print/getDocumento.ts
@@ -65,6 +65,7 @@ export async function getDocumentoEmitido(docId: string) {
     .maybeSingle();
   const escolaInfoRow = escolaInfo as { nome?: string | null } | null;
   const escolaRow = escola as { validation_base_url?: string | null; logo_url?: string | null } | null;
+  const rawLogoUrl = escolaRow?.logo_url?.trim() || null;
   const rawSnapshot = doc.dados_snapshot;
   const snapshot =
     rawSnapshot && typeof rawSnapshot === "object" && !Array.isArray(rawSnapshot)
@@ -88,6 +89,6 @@ export async function getDocumentoEmitido(docId: string) {
     },
     escolaNome: escolaInfoRow?.nome ?? "Escola",
     validationBaseUrl: escolaRow?.validation_base_url ?? null,
-    logoUrl: escolaRow?.logo_url ?? null,
+    logoUrl: rawLogoUrl,
   } as const;
 }

--- a/apps/web/src/components/financeiro/ReciboImprimivel.tsx
+++ b/apps/web/src/components/financeiro/ReciboImprimivel.tsx
@@ -84,12 +84,14 @@ export function ReciboPrintButton({
   alunoNome,
   valor,
   dataPagamento,
+  logoUrl = null,
 }: {
   mensalidadeId: string;
   escolaNome: string;
   alunoNome: string;
   valor: number;
   dataPagamento: string;
+  logoUrl?: string | null;
 }) {
   const { error } = useToast();
   const [status, setStatus] = useState<"idle" | "loading" | "preparing" | "success">("idle");
@@ -222,6 +224,7 @@ export function ReciboPrintButton({
           data={dataPagamento}
           urlValidacao={recibo.url_validacao}
           publicId={recibo.doc_id}
+          logoUrl={logoUrl}
         />
       ) : null}
     </div>

--- a/apps/web/src/components/financeiro/ReciboPagamentoCompacto.tsx
+++ b/apps/web/src/components/financeiro/ReciboPagamentoCompacto.tsx
@@ -64,14 +64,15 @@ export default function ReciboPagamentoCompacto({
 }: ReciboPagamentoCompactoProps) {
   const classeCurso = `${classeNome}${cursoNome ? ` - ${cursoNome}` : ""}`;
   const emissao = emitidoEm || "—";
+  const effectiveLogoUrl = logoUrl?.trim() ? logoUrl.trim() : "/insignia_med.png";
 
   return (
     <div className="space-y-3 bg-white font-sans text-slate-900">
       <header className="grid grid-cols-[auto_1fr_auto] items-start gap-3 border-b border-slate-200 pb-3">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
-          src={logoUrl ?? "/insignia_med.png"}
-          alt="Insígnia da República de Angola"
+          src={effectiveLogoUrl}
+          alt={logoUrl?.trim() ? `Logotipo de ${escolaNome}` : "Insígnia da República de Angola"}
           className="h-12 w-12 shrink-0 object-contain"
         />
 

--- a/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
+++ b/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
@@ -35,7 +35,7 @@ type MetodoDetalhes = {
   gateway_ref:   string;
 };
 
-type ReciboState = { url_validacao: string | null } | null;
+type ReciboState = { url_validacao: string | null; logo_url?: string | null } | null;
 
 export interface ModalPagamentoRapidoProps {
   escolaId?:    string | null;
@@ -522,6 +522,7 @@ export function ModalPagamentoRapido({
   const [concluido, setConcluido] = useState(false);
   const [recibo,    setRecibo]    = useState<ReciboState>(null);
   const [escolaNome, setEscolaNome] = useState<string | null>(null);
+  const [escolaLogoUrl, setEscolaLogoUrl] = useState<string | null>(null);
 
   const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
   const canEmitirRecibo = true;
@@ -568,7 +569,10 @@ export function ModalPagamentoRapido({
     if (!open || !escolaId) return;
     fetch(`/api/escolas/${escolaId}/nome`, { cache: "no-store" })
       .then(r => r.json())
-      .then(j => { if (j?.ok && j?.nome) setEscolaNome(j.nome); })
+      .then(j => {
+        if (j?.ok && j?.nome) setEscolaNome(j.nome);
+        if (j?.ok) setEscolaLogoUrl(j.logo_url ?? null);
+      })
       .catch(() => {});
   }, [escolaId, open]);
 
@@ -584,7 +588,7 @@ export function ModalPagamentoRapido({
     aluno, mensalidade, metodo, detalhes, valorPagoNum: valorNum,
     mesAno, trocoValido, canEmitirRecibo,
     onConcluido: () => setConcluido(true),
-    onRecibo:    setRecibo,
+    onRecibo:    (payload) => setRecibo(payload ? { ...payload, logo_url: escolaLogoUrl } : null),
     safeClose, onSuccess,
   });
 
@@ -798,6 +802,7 @@ export function ModalPagamentoRapido({
           valor={mensalidade?.valor ?? 0}
           data={new Date().toISOString()}
           urlValidacao={recibo.url_validacao}
+          logoUrl={recibo.logo_url ?? escolaLogoUrl}
         />
       )}
     </>

--- a/apps/web/src/components/secretaria/PagamentoModal.tsx
+++ b/apps/web/src/components/secretaria/PagamentoModal.tsx
@@ -17,6 +17,7 @@ type ReciboState = {
   aluno_nome: string;
   valor: number;
   data: string;
+  logo_url: string | null;
 } | null;
 
 type Props = {
@@ -53,6 +54,7 @@ export function PagamentoModal({
   const [showSuccess, setShowSuccess] = useState(false);
   const [recibo, setRecibo] = useState<ReciboState>(null);
   const [escolaNome, setEscolaNome] = useState<string | null>(null);
+  const [escolaLogoUrl, setEscolaLogoUrl] = useState<string | null>(null);
 
   const { success, error } = useToast();
   const { escolaId, escolaSlug } = useEscolaId();
@@ -68,7 +70,10 @@ export function PagamentoModal({
     if (!open || !escolaId) return;
     fetch(`/api/escolas/${escolaId}/nome`, { cache: "no-store" })
       .then(r => r.json())
-      .then(j => { if (j?.ok && j?.nome) setEscolaNome(j.nome); })
+      .then(j => {
+        if (j?.ok && j?.nome) setEscolaNome(j.nome);
+        if (j?.ok) setEscolaLogoUrl(j.logo_url ?? null);
+      })
       .catch(() => {});
   }, [escolaId, open]);
 
@@ -149,7 +154,8 @@ export function PagamentoModal({
         escola_nome: escolaNome || "Escola",
         aluno_nome: alunoNome || "Aluno",
         valor: totalKz,
-        data: new Date().toISOString()
+        data: new Date().toISOString(),
+        logo_url: escolaLogoUrl,
       });
     }
 
@@ -356,6 +362,7 @@ export function PagamentoModal({
           valor={recibo.valor}
           data={recibo.data}
           urlValidacao={recibo.url_validacao}
+          logoUrl={recibo.logo_url}
         />
       )}
     </>

--- a/apps/web/src/lib/escolaInfoClient.ts
+++ b/apps/web/src/lib/escolaInfoClient.ts
@@ -4,13 +4,14 @@ export type EscolaInfo = {
   nome: string | null;
   plano: string | null;
   status: string | null;
+  logo_url: string | null;
 };
 
 const inFlight = new Map<string, Promise<EscolaInfo>>();
 
 export async function fetchEscolaInfo(escolaIdOrSlug: string): Promise<EscolaInfo> {
   const key = String(escolaIdOrSlug || "").trim();
-  if (!key) return { nome: null, plano: null, status: null };
+  if (!key) return { nome: null, plano: null, status: null, logo_url: null };
 
   const cacheKey = `escolas:info:${key}`;
   if (typeof sessionStorage !== "undefined") {
@@ -22,6 +23,7 @@ export async function fetchEscolaInfo(escolaIdOrSlug: string): Promise<EscolaInf
           nome: parsed?.nome ?? null,
           plano: parsed?.plano ?? null,
           status: parsed?.status ?? null,
+          logo_url: parsed?.logo_url ?? null,
         };
       } catch {
         // ignore bad cache payload
@@ -41,6 +43,7 @@ export async function fetchEscolaInfo(escolaIdOrSlug: string): Promise<EscolaInf
         nome: res.ok && json?.ok ? (json?.nome ?? null) : null,
         plano: res.ok && json?.ok ? (json?.plano ?? null) : null,
         status: res.ok && json?.ok ? (json?.status ?? null) : null,
+        logo_url: res.ok && json?.ok ? (json?.logo_url ?? null) : null,
       };
 
       if (typeof sessionStorage !== "undefined") {


### PR DESCRIPTION
### Motivation
- Ensure receipts and other printable documents use the custom logo uploaded by the school admin instead of falling back to the default insignia.
- Make the school logo available to client-side flows that prepare/print receipts so the visual identity is consistent across modal and dedicated print pages.

### Description
- Return `logo_url` from the authenticated school info endpoint (`/api/escolas/[id]/nome`) and include it in the client-side `fetch` contract. (updated `apps/web/src/app/api/escolas/[id]/nome/route.ts` and `apps/web/src/lib/escolaInfoClient.ts`).
- Propagate the school `logoUrl` into receipt print flows and buttons by adding an optional `logoUrl` prop to `ReciboPrintButton`/`ReciboImprimivel` and passing it from the finance dashboard and secretary modals. (changes in `apps/web/src/components/financeiro/ReciboImprimivel.tsx`, `ReciboPagamentoCompacto.tsx`, dashboard page and secretary modals).
- Normalize logo handling so blank/whitespace logos are treated as absent and fall back to `/insignia_med.png`, and ensure document print loader uses a trimmed `logo_url`. (changes in `apps/web/src/app/secretaria/documentos/_print/getDocumento.ts` and `ReciboPagamentoCompacto.tsx`).
- Wire the modal and quick-pay flows to fetch school info (including `logo_url`) and stash the logo into the receipt payload so printed receipts from those flows show the uploaded logo. (changes in `apps/web/src/components/secretaria/PagamentoModal.tsx` and `ModalPagamentoRapido.tsx`).

### Testing
- Ran TypeScript checks with `pnpm -C apps/web typecheck`, which completed successfully (no type errors).
- Ran ESLint over the modified files with `pnpm -C apps/web exec eslint ...` which passed (the run showed existing non-blocking warnings in unrelated areas but no new errors).
- Performed focused file inspection of the modified print flows to verify `logo_url` is fetched, trimmed, propagated, and that the default fallback is used when appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b589be67483269e08e5fb989e5df8)