### PR TITLE
Update WhatsApp contact to +244944811150 on landing and K12 pages

### DIFF
--- a/apps/landing/app/(site)/diagnostico/DiagnosisPageClient.tsx
+++ b/apps/landing/app/(site)/diagnostico/DiagnosisPageClient.tsx
@@ -449,7 +449,7 @@ export function DiagnosisPageClient() {
                     <p className="text-slate-400 text-lg font-medium leading-relaxed">
                         O KLASSE ajuda a automatizar cobranças, organizar matrículas e dar visibilidade real à direção. Agende uma conversa com nossos especialistas.
                     </p>
-                    <a href="https://wa.me/244933349106?text=Fiz%20o%20diagnóstico%20e%20quero%20conhecer%20o%20KLASSE" className="btn-p w-full justify-center bg-[#25D366] hover:bg-[#128C7E] py-7 text-2xl shadow-xl shadow-emerald-500/20 uppercase font-black">
+                    <a href="https://wa.me/244944811150?text=Fiz%20o%20diagnóstico%20e%20quero%20conhecer%20o%20KLASSE" className="btn-p w-full justify-center bg-[#25D366] hover:bg-[#128C7E] py-7 text-2xl shadow-xl shadow-emerald-500/20 uppercase font-black">
                         <MessageCircle size={32} />
                         Falar no WhatsApp
                     </a>

--- a/apps/landing/app/components/landing/LandingPage.tsx
+++ b/apps/landing/app/components/landing/LandingPage.tsx
@@ -22,7 +22,7 @@ export function LandingPage() {
 
   const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.klasse.ao'
   const scheduleUrl =
-    process.env.NEXT_PUBLIC_SCHEDULE_URL ?? 'https://wa.me/244933349106?text=Quero%20saber%20mais%20sobre%20o%20KLASSE'
+    process.env.NEXT_PUBLIC_SCHEDULE_URL ?? 'https://wa.me/244944811150?text=Quero%20saber%20mais%20sobre%20o%20KLASSE'
 
   const primaryCta = { label: hero.primaryCta, href: '#onboarding' }
   const diagnosticCta = { label: hero.diagnosticCta, href: '/diagnostico' }

--- a/apps/web/src/app/escola/suspensa/page.tsx
+++ b/apps/web/src/app/escola/suspensa/page.tsx
@@ -47,7 +47,7 @@ export default function EscolaSuspensaPage() {
             fullWidth 
             tone="green" 
             className="bg-[#1F6B3B] hover:bg-[#1F6B3B]/90 font-bold"
-            onClick={() => window.open('https://wa.me/244933349106', '_blank')}
+            onClick={() => window.open('https://wa.me/244944811150', '_blank')}
           >
             <MessageCircle className="w-4 h-4 mr-2" /> Falar com Suporte
           </Button>

--- a/apps/web/src/app/onboarding/acompanhar/[token]/page.tsx
+++ b/apps/web/src/app/onboarding/acompanhar/[token]/page.tsx
@@ -1571,7 +1571,7 @@ export default function OnboardingAcompanharPage({ params }: { params: Promise<{
                 <p className="text-[9px] font-bold uppercase tracking-wider text-zinc-400">Canais Rápidos de Suporte</p>
                 <div className="grid grid-cols-2 gap-2">
                   <a
-                    href="https://wa.me/244923000000?text=Olá,%20preciso%20de%20ajuda%20com%20o%20onboarding%20da%20minha%20escola."
+                    href="https://wa.me/244944811150?text=Olá,%20preciso%20de%20ajuda%20com%20o%20onboarding%20da%20minha%20escola."
                     target="_blank"
                     rel="noreferrer"
                     className="flex items-center justify-center gap-1.5 p-2 rounded-lg bg-emerald-50 hover:bg-emerald-100/70 border border-emerald-100 transition-all text-[11px] font-bold text-emerald-700 no-underline"

--- a/apps/web/src/app/super-admin/health/page.tsx
+++ b/apps/web/src/app/super-admin/health/page.tsx
@@ -133,7 +133,7 @@ export default function AdminHealthDashboard() {
           <div className="flex flex-wrap justify-between items-center gap-4">
             <div className="text-sm text-gray-600">
               <p>KLASSE Admin • Sistema de monitoramento para Angola</p>
-              <p className="mt-1">Para suporte emergencial: +244 900 000 000 (WhatsApp)</p>
+              <p className="mt-1">Para suporte emergencial: +244 944 811 150 (WhatsApp)</p>
             </div>
             
             <div className="flex gap-2">

--- a/apps/web/src/emails/BillingRenewalEmail.tsx
+++ b/apps/web/src/emails/BillingRenewalEmail.tsx
@@ -141,7 +141,7 @@ export const BillingRenewalEmail = ({
             <Text className="text-[#666666] text-[12px] leading-[24px] text-center mt-4">
               © 2026 Moxi Soluções. Todos os direitos reservados.
               <br />
-              Suporte em Luanda: <strong>+244 9XX XXX XXX</strong>
+              Suporte em Luanda: <strong>+244 944 811 150</strong>
             </Text>
           </Container>
         </Body>


### PR DESCRIPTION
### Motivation
- Standardize and update the public WhatsApp contact used for lead capture and K12 support to the new number (+244944811150) so incoming leads and support requests reach the correct channel. 

### Description
- Replaced fallback `NEXT_PUBLIC_SCHEDULE_URL` and landing onboarding WhatsApp link to use `https://wa.me/244944811150` in `apps/landing/app/components/landing/LandingPage.tsx`.
- Updated diagnostic CTA WhatsApp link to `https://wa.me/244944811150` in `apps/landing/app/(site)/diagnostico/DiagnosisPageClient.tsx`.
- Updated suspended-school support WhatsApp link to `https://wa.me/244944811150` in `apps/web/src/app/escola/suspensa/page.tsx`.
- Updated onboarding quick-support WhatsApp link to `https://wa.me/244944811150` in `apps/web/src/app/onboarding/acompanhar/[token]/page.tsx`.
- Replaced visible support phone in admin health dashboard and billing renewal email to `+244 944 811 150` in `apps/web/src/app/super-admin/health/page.tsx` and `apps/web/src/emails/BillingRenewalEmail.tsx`.
- No functional logic changes beyond URL/phone string updates and no schema or backend changes.

### Testing
- Ran type checks for landing with `pnpm -C apps/landing typecheck` and it completed successfully.
- Ran type checks for web with `pnpm -C apps/web typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5a0a36ed4083268f2292489985a0fb)