### PR TITLE
Track receipt prints and enable reprint actions for mensalidades

### DIFF
--- a/apps/web/src/app/api/aluno/financeiro/route.ts
+++ b/apps/web/src/app/api/aluno/financeiro/route.ts
@@ -58,6 +58,26 @@ export async function GET(request: Request) {
 
     if (mensError) throw mensError;
 
+    const mensalidadeIds = (mensalidades ?? []).map((m) => m.id);
+    const reciboByMensalidadeId = new Map<string, string>();
+
+    if (mensalidadeIds.length) {
+      const { data: recibos } = await supabase
+        .from("documentos_emitidos")
+        .select("id, origem_id, created_at")
+        .eq("tipo", "recibo")
+        .eq("origem_tipo", "financeiro_recibos_emitir")
+        .in("origem_id", mensalidadeIds)
+        .order("created_at", { ascending: false });
+
+      for (const recibo of recibos ?? []) {
+        const origemId = String(recibo.origem_id ?? "");
+        if (origemId && !reciboByMensalidadeId.has(origemId)) {
+          reciboByMensalidadeId.set(origemId, recibo.id);
+        }
+      }
+    }
+
     // 2. Buscar Movimentos do Ledger (SSOT)
     const { data: movimentos, error: ledgerError } = await supabase
       .from("financeiro_ledger")
@@ -94,7 +114,8 @@ export async function GET(request: Request) {
         valor: Number(m.valor_previsto ?? m.valor ?? 0), 
         vencimento, 
         status, 
-        pago_em: m.data_pagamento_efetiva 
+        pago_em: m.data_pagamento_efetiva,
+        recibo_id: reciboByMensalidadeId.get(m.id) ?? null,
       };
     });
 

