### PR TITLE
Stabilize payment modal toasts and harden audit triggers

### DIFF
--- a/agents/outputs/APPLY_DIFF_44f703e8-d1e7-4d87-8854-b2ba8c1358af.md
+++ b/agents/outputs/APPLY_DIFF_44f703e8-d1e7-4d87-8854-b2ba8c1358af.md
@@ -1,0 +1,44 @@
+# Apply diff — Stabilize payment modal toast callbacks
+run_id:    44f703e8-d1e7-4d87-8854-b2ba8c1358af
+timestamp: 2026-07-20T12:44:52Z
+
+## Diff
+```diff
+diff --git a/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx b/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
+index 32e11bb..dfbf9e0 100644
+--- a/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
++++ b/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
+@@ -868,7 +868,13 @@ export function ModalPagamentoRapido({
+ 
+   const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
+   const confirm = useConfirm();
+-  const { success, error: toastError } = useToast();
++  const { toast } = useToast();
++  const toastSuccess = useCallback((title: string, message?: string) => {
++    toast({ variant: "success", title, message });
++  }, [toast]);
++  const toastError = useCallback((title: string, message?: string) => {
++    toast({ variant: "error", title, message, duration: 6000 });
++  }, [toast]);
+   const availableMensalidades = useMemo(() => {
+     if (mensalidades?.length) return sortMensalidades(mensalidades);
+     return mensalidade ? [mensalidade] : [];
+@@ -988,7 +994,7 @@ export function ModalPagamentoRapido({
+       }
+ 
+       setReversedPagamentoIds((prev) => new Set([...prev, pagamento.pagamento_id]));
+-      success("Pagamento revertido", "A mensalidade foi recalculada e a reversão ficou auditada.");
++      toastSuccess("Pagamento revertido", "A mensalidade foi recalculada e a reversão ficou auditada.");
+       await loadPagamentosPagosAluno();
+       onSuccess?.();
+     } catch (err) {
+@@ -996,7 +1002,7 @@ export function ModalPagamentoRapido({
+     } finally {
+       setRevertingPagamentoId(null);
+     }
+-  }, [confirm, loadPagamentosPagosAluno, onSuccess, success, toastError]);
++  }, [confirm, loadPagamentosPagosAluno, onSuccess, toastError, toastSuccess]);
+ 
+   const toggleMensalidade = useCallback((id: string) => {
+     setSelectedIds((prev) => {
+```

--- a/agents/outputs/APPLY_DIFF_66158bf0-93f1-4a74-b6cf-28eaff1f1110.md
+++ b/agents/outputs/APPLY_DIFF_66158bf0-93f1-4a74-b6cf-28eaff1f1110.md
@@ -1,0 +1,114 @@
+# Apply diff — Audit DML trigger execution hardening
+run_id:    66158bf0-93f1-4a74-b6cf-28eaff1f1110
+timestamp: 2026-07-20T12:33:32Z
+
+## Diff
+```diff
+--- /dev/null	2026-07-20 11:54:43.275156285 +0000
++++ supabase/migrations/20270720121500_harden_audit_dml_trigger_execution.sql	2026-07-20 12:33:32.718896687 +0000
+@@ -0,0 +1,104 @@
++-- Harden audit DML trigger execution for authenticated business mutations.
++-- The trigger writes to audit_logs from mutations such as pagamentos; execute it as
++-- postgres-owned SECURITY DEFINER so audit capture is not blocked by the caller's
++-- RLS/table/function privileges.
++
++BEGIN;
++
++CREATE OR REPLACE FUNCTION public.audit_dml_trigger()
++RETURNS trigger
++LANGUAGE plpgsql
++SECURITY DEFINER
++SET search_path TO 'public', 'pg_temp'
++AS $$
++DECLARE
++  v_escola_id uuid;
++  v_entity_id text;
++  v_portal text;
++  v_action text;
++  v_entity text := tg_table_name;
++  v_before jsonb;
++  v_after jsonb;
++  ctx jsonb;
++  v_actor_id uuid;
++BEGIN
++  v_action := CASE tg_op
++    WHEN 'INSERT' THEN 'CREATE'
++    WHEN 'UPDATE' THEN 'UPDATE'
++    WHEN 'DELETE' THEN 'DELETE'
++  END;
++
++  v_portal := CASE tg_table_name
++    WHEN 'pagamentos' THEN 'financeiro'
++    WHEN 'matriculas' THEN 'secretaria'
++    ELSE 'outro'
++  END;
++
++  IF tg_op = 'INSERT' THEN
++    BEGIN v_escola_id := (new).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
++    BEGIN v_entity_id := (new).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
++    v_before := NULL;
++    v_after := public.audit_redact_jsonb(v_entity, to_jsonb(new));
++  ELSIF tg_op = 'UPDATE' THEN
++    BEGIN v_escola_id := (new).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
++    BEGIN v_entity_id := (new).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
++    v_before := public.audit_redact_jsonb(v_entity, to_jsonb(old));
++    v_after := public.audit_redact_jsonb(v_entity, to_jsonb(new));
++  ELSE
++    BEGIN v_escola_id := (old).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
++    BEGIN v_entity_id := (old).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
++    v_before := public.audit_redact_jsonb(v_entity, to_jsonb(old));
++    v_after := NULL;
++  END IF;
++
++  IF v_escola_id IS NULL THEN
++    IF tg_op = 'DELETE' THEN
++      RETURN old;
++    END IF;
++    RETURN new;
++  END IF;
++
++  ctx := COALESCE(public.audit_request_context(), '{}'::jsonb);
++  v_actor_id := public.safe_auth_uid();
++
++  INSERT INTO public.audit_logs (
++    escola_id,
++    actor_id,
++    actor_role,
++    user_id,
++    portal,
++    action,
++    entity,
++    entity_id,
++    details,
++    before,
++    after,
++    ip,
++    user_agent
++  ) VALUES (
++    v_escola_id,
++    v_actor_id,
++    ctx->>'actor_role',
++    v_actor_id,
++    v_portal,
++    v_action,
++    v_entity,
++    v_entity_id,
++    jsonb_build_object('op', tg_op),
++    v_before,
++    v_after,
++    ctx->>'ip',
++    ctx->>'user_agent'
++  );
++
++  IF tg_op = 'DELETE' THEN
++    RETURN old;
++  END IF;
++  RETURN new;
++END;
++$$;
++
++REVOKE ALL ON FUNCTION public.audit_dml_trigger() FROM PUBLIC;
++GRANT EXECUTE ON FUNCTION public.audit_dml_trigger() TO postgres, service_role;
++
++COMMIT;
+```

--- a/agents/outputs/APPLY_DIFF_a140af81-a1e7-4e21-bd77-b28a412ca979.md
+++ b/agents/outputs/APPLY_DIFF_a140af81-a1e7-4e21-bd77-b28a412ca979.md
@@ -1,0 +1,55 @@
+# Apply diff — Audit request context grants
+run_id:    a140af81-a1e7-4e21-bd77-b28a412ca979
+timestamp: 2026-07-20T11:58:44Z
+
+## Diff
+```diff
+--- /dev/null	2026-07-20 11:54:41.792194142 +0000
++++ supabase/migrations/20270720120000_fix_audit_request_context_execute.sql	2026-07-20 11:58:44.868751500 +0000
+@@ -0,0 +1,45 @@
++-- Fix balcão pagamentos failure caused by audit trigger invoking audit_request_context
++-- as the authenticated request role.
++
++BEGIN;
++
++CREATE OR REPLACE FUNCTION public.audit_request_context()
++RETURNS jsonb
++LANGUAGE plpgsql
++STABLE
++SECURITY DEFINER
++SET search_path TO 'public'
++AS $$
++DECLARE
++  headers jsonb;
++  claims jsonb;
++  ip text;
++  ua text;
++  role text;
++BEGIN
++  headers := NULL;
++  BEGIN
++    headers := current_setting('request.headers', true)::jsonb;
++  EXCEPTION WHEN others THEN
++    headers := NULL;
++  END;
++
++  claims := NULL;
++  BEGIN
++    claims := current_setting('request.jwt.claims', true)::jsonb;
++  EXCEPTION WHEN others THEN
++    claims := NULL;
++  END;
++
++  ip := COALESCE(headers->>'x-forwarded-for', headers->>'x-real-ip');
++  ua := headers->>'user-agent';
++  role := COALESCE(claims->>'user_role', claims->>'role');
++
++  RETURN jsonb_build_object('ip', ip, 'user_agent', ua, 'actor_role', role);
++END;
++$$;
++
++REVOKE ALL ON FUNCTION public.audit_request_context() FROM PUBLIC;
++GRANT EXECUTE ON FUNCTION public.audit_request_context() TO anon, authenticated, service_role;
++
++COMMIT;
+```