--- a/apps/web/src/app/secretaria/documentos/[docId]/recibo/print/page.tsx
+++ b/apps/web/src/app/secretaria/documentos/[docId]/recibo/print/page.tsx
@@ -18,7 +18,7 @@ export default async function ReciboPrintPage({
   params: Promise<{ docId: string }>;
 }) {
   const { docId } = await params;
-  const data = await getDocumentoEmitido(docId);
+  const data = await getDocumentoEmitido(docId, { incrementPrintCount: true });
 
   if ("error" in data) return <div className="p-8">{data.error}</div>;
 
@@ -91,10 +91,19 @@ export default async function ReciboPrintPage({
   const classeNome = getSnapshotString(snapshot.classe_nome, fallbackClasseNome ?? "—");
   const cursoNome = getSnapshotString(snapshot.curso_nome, fallbackCursoNome ?? "");
 
+  const printCount = Number(doc.print_count ?? 0);
+  const showSecondVia = printCount >= 2;
+  const currentDateLabel = new Date().toLocaleDateString("pt-PT");
+
   return (
     <div className={`min-h-screen ${styles.printRoot} text-slate-900`}>
       <PrintTrigger />
       <div className={`${styles.sheet} ${styles.receiptCompactSheet} shadow-lg`}>
+        {showSecondVia ? (
+          <p className="mb-2 text-right text-[10px] text-slate-400">
+            2ª Via — Emitido em {currentDateLabel}
+          </p>
+        ) : null}
         <ReciboPagamentoDuasVias
           escolaNome={escolaNome}
           alunoNome={alunoNome}

--- a/apps/web/src/app/secretaria/documentos/_print/getDocumento.ts
+++ b/apps/web/src/app/secretaria/documentos/_print/getDocumento.ts
@@ -25,6 +25,8 @@ export type DocumentoSnapshot = {
 };
 
 export type DocumentoEmitido = {
+  print_count?: number | null;
+  last_printed_at?: string | null;
   id: string;
   public_id: string;
   escola_id: string;
@@ -35,7 +37,7 @@ export type DocumentoEmitido = {
   dados_snapshot: DocumentoSnapshot;
 };
 
-export async function getDocumentoEmitido(docId: string) {
+export async function getDocumentoEmitido(docId: string, opts?: { incrementPrintCount?: boolean }) {
   const supabase = await supabaseServerTyped();
   const { data: auth } = await supabase.auth.getUser();
   const user = auth?.user;
@@ -46,7 +48,7 @@ export async function getDocumentoEmitido(docId: string) {
 
   const { data: doc, error } = await supabase
     .from("documentos_emitidos")
-    .select("id, public_id, escola_id, aluno_id, tipo, created_at, dados_snapshot, numero_sequencial, hash_validacao")
+    .select("id, public_id, escola_id, aluno_id, tipo, created_at, dados_snapshot, numero_sequencial, hash_validacao, print_count, last_printed_at")
     .eq("id", docId)
     .single();
 
@@ -57,6 +59,24 @@ export async function getDocumentoEmitido(docId: string) {
   const escolaId = await resolveEscolaIdForUser(supabase as any, user.id, doc.escola_id as string);
   if (!escolaId || escolaId !== doc.escola_id) {
     return { error: "Sem permissão" } as const;
+  }
+
+
+  let printMeta: { print_count: number; last_printed_at: string | null } | null = null;
+  if (opts?.incrementPrintCount && doc.tipo === "recibo") {
+    const { data: printData } = await (supabase as any).rpc("increment_documento_print", {
+      p_doc_id: doc.id,
+      p_actor_id: user.id,
+      p_actor_email: user.email ?? null,
+    });
+
+    const printRow = Array.isArray(printData) ? printData[0] : printData;
+    if (printRow && typeof printRow.print_count === "number") {
+      printMeta = {
+        print_count: printRow.print_count,
+        last_printed_at: typeof printRow.last_printed_at === "string" ? printRow.last_printed_at : null,
+      };
+    }
   }
 
   const rawSnapshot = doc.dados_snapshot;
@@ -117,6 +137,8 @@ export async function getDocumentoEmitido(docId: string) {
       tipo: doc.tipo,
       created_at: doc.created_at,
       hash_validacao: doc.hash_validacao ?? null,
+      print_count: printMeta?.print_count ?? doc.print_count ?? 0,
+      last_printed_at: printMeta?.last_printed_at ?? doc.last_printed_at ?? null,
       dados_snapshot: {
         ...snapshot,
         hash_validacao: snapshot.hash_validacao ?? doc.hash_validacao ?? null,

--- a/apps/web/src/components/aluno/AlunoPerfilPage.tsx
+++ b/apps/web/src/components/aluno/AlunoPerfilPage.tsx
@@ -32,7 +32,7 @@ export default async function AlunoPerfilPage({ escolaId, alunoId, role }: { esc
         <DossierTabs
           aluno={aluno}
           slotPerfil={<DossierPerfilSection aluno={aluno} />}
-          slotFinanceiro={<DossierFinanceiroSection aluno={aluno} />}
+          slotFinanceiro={<DossierFinanceiroSection aluno={aluno} role={role} />}
           slotHistorico={<DossierHistoricoSection aluno={aluno} alunoId={alunoId} role={role} escolaId={resolvedEscolaId} />}
           slotDocumentos={<DossierDocumentosSection alunoId={alunoId} />}
         />

--- a/apps/web/src/components/aluno/DossierSeccoes.tsx
+++ b/apps/web/src/components/aluno/DossierSeccoes.tsx
@@ -1,11 +1,14 @@
+"use client";
+
 import Link from "next/link";
-import { CheckCircle2, FileText, TrendingDown, Wallet } from "lucide-react";
+import { CheckCircle2, FileText, TrendingDown, Wallet, Printer } from "lucide-react";
 import { StatusPill } from "@/components/ui/StatusPill";
 import { formatDate, formatKwanza, monthName } from "@/lib/formatters";
 import type { AlunoNormalizado, DossierMensalidade } from "@/lib/aluno/types";
 import type { DossierRole } from "@/components/aluno/DossierAcoes";
 import { DossierHistoricoTimelineSection } from "@/components/aluno/DossierHistoricoTimelineSection";
 import { QuickEditField } from "@/components/aluno/QuickEditField";
+import { useToast } from "@/components/feedback/FeedbackSystem";
 
 export function DossierPerfilSection({ aluno }: { aluno: AlunoNormalizado }) {
   const p = aluno.perfil;
@@ -105,7 +108,15 @@ export function DossierPerfilSection({ aluno }: { aluno: AlunoNormalizado }) {
   );
 }
 
-function MensalidadeRow({ m }: { m: DossierMensalidade }) {
+function MensalidadeRow({
+  m,
+  canReprint,
+  onMissingRecibo,
+}: {
+  m: DossierMensalidade;
+  canReprint: boolean;
+  onMissingRecibo: () => void;
+}) {
   const vencimentoLabel = m.vencimento ? formatDate(m.vencimento) : null;
   const vencimentoDate = m.vencimento ? new Date(m.vencimento) : null;
   const today = new Date();
@@ -120,7 +131,7 @@ function MensalidadeRow({ m }: { m: DossierMensalidade }) {
     : null;
 
   return (
-      <div className="grid gap-3 rounded-xl border border-slate-200 p-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto] md:items-center">
+      <div className="grid gap-3 rounded-xl border border-slate-200 p-3 md:grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] md:items-center">
       <div>
         <p className="font-semibold text-slate-900 capitalize">
           {monthName(m.mes)} {m.ano}
@@ -143,11 +154,37 @@ function MensalidadeRow({ m }: { m: DossierMensalidade }) {
           </p>
         )}
       </div>
+      <div className="md:justify-self-end">
+        {m.status === "pago" ? (
+          <button
+            type="button"
+            disabled={!canReprint}
+            title={
+              !canReprint
+                ? "Permissão restrita: secretaria/financeiro"
+                : m.recibo_id
+                  ? "Reimprimir recibo"
+                  : "Recibo indisponível"
+            }
+            onClick={() => {
+              if (!canReprint) return;
+              if (!m.recibo_id) return onMissingRecibo();
+              window.open(`/secretaria/documentos/${m.recibo_id}/recibo/print`, "_blank", "noopener,noreferrer");
+            }}
+            className="group inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-600 shadow-sm transition-colors hover:text-klasse-gold disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Printer className="h-4 w-4 text-slate-400 transition-colors group-hover:text-klasse-gold" />
+            Reimprimir
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }
 
-export function DossierFinanceiroSection({ aluno }: { aluno: AlunoNormalizado }) {
+export function DossierFinanceiroSection({ aluno, role }: { aluno: AlunoNormalizado; role: DossierRole }) {
+  const { error } = useToast();
+  const canReprint = role === "secretaria";
   const f = aluno.financeiro;
   const atrasado = f.situacao === "inadimplente";
   return (
@@ -190,13 +227,21 @@ export function DossierFinanceiroSection({ aluno }: { aluno: AlunoNormalizado })
         </p>
         {f.mensalidades.length ? (
           <div className="space-y-2">
-            <div className="hidden md:grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto] text-[10px] font-bold uppercase tracking-widest text-slate-400 px-3">
+            <div className="hidden md:grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_auto_auto] text-[10px] font-bold uppercase tracking-widest text-slate-400 px-3">
               <span>Mês</span>
               <span className="text-right">Valor</span>
               <span className="text-right">Estado</span>
+              <span className="text-right">Ação</span>
             </div>
             {f.mensalidades.map((m) => (
-              <MensalidadeRow key={m.id} m={m} />
+              <MensalidadeRow
+                key={m.id}
+                m={m}
+                canReprint={canReprint}
+                onMissingRecibo={() =>
+                  error("Recibo indisponível", "Não existe documento emitido vinculado para esta mensalidade.")
+                }
+              />
             ))}
           </div>
         ) : (

--- a/apps/web/src/components/aluno/tabs/TabFinanceiro.tsx
+++ b/apps/web/src/components/aluno/tabs/TabFinanceiro.tsx
@@ -2,12 +2,18 @@
 
 import { useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Check, Filter, Wallet, ArrowUpCircle, ArrowDownCircle, Info } from "lucide-react";
+import { Check, Filter, Wallet, ArrowUpCircle, ArrowDownCircle, Info, Printer } from "lucide-react";
 import { Button } from "@/components/ui/Button";
 import { PaymentDrawer } from "@/components/aluno/financeiro-portal/PaymentDrawer";
 import { usePortalSWR } from "@/components/aluno/usePortalSWR";
 
-type Item = { id: string; competencia: string; valor: number; status: "pago" | "pendente" | "atrasado" | "em_verificacao" };
+type Item = {
+  id: string;
+  competencia: string;
+  valor: number;
+  status: "pago" | "pendente" | "atrasado" | "em_verificacao";
+  recibo_id?: string | null;
+};
 type Movimento = {
   id: string;
   tipo: "debito" | "credito";
@@ -120,6 +126,11 @@ export function TabFinanceiro() {
     setRefreshing(false);
   };
 
+  const handleReprintRecibo = (reciboId: string | null | undefined) => {
+    if (!reciboId) return;
+    window.open(`/secretaria/documentos/${reciboId}/recibo/print`, "_blank", "noopener,noreferrer");
+  };
+
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -222,9 +233,21 @@ export function TabFinanceiro() {
                     <p className="text-xs text-slate-500">{money.format(item.valor)}</p>
                   </div>
                   {item.status === "pago" ? (
-                    <span className="inline-flex items-center gap-1 rounded-full bg-klasse-green-50 px-3 py-1 text-xs font-medium text-klasse-green-700">
-                      <Check className="h-4 w-4" /> Pago
-                    </span>
+                    <div className="flex items-center gap-2">
+                      <span className="inline-flex items-center gap-1 rounded-full bg-klasse-green-50 px-3 py-1 text-xs font-medium text-klasse-green-700">
+                        <Check className="h-4 w-4" /> Pago
+                      </span>
+                      <button
+                        type="button"
+                        title={item.recibo_id ? "Reimprimir recibo" : "Recibo indisponível"}
+                        disabled={!item.recibo_id}
+                        onClick={() => handleReprintRecibo(item.recibo_id)}
+                        className="group inline-flex min-h-10 items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 text-xs font-semibold text-slate-600 shadow-sm transition-colors hover:text-klasse-gold disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-slate-600"
+                      >
+                        <Printer className="h-4 w-4 text-slate-400 transition-colors group-hover:text-klasse-gold" />
+                        Reimprimir
+                      </button>
+                    </div>
                   ) : item.status === "em_verificacao" ? (
                     <span className="rounded-full bg-klasse-gold-100 px-3 py-1 text-xs font-medium text-klasse-gold-700">
                       Em Verificação

--- a/apps/web/src/lib/aluno/normalize.ts
+++ b/apps/web/src/lib/aluno/normalize.ts
@@ -45,6 +45,7 @@ function normalizarMensalidade(m: RawDossierMensalidade): DossierMensalidade {
     saldo,
     vencimento,
     pago_em: m.pago_em ?? null,
+    recibo_id: m.recibo_id ?? null,
     atrasada,
   };
 }

--- a/apps/web/src/lib/aluno/types.ts
+++ b/apps/web/src/lib/aluno/types.ts
@@ -45,6 +45,7 @@ export type RawDossierMensalidade = {
   vencimento?: string | null;
   data_vencimento?: string | null;
   pago_em?: string | null;
+  recibo_id?: string | null;
 };
 
 export type RawDossierFinanceiro = {
@@ -100,6 +101,7 @@ export type DossierMensalidade = {
   saldo: number;
   vencimento: string | null;
   pago_em: string | null;
+  recibo_id: string | null;
   atrasada: boolean;
 };
 

--- a/supabase/migrations/20270521090000_documentos_emitidos_print_tracking.sql
+++ b/supabase/migrations/20270521090000_documentos_emitidos_print_tracking.sql
@@ -1,0 +1,64 @@
+BEGIN;
+
+ALTER TABLE public.documentos_emitidos
+  ADD COLUMN IF NOT EXISTS print_count integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_printed_at timestamptz NULL;
+
+CREATE OR REPLACE FUNCTION public.increment_documento_print(
+  p_doc_id uuid,
+  p_actor_id uuid DEFAULT NULL,
+  p_actor_email text DEFAULT NULL
+)
+RETURNS TABLE (print_count integer, last_printed_at timestamptz)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_doc public.documentos_emitidos%ROWTYPE;
+BEGIN
+  UPDATE public.documentos_emitidos
+  SET print_count = COALESCE(print_count, 0) + 1,
+      last_printed_at = NOW()
+  WHERE id = p_doc_id
+  RETURNING * INTO v_doc;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'DOCUMENTO_NOT_FOUND';
+  END IF;
+
+  INSERT INTO public.audit_logs (
+    escola_id,
+    user_id,
+    user_email,
+    portal,
+    acao,
+    tabela,
+    entity,
+    entity_id,
+    details
+  ) VALUES (
+    v_doc.escola_id,
+    p_actor_id,
+    p_actor_email,
+    'secretaria',
+    'documento_recibo_reprint',
+    'documentos_emitidos',
+    'documentos_emitidos',
+    v_doc.id,
+    jsonb_build_object(
+      'doc_id', v_doc.id,
+      'via', GREATEST(COALESCE(v_doc.print_count, 0), 1),
+      'print_count', COALESCE(v_doc.print_count, 0),
+      'timestamp', NOW()
+    )
+  );
+
+  RETURN QUERY SELECT v_doc.print_count, v_doc.last_printed_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.increment_documento_print(uuid, uuid, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.increment_documento_print(uuid, uuid, text) TO authenticated, service_role;
+
+COMMIT;


### PR DESCRIPTION
### Motivation

- Add server-side tracking for printed receipts so the system can record and surface reprint metadata and audit events. 
- Surface issued receipt IDs alongside mensalidades so the UI can offer direct reprint links. 
- Allow secretarial users to reprint receipts from student dossier and financeiro views while preventing unauthorized printing.

### Description

- Database migration adds `print_count` and `last_printed_at` to `documentos_emitidos` and implements `increment_documento_print(p_doc_id, p_actor_id, p_actor_email)` which updates counts and writes an `audit_logs` entry. 
- `getDocumentoEmitido` now accepts `opts?: { incrementPrintCount?: boolean }`, returns `print_count`/`last_printed_at`, and calls the RPC when printing receipts. 
- The financeiro route fetches `documentos_emitidos` for mensalidade IDs, builds a `reciboByMensalidadeId` map and includes `recibo_id` in the mensalidades payload. 
- Frontend changes add reprint UI: `TabFinanceiro` and `DossierSeccoes` display a `Reimprimir` button when a `recibo_id` exists, `ReciboPrintPage` calls `getDocumentoEmitido(docId, { incrementPrintCount: true })` and shows a "2ª Via" label when `print_count >= 2`; types and normalization were updated to include `recibo_id` and document print metadata; missing receipt attempts show a toast to the user.

### Testing

- Ran TypeScript checks and a production frontend build with `pnpm build` for the web app and the checks passed. 
- Ran the test suite with `pnpm test` and unit tests relevant to the financeiro/dossier flows passed. 
- Manual smoke checks of printing flow exercised `increment_documento_print` and verified `print_count` and `audit_logs` entries were created successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f0c929b008326af31b51fec4c9503)