--- a/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
+++ b/apps/web/src/components/secretaria/ModalPagamentoRapido.tsx
@@ -868,7 +868,13 @@ export function ModalPagamentoRapido({
 
   const confirmBtnRef = useRef<HTMLButtonElement | null>(null);
   const confirm = useConfirm();
-  const { success, error: toastError } = useToast();
+  const { toast } = useToast();
+  const toastSuccess = useCallback((title: string, message?: string) => {
+    toast({ variant: "success", title, message });
+  }, [toast]);
+  const toastError = useCallback((title: string, message?: string) => {
+    toast({ variant: "error", title, message, duration: 6000 });
+  }, [toast]);
   const availableMensalidades = useMemo(() => {
     if (mensalidades?.length) return sortMensalidades(mensalidades);
     return mensalidade ? [mensalidade] : [];
@@ -988,7 +994,7 @@ export function ModalPagamentoRapido({
       }
 
       setReversedPagamentoIds((prev) => new Set([...prev, pagamento.pagamento_id]));
-      success("Pagamento revertido", "A mensalidade foi recalculada e a reversão ficou auditada.");
+      toastSuccess("Pagamento revertido", "A mensalidade foi recalculada e a reversão ficou auditada.");
       await loadPagamentosPagosAluno();
       onSuccess?.();
     } catch (err) {
@@ -996,7 +1002,7 @@ export function ModalPagamentoRapido({
     } finally {
       setRevertingPagamentoId(null);
     }
-  }, [confirm, loadPagamentosPagosAluno, onSuccess, success, toastError]);
+  }, [confirm, loadPagamentosPagosAluno, onSuccess, toastError, toastSuccess]);
 
   const toggleMensalidade = useCallback((id: string) => {
     setSelectedIds((prev) => {

--- a/supabase/migrations/20270720120000_fix_audit_request_context_execute.sql
+++ b/supabase/migrations/20270720120000_fix_audit_request_context_execute.sql
@@ -1,0 +1,45 @@
+-- Fix balcão pagamentos failure caused by audit trigger invoking audit_request_context
+-- as the authenticated request role.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.audit_request_context()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  headers jsonb;
+  claims jsonb;
+  ip text;
+  ua text;
+  role text;
+BEGIN
+  headers := NULL;
+  BEGIN
+    headers := current_setting('request.headers', true)::jsonb;
+  EXCEPTION WHEN others THEN
+    headers := NULL;
+  END;
+
+  claims := NULL;
+  BEGIN
+    claims := current_setting('request.jwt.claims', true)::jsonb;
+  EXCEPTION WHEN others THEN
+    claims := NULL;
+  END;
+
+  ip := COALESCE(headers->>'x-forwarded-for', headers->>'x-real-ip');
+  ua := headers->>'user-agent';
+  role := COALESCE(claims->>'user_role', claims->>'role');
+
+  RETURN jsonb_build_object('ip', ip, 'user_agent', ua, 'actor_role', role);
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.audit_request_context() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.audit_request_context() TO anon, authenticated, service_role;
+
+COMMIT;

--- a/supabase/migrations/20270720121500_harden_audit_dml_trigger_execution.sql
+++ b/supabase/migrations/20270720121500_harden_audit_dml_trigger_execution.sql
@@ -1,0 +1,104 @@
+-- Harden audit DML trigger execution for authenticated business mutations.
+-- The trigger writes to audit_logs from mutations such as pagamentos; execute it as
+-- postgres-owned SECURITY DEFINER so audit capture is not blocked by the caller's
+-- RLS/table/function privileges.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.audit_dml_trigger()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_escola_id uuid;
+  v_entity_id text;
+  v_portal text;
+  v_action text;
+  v_entity text := tg_table_name;
+  v_before jsonb;
+  v_after jsonb;
+  ctx jsonb;
+  v_actor_id uuid;
+BEGIN
+  v_action := CASE tg_op
+    WHEN 'INSERT' THEN 'CREATE'
+    WHEN 'UPDATE' THEN 'UPDATE'
+    WHEN 'DELETE' THEN 'DELETE'
+  END;
+
+  v_portal := CASE tg_table_name
+    WHEN 'pagamentos' THEN 'financeiro'
+    WHEN 'matriculas' THEN 'secretaria'
+    ELSE 'outro'
+  END;
+
+  IF tg_op = 'INSERT' THEN
+    BEGIN v_escola_id := (new).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
+    BEGIN v_entity_id := (new).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
+    v_before := NULL;
+    v_after := public.audit_redact_jsonb(v_entity, to_jsonb(new));
+  ELSIF tg_op = 'UPDATE' THEN
+    BEGIN v_escola_id := (new).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
+    BEGIN v_entity_id := (new).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
+    v_before := public.audit_redact_jsonb(v_entity, to_jsonb(old));
+    v_after := public.audit_redact_jsonb(v_entity, to_jsonb(new));
+  ELSE
+    BEGIN v_escola_id := (old).escola_id; EXCEPTION WHEN others THEN v_escola_id := NULL; END;
+    BEGIN v_entity_id := (old).id::text; EXCEPTION WHEN others THEN v_entity_id := NULL; END;
+    v_before := public.audit_redact_jsonb(v_entity, to_jsonb(old));
+    v_after := NULL;
+  END IF;
+
+  IF v_escola_id IS NULL THEN
+    IF tg_op = 'DELETE' THEN
+      RETURN old;
+    END IF;
+    RETURN new;
+  END IF;
+
+  ctx := COALESCE(public.audit_request_context(), '{}'::jsonb);
+  v_actor_id := public.safe_auth_uid();
+
+  INSERT INTO public.audit_logs (
+    escola_id,
+    actor_id,
+    actor_role,
+    user_id,
+    portal,
+    action,
+    entity,
+    entity_id,
+    details,
+    before,
+    after,
+    ip,
+    user_agent
+  ) VALUES (
+    v_escola_id,
+    v_actor_id,
+    ctx->>'actor_role',
+    v_actor_id,
+    v_portal,
+    v_action,
+    v_entity,
+    v_entity_id,
+    jsonb_build_object('op', tg_op),
+    v_before,
+    v_after,
+    ctx->>'ip',
+    ctx->>'user_agent'
+  );
+
+  IF tg_op = 'DELETE' THEN
+    RETURN old;
+  END IF;
+  RETURN new;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.audit_dml_trigger() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.audit_dml_trigger() TO postgres, service_role;
+
+COMMIT;


### PR DESCRIPTION
### Motivation
- Ensure toast notifications in the fast payment modal are invoked reliably and avoid stale callback references that caused inconsistent UI feedback.
- Fix failures where the audit trigger could not capture mutations because it executed with the caller's role and lacked privileges.
- Harden audit logging so DML mutations such as `pagamentos` always write to `audit_logs` even when RLS or caller privileges would otherwise block it.

### Description
- Replace direct `useToast()` destructuring in `ModalPagamentoRapido` with a single `toast` handler and two stable `useCallback` wrappers `toastSuccess` and `toastError`, and update call sites to use them. 
- Update hook dependency arrays in `ModalPagamentoRapido` to reference the new `toastSuccess`/`toastError` callbacks to avoid stale closures. 
- Add `supabase/migrations/20270720120000_fix_audit_request_context_execute.sql` which creates `public.audit_request_context()` as `SECURITY DEFINER` and grants `EXECUTE` to `anon`, `authenticated`, and `service_role`. 
- Add `supabase/migrations/20270720121500_harden_audit_dml_trigger_execution.sql` which creates `public.audit_dml_trigger()` as `SECURITY DEFINER`, uses `audit_request_context()` safely, inserts into `public.audit_logs`, and grants `EXECUTE` to `postgres` and `service_role` while revoking public access.

### Testing
- Ran TypeScript typecheck and build via `yarn build`, which completed successfully. 
- Executed the test suite with `yarn test`, and unit tests passed. 
- Validated SQL migrations by performing a syntax/check run and applying them in a staging database, and the migration scripts executed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5e0c79d1a083268db049cdd2cdddf2)